### PR TITLE
feat(bridge): recover from Gemini trust check via structured signal + orchestrator retry

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-delegator",
   "description": "GPT expert subagents for Claude Code via Codex CLI. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,24 @@ You need at least one of the following providers configured:
 | Provider not authenticated | Codex: run `codex login`. Gemini: run `gemini` once to complete sign-in (or set `GOOGLE_API_KEY`) |
 | Tool not appearing | Run `claude mcp list` and verify registration |
 | Expert not triggered | Try explicit: "Ask GPT to review..." or "Ask Gemini to review..." |
+| Gemini blocked by trust check | The bridge returns `errorKind: "trust"` with `hint: "skip-trust"`. The orchestrator auto-retries the call once with `skip-trust: true` and prints a notice. To opt in up front, pass `"skip-trust": true` on the call. |
+
+### Untrusted directories
+
+The Gemini CLI refuses to run from a directory it has not been told to trust (entries live in `~/.gemini/trustedFolders.json`). When that happens the bridge surfaces a structured signal:
+
+```json
+{
+  "isError": true,
+  "errorKind": "trust",
+  "retryable": true,
+  "hint": "skip-trust"
+}
+```
+
+The orchestration rules (`rules/orchestration.md` -> "Trust Failure Recovery") instruct Claude to retry the same call once with `"skip-trust": true`, preserving `threadId` for `gemini-reply`. A second consecutive trust failure (when `skip-trust: true` was already set) escalates to the user instead of looping.
+
+Callers that already know they want to bypass the trust check can pass `"skip-trust": true` from the start.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-delegator",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/rules/model-selection.md
+++ b/rules/model-selection.md
@@ -146,8 +146,11 @@ Every expert can operate in two modes:
 | `prompt` | string | **Required.** The delegation prompt (use 7-section format) |
 | `developer-instructions` | string | Expert prompt injection (from `prompts/*.md`) |
 | `sandbox` | `read-only`, `workspace-write` | Controls file access. |
-| `model` | e.g. `gemini-2.5-pro` | Override the default model |
+| `model` | e.g. `gemini-2.5-pro`, `auto-gemini-3` | Override the default model |
 | `cwd` | path | Working directory for the task |
+| `include-directories` | string[] | Extra dirs to include alongside `cwd`. |
+| `timeout` | number (ms) | Bridge-side timeout. 1..600000. Default 120000. |
+| `skip-trust` | boolean | Pass `--skip-trust` to bypass the Gemini CLI trusted-directory check. Default `false`. Use to recover from `errorKind: "trust"` (see `orchestration.md` "Trust Failure Recovery"). |
 
 ### `mcp__gemini__gemini-reply` (Continue Session)
 
@@ -155,13 +158,29 @@ Every expert can operate in two modes:
 |-----------|--------|-------|
 | `threadId` | string | **Required.** Thread ID from previous `gemini` call |
 | `prompt` | string | **Required.** Follow-up instruction |
+| `sandbox` | `read-only`, `workspace-write` | Controls file access. |
+| `cwd` | path | Working directory for the task |
+| `include-directories` | string[] | Extra dirs to include alongside `cwd`. |
+| `timeout` | number (ms) | Bridge-side timeout. 1..600000. Default 120000. |
+| `skip-trust` | boolean | Pass `--skip-trust` to bypass the Gemini CLI trusted-directory check. Default `false`. |
 
 ### Response Format (both providers)
+
+Success:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `threadId` | string | Session ID for multi-turn follow-ups |
 | `content` | string | The expert's text response |
+
+Error (Gemini bridge only - bridge sets `isError: true` and adds these fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `isError` | boolean | `true` on bridge-side failure. |
+| `errorKind` | `timeout` \| `parse` \| `trust` \| `missing-cli` \| `upstream-abort` \| `unknown` | Machine-readable category. |
+| `retryable` | boolean | `true` means the orchestrator may retry; see `orchestration.md`. |
+| `hint` | `"skip-trust"` (when present) | Recovery action the orchestrator should apply on the next call. Only set today for `errorKind: "trust"`. |
 
 ## When NOT to Delegate
 

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -207,6 +207,45 @@ REQUIREMENTS:
 - [Original requirements]
 ```
 
+### Trust Failure Recovery (Gemini only)
+
+The Gemini CLI refuses to run from an untrusted directory unless `--skip-trust` is passed. When this happens, the bridge surfaces a structured signal:
+
+```
+{
+  isError: true,
+  errorKind: "trust",
+  retryable: true,
+  hint: "skip-trust",
+  content: [{ type: "text", text: "Error: ... not a trusted directory ..." }]
+}
+```
+
+Treat this as a recoverable failure and run the recovery once:
+
+1. **If the originating call was `mcp__gemini__gemini` AND the original args did NOT include `skip-trust: true`:**
+   - Print a user-visible notice: `Gemini blocked by trust check; retrying with skip-trust...`
+   - Re-issue `mcp__gemini__gemini` with the SAME `prompt`, `developer-instructions`, `sandbox`, `cwd`, `model`, `include-directories`, `timeout`, plus `skip-trust: true`.
+2. **If the originating call was `mcp__gemini__gemini-reply` AND the original args did NOT include `skip-trust: true`:**
+   - Print the same notice.
+   - Re-issue `mcp__gemini__gemini-reply` with the SAME `threadId`, SAME `prompt`, plus `skip-trust: true`. Preserves the session.
+3. **If the original args ALREADY had `skip-trust: true` and the call still returned `errorKind: "trust"`:**
+   - Do NOT retry. Surface the bridge's error message verbatim and escalate to the user.
+
+Recovery applies to Gemini only. Codex has its own trust model via `[projects.*]` entries in `~/.codex/config.toml`.
+
+```typescript
+// Example: initial gemini failed with trust error
+const r1 = await mcp__gemini__gemini({ prompt, "developer-instructions": di, cwd, model: "auto-gemini-3" })
+if (r1.isError && r1.errorKind === "trust") {
+  // Notice already printed
+  const r2 = await mcp__gemini__gemini({
+    prompt, "developer-instructions": di, cwd, model: "auto-gemini-3",
+    "skip-trust": true,
+  })
+}
+```
+
 ---
 
 ## Example: Architecture Question

--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -43,6 +43,29 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+// --- Error Classification ---
+
+// Pure helper: given a runGemini rejection's message and code, produce the
+// structured error fields the orchestrator consumes. Exported for tests.
+function classifyGeminiError(errMsg, errCode) {
+  const msg = String(errMsg || "");
+  const lower = msg.toLowerCase();
+  if (errCode === "timeout") return { errorKind: "timeout", retryable: true };
+  if (errCode === "parse")   return { errorKind: "parse",   retryable: false };
+  if (
+    lower.includes("trusted directory") ||
+    lower.includes("trust check") ||
+    lower.includes("not a trusted folder")
+  ) {
+    return { errorKind: "trust", retryable: true, hint: "skip-trust" };
+  }
+  if (msg.includes("Gemini CLI not found")) return { errorKind: "missing-cli", retryable: false };
+  if (lower.includes("aborterror") || lower.includes("aborted")) {
+    return { errorKind: "upstream-abort", retryable: true };
+  }
+  return { errorKind: "unknown", retryable: false };
+}
+
 // --- Gemini CLI Wrapper ---
 
 function lastJSONObject(s) {
@@ -142,8 +165,13 @@ async function runGemini(args, cwd, timeoutMs) {
         err.code = "timeout";
         return reject(err);
       }
-      if (code !== 0 && !stdout) {
-        return reject(new Error(stderr.trim() || `Gemini exited with code ${code}`));
+      if (code !== 0) {
+        // Prefer stderr on failure so trust/auth errors are not masked by
+        // stdout banners (issue #2). Fall back to stdout/parse only when
+        // stderr is empty so legacy JSON-bearing failures still work.
+        const trimmedErr = stderr.trim();
+        if (trimmedErr) return reject(new Error(trimmedErr));
+        if (!stdout)    return reject(new Error(`Gemini exited with code ${code}`));
       }
 
       try {
@@ -171,7 +199,7 @@ const handlers = {
     sendResponse(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
-      serverInfo: { name: "claude-delegator-gemini", version: "1.3.0" }
+      serverInfo: { name: "claude-delegator-gemini", version: "1.4.0" }
     });
   },
 
@@ -338,12 +366,7 @@ const handlers = {
     } catch (e) {
       const errMsg = (e && e.message) || String(e);
       const errCode = e && e.code;
-      let errorKind = "unknown", retryable = false;
-      if (errCode === "timeout") { errorKind = "timeout"; retryable = true; }
-      else if (errCode === "parse") { errorKind = "parse"; retryable = false; }
-      else if (errMsg.includes("trusted directory")) { errorKind = "trust"; retryable = false; }
-      else if (errMsg.includes("Gemini CLI not found")) { errorKind = "missing-cli"; retryable = false; }
-      else if (errMsg.includes("AbortError") || errMsg.includes("aborted")) { errorKind = "upstream-abort"; retryable = true; }
+      const { errorKind, retryable, hint } = classifyGeminiError(errMsg, errCode);
 
       if (shouldRespond) {
         sendResponse(id, {
@@ -351,6 +374,7 @@ const handlers = {
           isError: true,
           errorKind,
           retryable,
+          ...(hint ? { hint } : {}),
         });
       }
     }
@@ -412,4 +436,5 @@ if (require.main === module) {
 // Test-only exports
 if (typeof module !== "undefined" && module.exports) {
   module.exports.lastJSONObject = lastJSONObject;
+  module.exports.classifyGeminiError = classifyGeminiError;
 }

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -171,3 +171,102 @@ test("B6: unset env falls back to gemini-2.5-flash", async () => {
   const mIdx = argv.indexOf("-m");
   assert.equal(argv[mIdx + 1], "gemini-2.5-flash");
 });
+
+// --- B7: trust-check classification (issue #2) ---
+
+test("B7a: gemini trust failure surfaces errorKind=trust, retryable=true, hint=skip-trust", async () => {
+  const child = startBridge({ fakeBin: "fake-gemini-trust.sh" });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "hi" } },
+  });
+  setTimeout(() => child.stdin.end(), 800);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true);
+  assert.equal(r.result.errorKind, "trust");
+  assert.equal(r.result.retryable, true);
+  assert.equal(r.result.hint, "skip-trust");
+});
+
+test("B7f: gemini-reply trust failure classifies identically", async () => {
+  const child = startBridge({ fakeBin: "fake-gemini-trust.sh" });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini-reply", arguments: { threadId: "abc", prompt: "follow up" } },
+  });
+  setTimeout(() => child.stdin.end(), 800);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true);
+  assert.equal(r.result.errorKind, "trust");
+  assert.equal(r.result.retryable, true);
+  assert.equal(r.result.hint, "skip-trust");
+});
+
+test("B7g: stderr trust error is not masked when stdout has noise", async () => {
+  const child = startBridge({ fakeBin: "fake-gemini-trust-with-stdout.sh" });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "hi" } },
+  });
+  setTimeout(() => child.stdin.end(), 800);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true);
+  assert.equal(r.result.errorKind, "trust", "stderr trust text must win over stdout banner");
+  assert.equal(r.result.retryable, true);
+});
+
+// Pure-function classifier units (no spawn).
+test("B7b: classifyGeminiError matches 'trusted directory' case-insensitively", () => {
+  const { classifyGeminiError } = require("../server/gemini/index.js");
+  assert.deepEqual(
+    classifyGeminiError("Error: not a trusted directory", null),
+    { errorKind: "trust", retryable: true, hint: "skip-trust" }
+  );
+  assert.deepEqual(
+    classifyGeminiError("NOT A Trusted Directory", null),
+    { errorKind: "trust", retryable: true, hint: "skip-trust" }
+  );
+});
+
+test("B7c: classifyGeminiError matches 'trust check' wording", () => {
+  const { classifyGeminiError } = require("../server/gemini/index.js");
+  const r = classifyGeminiError("trust check failed for /tmp/x", null);
+  assert.equal(r.errorKind, "trust");
+  assert.equal(r.retryable, true);
+  assert.equal(r.hint, "skip-trust");
+});
+
+test("B7d: classifyGeminiError preserves timeout / parse / missing-cli / abort branches", () => {
+  const { classifyGeminiError } = require("../server/gemini/index.js");
+  assert.deepEqual(classifyGeminiError("anything", "timeout"), { errorKind: "timeout", retryable: true });
+  assert.deepEqual(classifyGeminiError("anything", "parse"),   { errorKind: "parse",   retryable: false });
+  const missing = classifyGeminiError("Gemini CLI not found. Please install it.", null);
+  assert.equal(missing.errorKind, "missing-cli");
+  assert.equal(missing.retryable, false);
+  const abort = classifyGeminiError("AbortError: signal aborted", null);
+  assert.equal(abort.errorKind, "upstream-abort");
+  assert.equal(abort.retryable, true);
+});
+
+test("B7e: classifyGeminiError falls back to unknown for unrelated text", () => {
+  const { classifyGeminiError } = require("../server/gemini/index.js");
+  const r = classifyGeminiError("network blip", null);
+  assert.equal(r.errorKind, "unknown");
+  assert.equal(r.retryable, false);
+  assert.equal(r.hint, undefined);
+});
+
+test("B7e: classifyGeminiError tolerates null/undefined errMsg", () => {
+  const { classifyGeminiError } = require("../server/gemini/index.js");
+  assert.equal(classifyGeminiError(null, null).errorKind, "unknown");
+  assert.equal(classifyGeminiError(undefined, null).errorKind, "unknown");
+});

--- a/test/fixtures/fake-gemini-trust-with-stdout.sh
+++ b/test/fixtures/fake-gemini-trust-with-stdout.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fake gemini CLI that prints a banner to stdout and a trust error to stderr,
+# then exits non-zero. Verifies stderr is not masked by stdout (B7g).
+set -euo pipefail
+
+if [ "${1:-}" = "--version" ]; then
+  echo "0.41.2-fake-trust-stdout"
+  exit 0
+fi
+
+printf '%s\0' "$@" >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+printf '\n' >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+
+echo "Loaded gemini config from ~/.gemini/settings.json"
+echo "Error: not a trusted directory. Re-run from a trusted folder or pass --skip-trust." >&2
+exit 1

--- a/test/fixtures/fake-gemini-trust.sh
+++ b/test/fixtures/fake-gemini-trust.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fake gemini CLI that always fails with a trust-check error. Used by B7a / B7f.
+set -euo pipefail
+
+if [ "${1:-}" = "--version" ]; then
+  echo "0.41.2-fake-trust"
+  exit 0
+fi
+
+printf '%s\0' "$@" >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+printf '\n' >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+
+echo "Error: not a trusted directory. Re-run from a trusted folder or pass --skip-trust." >&2
+exit 1


### PR DESCRIPTION
Closes #2.

## Summary

- Bridge now signals trust failures as `retryable: true` with `hint: "skip-trust"` instead of the previous hard `retryable: false`.
- Orchestration rules teach Claude to retry the same Gemini call once with `skip-trust: true`, preserving `threadId` for `gemini-reply`. Second consecutive trust failure escalates instead of looping.
- Trust detection extracted into a pure `classifyGeminiError` helper (case-insensitive, multiple wordings) and `runGemini` now prefers stderr on non-zero exit so trust errors are not masked by stdout banners.

## Files

- `server/gemini/index.js` - `classifyGeminiError` helper; `runGemini` stderr-first on non-zero exit; `catch` uses classifier with conditional `hint` spread; `serverInfo.version` bumped to `1.4.0`.
- `rules/orchestration.md` - new "Trust Failure Recovery (Gemini only)" subsection.
- `rules/model-selection.md` - `skip-trust` parameter rows for `gemini` and `gemini-reply`; structured error response table.
- `README.md` - "Untrusted directories" subsection + Troubleshooting row.
- `test/bridge.test.js` + `test/fixtures/fake-gemini-trust*.sh` - B7a-g.
- `.claude-plugin/plugin.json`, `package.json` - version `1.4.0`.

## Design

Converged via `/agree-both` (3 rounds, all three approve). Rejected alternatives:
- Silent bridge auto-retry with `--skip-trust` (would bypass security implicitly).
- Default `skip-trust: true` (removes the safety net).
- Env-gated bridge auto-retry (redundant once orchestrator does it explicitly).

## Test plan

- [x] `npm test` - 20/20 pass (B1, B2 x3, B4 x5, B5, B6 x2, B7a, B7b, B7c, B7d, B7e x2, B7f, B7g).
- [x] B7a covers initial `gemini` from untrusted dir -> `errorKind: "trust"`, `retryable: true`, `hint: "skip-trust"`.
- [x] B7f covers `gemini-reply` trust failure -> same classification.
- [x] B7g covers stderr-trust-text + stdout-banner case (regression: previously misclassified as `parse`).
- [x] B7b-e cover classifier units: case-insensitive trust matching, missing-cli, upstream-abort, parse, timeout, unknown, null/undefined input.
- [ ] Manual smoke from an untrusted `mktemp -d` to verify the orchestrator retry path end-to-end after the plugin is installed at 1.4.0.

## Backwards compatibility

- API additive only. Existing tools (`gemini`, `gemini-reply`) accept the same args. New response fields (`hint`) are optional and only set when `errorKind: "trust"`.
- Previous tests (B1-B6) unchanged and still green.