### PR TITLE
feat(bridge): recover disk-flushed Gemini answer on soft timeout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-delegator",
       "source": "./",
       "description": "GPT expert subagents for Claude Code via Codex CLI. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "author": {
         "name": "Jarrod Watts",
         "url": "https://github.com/jarrodwatts"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-delegator",
   "description": "GPT expert subagents for Claude Code via Codex CLI. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"

--- a/README.md
+++ b/README.md
@@ -219,6 +219,32 @@ The orchestration rules (`rules/orchestration.md` -> "Trust Failure Recovery") i
 
 Callers that already know they want to bypass the trust check can pass `"skip-trust": true` from the start.
 
+### Timeouts and recovery
+
+`timeout` is a **soft** deadline (default 300000ms; Gemini 3 deep prompts run
+200-260s). The Gemini CLI ignores SIGTERM and persists its full answer to disk at
+`~/.gemini/tmp/<slug>/chats/session-*.jsonl` regardless. When the soft timeout
+fires the bridge does not fail immediately: it drains - keeps Gemini alive and
+polls that jsonl for a record newer than the call's start - for up to
+`recovery-grace` ms (default 120000, range 0..600000). If the answer appears it is
+returned as a normal success with a top-level `"recovered": true` flag and a
+stderr log line; `content` is unmodified so response parsers keep working. If the
+grace budget is exhausted with no answer, the call fails with the usual
+`errorKind: "timeout"` (still `retryable`).
+
+- `"recovery-grace": 0` disables the drain (immediate legacy timeout).
+- `GEMINI_DISABLE_TIMEOUT_RECOVERY=1` (env) forces full legacy behavior.
+- Total wall time is bounded by `timeout + recovery-grace`.
+
+Manual recovery (any session, even without this plugin): find the project slug
+under `~/.gemini/tmp/` (its `.project_root` file holds the absolute cwd), then in
+that slug's `chats/` open the newest `session-*.jsonl`; the last record with
+`"type":"gemini"` has the full answer in `.content`.
+
+Known limitation: heavy parallel calls from the same cwd (e.g. `agree-both`) can
+race on "newest session file". A spawn-start timestamp guard (2000ms skew
+tolerance) makes mis-attribution unlikely but not impossible.
+
 ---
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-delegator",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/rules/model-selection.md
+++ b/rules/model-selection.md
@@ -149,7 +149,8 @@ Every expert can operate in two modes:
 | `model` | e.g. `gemini-2.5-pro`, `auto-gemini-3` | Override the default model |
 | `cwd` | path | Working directory for the task |
 | `include-directories` | string[] | Extra dirs to include alongside `cwd`. |
-| `timeout` | number (ms) | Bridge-side timeout. 1..600000. Default 120000. |
+| `timeout` | number (ms) | Soft timeout. 1..600000. Default 300000. On expiry the bridge drains and recovers the disk-flushed answer. |
+| `recovery-grace` | number (ms) | Extra drain budget after the soft timeout. 0..600000. Default 120000. 0 disables drain. |
 | `skip-trust` | boolean | Pass `--skip-trust` to bypass the Gemini CLI trusted-directory check. Default `false`. Use to recover from `errorKind: "trust"` (see `orchestration.md` "Trust Failure Recovery"). |
 
 ### `mcp__gemini__gemini-reply` (Continue Session)
@@ -161,7 +162,8 @@ Every expert can operate in two modes:
 | `sandbox` | `read-only`, `workspace-write` | Controls file access. |
 | `cwd` | path | Working directory for the task |
 | `include-directories` | string[] | Extra dirs to include alongside `cwd`. |
-| `timeout` | number (ms) | Bridge-side timeout. 1..600000. Default 120000. |
+| `timeout` | number (ms) | Soft timeout. 1..600000. Default 300000. On expiry the bridge drains and recovers the disk-flushed answer. |
+| `recovery-grace` | number (ms) | Extra drain budget after the soft timeout. 0..600000. Default 120000. 0 disables drain. |
 | `skip-trust` | boolean | Pass `--skip-trust` to bypass the Gemini CLI trusted-directory check. Default `false`. |
 
 ### Response Format (both providers)
@@ -172,6 +174,7 @@ Success:
 |-------|------|-------------|
 | `threadId` | string | Session ID for multi-turn follow-ups |
 | `content` | string | The expert's text response |
+| `recovered` | boolean | Present and `true` when the answer was recovered from disk after a soft timeout (drain). Normal success - no special handling needed. |
 
 Error (Gemini bridge only - bridge sets `isError: true` and adds these fields):
 

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -246,6 +246,21 @@ if (r1.isError && r1.errorKind === "trust") {
 }
 ```
 
+### Timeout Recovery (Gemini only)
+
+The Gemini bridge has a **soft** timeout. On expiry it keeps Gemini alive and
+recovers the disk-flushed answer (see README "Timeouts and recovery"). Two
+outcomes:
+
+- Success with `recovered: true` -> this is a **normal success**. Use `content`
+  and `threadId` as usual. No retry, no special handling. (The `recovered` flag
+  is informational only.)
+- `errorKind: "timeout"` -> recovery failed within the grace budget. Still
+  `retryable`. Retry as a fresh call; consider a larger `timeout` /
+  `recovery-grace` for known-deep prompts.
+
+Do not treat `recovered: true` as an error or re-issue the call.
+
 ---
 
 ## Example: Architecture Question

--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -8,9 +8,16 @@
  */
 
 const { spawn, execSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
 const DEFAULT_MODEL = process.env.GEMINI_DEFAULT_MODEL || "gemini-2.5-flash";
-const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes (Gemini 3 deep prompts run 200-260s)
+const DEFAULT_RECOVERY_GRACE_MS = 120_000; // extra drain budget after the soft timeout
+const RECOVERY_POLL_MS = 1_000;
+const RECOVERY_SKEW_MS = 2_000; // clock-skew tolerance for the stale-answer guard
+const MAX_MS = 600_000;
 const VALID_SANDBOX_VALUES = new Set(["read-only", "workspace-write"]);
 
 // --- MCP Protocol Helpers ---
@@ -66,6 +73,105 @@ function classifyGeminiError(errMsg, errCode) {
   return { errorKind: "unknown", retryable: false };
 }
 
+// --- Timeout Recovery ---
+//
+// The Gemini CLI ignores SIGTERM and persists its full answer to disk at
+// ~/.gemini/tmp/<slug>/chats/session-*.jsonl regardless. When the bridge's
+// soft timeout fires we drain (keep the CLI alive, poll the jsonl) and return
+// the late-flushed answer instead of failing hard.
+
+function geminiTmpRoot() {
+  return process.env.GEMINI_TMP_ROOT || path.join(os.homedir(), ".gemini", "tmp");
+}
+
+function realOrSelf(p) {
+  try { return fs.realpathSync(p); } catch (_) { return p; }
+}
+
+// Find the slug dir whose .project_root points at `cwd`. Slug names are not
+// derivable reliably, so match by file content rather than name.
+function resolveSlugDir(cwd, root) {
+  const base = root || geminiTmpRoot();
+  const target = realOrSelf(path.resolve(cwd));
+  let entries;
+  try { entries = fs.readdirSync(base, { withFileTypes: true }); }
+  catch (_) { return null; }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const slugDir = path.join(base, e.name);
+    let content;
+    try { content = fs.readFileSync(path.join(slugDir, ".project_root"), "utf8"); }
+    catch (_) { continue; }
+    if (realOrSelf(path.resolve(content.trim())) === target) return slugDir;
+  }
+  return null;
+}
+
+function newestSessionFile(slugDir) {
+  const chats = path.join(slugDir, "chats");
+  let names;
+  try { names = fs.readdirSync(chats); }
+  catch (_) { return null; }
+  let best = null, bestMtime = -1;
+  for (const n of names) {
+    if (!n.startsWith("session-") || !n.endsWith(".jsonl")) continue;
+    const fp = path.join(chats, n);
+    let st;
+    try { st = fs.statSync(fp); } catch (_) { continue; }
+    if (st.mtimeMs > bestMtime) { bestMtime = st.mtimeMs; best = fp; }
+  }
+  return best;
+}
+
+// Last `type:"gemini"` record whose timestamp is at/after the spawn start
+// (stale-answer guard). threadId comes from the metadata record's sessionId.
+function extractGeminiAnswer(filePath, sinceMs) {
+  let raw;
+  try { raw = fs.readFileSync(filePath, "utf8"); }
+  catch (_) { return null; }
+  const floor = (typeof sinceMs === "number" ? sinceMs : 0) - RECOVERY_SKEW_MS;
+  let threadId = "unknown";
+  let answer = null;
+  for (const line of raw.split("\n")) {
+    const s = line.trim();
+    if (!s) continue;
+    let o;
+    try { o = JSON.parse(s); } catch (_) { continue; }
+    if (o && typeof o === "object" && o.sessionId && o.type === undefined) {
+      threadId = o.sessionId;
+      continue;
+    }
+    if (o && o.type === "gemini" && typeof o.content === "string") {
+      const ts = Date.parse(o.timestamp);
+      if (Number.isFinite(ts) && ts >= floor) answer = o.content;
+    }
+  }
+  if (answer == null) return null;
+  return { content: answer, threadId };
+}
+
+function tryRecoverOnce(cwd, spawnStartMs) {
+  const slugDir = resolveSlugDir(cwd);
+  if (!slugDir) return null;
+  const f = newestSessionFile(slugDir);
+  if (!f) return null;
+  return extractGeminiAnswer(f, spawnStartMs);
+}
+
+// Poll for a recovered answer until found or `graceMs` is exhausted.
+// `isAborted()` lets the caller stop the loop once the call settles elsewhere.
+async function recoverAfterTimeout({ cwd, spawnStartMs, graceMs, pollMs, isAborted }) {
+  const deadline = Date.now() + (graceMs > 0 ? graceMs : 0);
+  const step = pollMs > 0 ? pollMs : RECOVERY_POLL_MS;
+  for (;;) {
+    if (isAborted && isAborted()) return null;
+    const rec = tryRecoverOnce(cwd, spawnStartMs);
+    if (rec) return rec;
+    if (Date.now() >= deadline) return null;
+    await new Promise((r) => setTimeout(r, step));
+  }
+}
+
 // --- Gemini CLI Wrapper ---
 
 function lastJSONObject(s) {
@@ -101,43 +207,102 @@ function lastJSONObject(s) {
   return s.slice(a, b + 1);
 }
 
-async function runGemini(args, cwd, timeoutMs) {
+async function runGemini(args, cwd, timeoutMs, recoveryGraceMs) {
   return new Promise((resolve, reject) => {
     const t = (typeof timeoutMs === "number" && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS;
-    let killed = false;
+    const effCwd = cwd || process.cwd();
+    const spawnStartMs = Date.now();
+    const disableRecovery = process.env.GEMINI_DISABLE_TIMEOUT_RECOVERY === "1";
+    const grace = disableRecovery
+      ? 0
+      : (typeof recoveryGraceMs === "number" && recoveryGraceMs >= 0
+          ? recoveryGraceMs
+          : DEFAULT_RECOVERY_GRACE_MS);
+
+    let killed = false;   // legacy hard-kill path (grace === 0)
+    let draining = false; // soft timeout fired, waiting for a disk-flushed answer
     let settled = false;
     let graceTimer = null;
+
     // Force JSON output for reliable parsing
     const geminiArgs = [...args, "-o", "json"];
     const geminiProcess = spawn("gemini", geminiArgs, {
       env: process.env,
       shell: false,
-      cwd: cwd || process.cwd() // Ensure we run in the requested directory
+      cwd: effCwd
     });
+
+    function clearTimers() { clearTimeout(killTimer); if (graceTimer) clearTimeout(graceTimer); }
+    function destroyStreams() {
+      try { geminiProcess.stdout.destroy(); } catch (_) {}
+      try { geminiProcess.stderr.destroy(); } catch (_) {}
+    }
+    function timeoutError() {
+      const err = new Error("Gemini timed out after " + Math.round(t / 1000) + "s");
+      err.code = "timeout";
+      return err;
+    }
+    function finishRecovered(rec) {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      try { geminiProcess.kill("SIGTERM"); } catch (_) {}
+      setTimeout(() => { try { geminiProcess.kill("SIGKILL"); } catch (_) {} }, 1_000);
+      destroyStreams();
+      process.stderr.write(
+        "[claude-delegator] recovered Gemini answer from disk after soft timeout (" +
+        Math.round((Date.now() - spawnStartMs) / 1000) + "s)\n"
+      );
+      resolve({ response: rec.content, threadId: rec.threadId, recovered: true });
+    }
+    function finishTimeout() {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      try { geminiProcess.kill("SIGTERM"); } catch (_) {}
+      setTimeout(() => { try { geminiProcess.kill("SIGKILL"); } catch (_) {} }, 1_000);
+      destroyStreams();
+      reject(timeoutError());
+    }
+
     const killTimer = setTimeout(() => {
+      if (settled) return;
+      if (grace > 0) {
+        // Drain: do NOT kill. Keep Gemini alive and poll the chat jsonl for a
+        // record newer than spawn-start, up to the grace budget.
+        draining = true;
+        recoverAfterTimeout({
+          cwd: effCwd,
+          spawnStartMs,
+          graceMs: grace,
+          pollMs: RECOVERY_POLL_MS,
+          isAborted: () => settled,
+        }).then((rec) => {
+          if (settled) return;
+          if (rec) finishRecovered(rec);
+          else finishTimeout();
+        }).catch(() => { if (!settled) finishTimeout(); });
+        return;
+      }
+      // Legacy hard-kill path.
       killed = true;
       try { geminiProcess.kill("SIGTERM"); } catch (_) {}
       graceTimer = setTimeout(() => {
         try { geminiProcess.kill("SIGKILL"); } catch (_) {}
       }, 1_000);
     }, t);
-    function clearTimers() { clearTimeout(killTimer); if (graceTimer) clearTimeout(graceTimer); }
+
     geminiProcess.on("close", clearTimers);
     geminiProcess.on("error", clearTimers);
 
-    // exit fires when the process itself exits even if child pipes are still open.
-    // Use it to surface the timeout error early without waiting for pipe drain.
-    // Destroy the child streams so orphaned grandchildren (e.g. sleep) holding
-    // the pipe fds open do not keep our event loop alive.
+    // exit fires when the process itself exits even if child pipes are still
+    // open. Surface the legacy timeout early without waiting for pipe drain.
     geminiProcess.on("exit", () => {
       if (killed && !settled) {
         settled = true;
         clearTimers();
-        try { geminiProcess.stdout.destroy(); } catch (_) {}
-        try { geminiProcess.stderr.destroy(); } catch (_) {}
-        const err = new Error("Gemini timed out after " + Math.round(t / 1000) + "s");
-        err.code = "timeout";
-        reject(err);
+        destroyStreams();
+        reject(timeoutError());
       }
     });
 
@@ -158,35 +323,65 @@ async function runGemini(args, cwd, timeoutMs) {
     geminiProcess.stderr.on("data", (data) => { stderr += data.toString(); });
 
     geminiProcess.on("close", (code) => {
-      if (settled) return; // already resolved/rejected via exit event
-      settled = true;
-      if (killed) {
-        const err = new Error("Gemini timed out after " + Math.round(t / 1000) + "s");
-        err.code = "timeout";
-        return reject(err);
-      }
-      if (code !== 0) {
-        // Prefer stderr on failure so trust/auth errors are not masked by
-        // stdout banners (issue #2). Fall back to stdout/parse only when
-        // stderr is empty so legacy JSON-bearing failures still work.
-        const trimmedErr = stderr.trim();
-        if (trimmedErr) return reject(new Error(trimmedErr));
-        if (!stdout)    return reject(new Error(`Gemini exited with code ${code}`));
+      if (settled) return; // already resolved/rejected elsewhere
+      if (killed) {        // legacy soft-timeout kill
+        settled = true;
+        clearTimers();
+        return reject(timeoutError());
       }
 
-      try {
-        const jsonStr = lastJSONObject(stdout);
-        if (!jsonStr) throw new Error("No JSON response found");
-        const data = JSON.parse(jsonStr);
-        resolve({
-          response: data.response || "(No output)",
-          threadId: data.session_id || "unknown"
-        });
-      } catch (e) {
-        const err = new Error(`Parse error: ${e.message}\nRaw output was: ${stdout}`);
-        err.code = "parse";
-        reject(err);
+      // Child exited on its own. Prefer real stdout JSON (normal completion,
+      // including slow-but-finished during drain).
+      const trimmedErr = stderr.trim();
+      const jsonStr = lastJSONObject(stdout);
+      if (jsonStr) {
+        try {
+          const data = JSON.parse(jsonStr);
+          settled = true;
+          clearTimers();
+          return resolve({
+            response: data.response || "(No output)",
+            threadId: data.session_id || "unknown"
+          });
+        } catch (e) {
+          if (!draining) {
+            settled = true;
+            clearTimers();
+            const err = new Error(`Parse error: ${e.message}\nRaw output was: ${stdout}`);
+            err.code = "parse";
+            return reject(err);
+          }
+          // draining: fall through to disk recovery
+        }
       }
+
+      // Prefer stderr on failure so trust/auth errors are not masked by
+      // stdout banners (issue #2).
+      if (code !== 0 && trimmedErr) {
+        settled = true;
+        clearTimers();
+        return reject(new Error(trimmedErr));
+      }
+
+      if (draining) {
+        // Soft timeout already fired; the child is gone. One final disk check,
+        // then give up (no point waiting the rest of the grace budget).
+        const rec = tryRecoverOnce(effCwd, spawnStartMs);
+        if (rec) return finishRecovered(rec);
+        return finishTimeout();
+      }
+
+      if (code !== 0 && !stdout) {
+        settled = true;
+        clearTimers();
+        return reject(new Error(`Gemini exited with code ${code}`));
+      }
+
+      settled = true;
+      clearTimers();
+      const err = new Error(`Parse error: No JSON response found\nRaw output was: ${stdout}`);
+      err.code = "parse";
+      reject(err);
     });
   });
 }
@@ -199,7 +394,7 @@ const handlers = {
     sendResponse(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
-      serverInfo: { name: "claude-delegator-gemini", version: "1.4.0" }
+      serverInfo: { name: "claude-delegator-gemini", version: "1.5.0" }
     });
   },
 
@@ -223,7 +418,8 @@ const handlers = {
                 items: { type: "string" },
                 description: "Additional directories to include in the workspace alongside cwd. Equivalent to --include-directories on the Gemini CLI."
               },
-              timeout: { type: "number", description: "Bridge-side timeout in ms before SIGTERM. 1..600000. Default 120000.", default: DEFAULT_TIMEOUT_MS },
+              timeout: { type: "number", description: "Soft timeout in ms. 1..600000. Default 300000. On expiry the bridge drains and recovers the disk-flushed answer instead of failing.", default: DEFAULT_TIMEOUT_MS },
+              "recovery-grace": { type: "number", description: "Extra ms to keep Gemini alive after the soft timeout to recover a late-flushed answer from disk. 0..600000. Default 120000. 0 disables drain.", default: DEFAULT_RECOVERY_GRACE_MS },
               "skip-trust": { type: "boolean", description: "Pass --skip-trust to bypass the Gemini CLI's trusted-directory check. Read-only sandbox is still gated separately.", default: false }
             },
             required: ["prompt"]
@@ -244,7 +440,8 @@ const handlers = {
                 items: { type: "string" },
                 description: "Additional directories to include in the workspace alongside cwd. Equivalent to --include-directories on the Gemini CLI."
               },
-              timeout: { type: "number", description: "Bridge-side timeout in ms before SIGTERM. 1..600000. Default 120000.", default: DEFAULT_TIMEOUT_MS },
+              timeout: { type: "number", description: "Soft timeout in ms. 1..600000. Default 300000. On expiry the bridge drains and recovers the disk-flushed answer instead of failing.", default: DEFAULT_TIMEOUT_MS },
+              "recovery-grace": { type: "number", description: "Extra ms to keep Gemini alive after the soft timeout to recover a late-flushed answer from disk. 0..600000. Default 120000. 0 disables drain.", default: DEFAULT_RECOVERY_GRACE_MS },
               "skip-trust": { type: "boolean", description: "Pass --skip-trust to bypass the Gemini CLI's trusted-directory check. Read-only sandbox is still gated separately.", default: false }
             },
             required: ["threadId", "prompt"]
@@ -280,6 +477,13 @@ const handlers = {
     if (args.timeout !== undefined) {
       if (typeof args.timeout !== "number" || !Number.isFinite(args.timeout) || args.timeout <= 0 || args.timeout > 600_000) {
         if (shouldRespond) sendError(id, -32602, "Invalid params: 'timeout' must be a number > 0 and <= 600000 milliseconds");
+        return;
+      }
+    }
+    if (args["recovery-grace"] !== undefined) {
+      const g = args["recovery-grace"];
+      if (typeof g !== "number" || !Number.isFinite(g) || g < 0 || g > MAX_MS) {
+        if (shouldRespond) sendError(id, -32602, "Invalid params: 'recovery-grace' must be a number >= 0 and <= 600000 milliseconds");
         return;
       }
     }
@@ -353,14 +557,18 @@ const handlers = {
       }
 
       const timeoutMs = (typeof args.timeout === "number" && args.timeout > 0) ? args.timeout : DEFAULT_TIMEOUT_MS;
-      const { response, threadId } = await runGemini(geminiArgs, args.cwd, timeoutMs);
+      const recoveryGraceMs = (typeof args["recovery-grace"] === "number" && args["recovery-grace"] >= 0)
+        ? args["recovery-grace"]
+        : DEFAULT_RECOVERY_GRACE_MS;
+      const { response, threadId, recovered } = await runGemini(geminiArgs, args.cwd, timeoutMs, recoveryGraceMs);
 
       // Return metadata (threadId) at the top level for orchestration rules,
       // and standard content array for the UI.
       if (shouldRespond) {
         sendResponse(id, {
           content: [{ type: "text", text: response }],
-          threadId: threadId
+          threadId: threadId,
+          ...(recovered ? { recovered: true } : {})
         });
       }
     } catch (e) {
@@ -437,4 +645,9 @@ if (require.main === module) {
 if (typeof module !== "undefined" && module.exports) {
   module.exports.lastJSONObject = lastJSONObject;
   module.exports.classifyGeminiError = classifyGeminiError;
+  module.exports.geminiTmpRoot = geminiTmpRoot;
+  module.exports.resolveSlugDir = resolveSlugDir;
+  module.exports.newestSessionFile = newestSessionFile;
+  module.exports.extractGeminiAnswer = extractGeminiAnswer;
+  module.exports.recoverAfterTimeout = recoverAfterTimeout;
 }

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -11,7 +11,7 @@ test("B1: timeout kills slow gemini and surfaces structured error", async () => 
   send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
   send(child, {
     jsonrpc: "2.0", id: 2, method: "tools/call",
-    params: { name: "gemini", arguments: { prompt: "slow", timeout: 500 } },
+    params: { name: "gemini", arguments: { prompt: "slow", timeout: 500, "recovery-grace": 0 } },
   });
 
   // Close stdin shortly after sending; bridge should still complete via its timeout.
@@ -269,4 +269,134 @@ test("B7e: classifyGeminiError tolerates null/undefined errMsg", () => {
   const { classifyGeminiError } = require("../server/gemini/index.js");
   assert.equal(classifyGeminiError(null, null).errorKind, "unknown");
   assert.equal(classifyGeminiError(undefined, null).errorKind, "unknown");
+});
+
+// --- B8: timeout-recovery (read late-flushed answer from disk) ---
+
+const fs8 = require("node:fs");
+const os8 = require("node:os");
+const path8 = require("node:path");
+
+function tmpRoot() {
+  return fs8.mkdtempSync(path8.join(os8.tmpdir(), "cdg-gtmp-"));
+}
+
+test("B8a: soft timeout drains and recovers the disk-persisted answer", async () => {
+  const root = tmpRoot();
+  const child = startBridge({
+    fakeBin: "fake-gemini-timeout-recover.sh",
+    env: { GEMINI_TMP_ROOT: root, FAKE_GEMINI_SLEEP: "2" },
+  });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "deep", timeout: 800, "recovery-grace": 10000 } },
+  });
+  setTimeout(() => child.stdin.end(), 12000);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.ok(r, "got tools/call response");
+  assert.ok(!r.result.isError, "not an error: " + JSON.stringify(r.result));
+  assert.equal(r.result.recovered, true, "recovered flag");
+  assert.equal(r.result.content[0].text, "RECOVERED ANSWER OK");
+  assert.equal(r.result.threadId, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+});
+
+test("B8b: GEMINI_DISABLE_TIMEOUT_RECOVERY=1 keeps legacy timeout", async () => {
+  const root = tmpRoot();
+  const child = startBridge({
+    fakeBin: "fake-gemini-timeout-recover.sh",
+    env: { GEMINI_TMP_ROOT: root, FAKE_GEMINI_SLEEP: "2", GEMINI_DISABLE_TIMEOUT_RECOVERY: "1" },
+  });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "deep", timeout: 500, "recovery-grace": 10000 } },
+  });
+  setTimeout(() => child.stdin.end(), 5000);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true);
+  assert.equal(r.result.errorKind, "timeout");
+  assert.equal(r.result.retryable, true);
+});
+
+test("B8c: no disk answer -> timeout after soft + grace", async () => {
+  const root = tmpRoot();
+  const child = startBridge({
+    fakeBin: "fake-gemini-timeout-recover.sh",
+    env: { GEMINI_TMP_ROOT: root, FAKE_GEMINI_SLEEP: "1", FAKE_GEMINI_NOWRITE: "1" },
+  });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "deep", timeout: 500, "recovery-grace": 3000 } },
+  });
+  setTimeout(() => child.stdin.end(), 6000);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true);
+  assert.equal(r.result.errorKind, "timeout");
+});
+
+test("B8d: stale answer (timestamp before spawn-start) is not returned", async () => {
+  const root = tmpRoot();
+  const child = startBridge({
+    fakeBin: "fake-gemini-timeout-recover.sh",
+    env: { GEMINI_TMP_ROOT: root, FAKE_GEMINI_SLEEP: "1", FAKE_GEMINI_STALE: "1" },
+  });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "deep", timeout: 500, "recovery-grace": 3000 } },
+  });
+  setTimeout(() => child.stdin.end(), 6000);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true);
+  assert.equal(r.result.errorKind, "timeout");
+  assert.ok(
+    !JSON.stringify(r.result).includes("RECOVERED ANSWER OK"),
+    "stale content must not be returned"
+  );
+});
+
+test("B8e: extractGeminiAnswer returns last gemini record + metadata threadId", () => {
+  const { extractGeminiAnswer } = require("../server/gemini/index.js");
+  const dir = tmpRoot();
+  const f = path8.join(dir, "session-x.jsonl");
+  const ts = new Date().toISOString();
+  fs8.writeFileSync(f, [
+    JSON.stringify({ sessionId: "sid-123", projectHash: "h", startTime: ts, lastUpdated: ts, kind: "main" }),
+    JSON.stringify({ id: "u1", timestamp: ts, type: "user", content: "q" }),
+    JSON.stringify({ id: "g1", timestamp: ts, type: "gemini", content: "first" }),
+    JSON.stringify({ id: "g2", timestamp: ts, type: "gemini", content: "FINAL" }),
+  ].join("\n") + "\n");
+  const got = extractGeminiAnswer(f, Date.now() - 60000);
+  assert.equal(got.content, "FINAL");
+  assert.equal(got.threadId, "sid-123");
+});
+
+test("B8e: extractGeminiAnswer applies the stale guard", () => {
+  const { extractGeminiAnswer } = require("../server/gemini/index.js");
+  const dir = tmpRoot();
+  const f = path8.join(dir, "session-y.jsonl");
+  fs8.writeFileSync(f,
+    JSON.stringify({ id: "g1", timestamp: "2000-01-01T00:00:00.000Z", type: "gemini", content: "OLD" }) + "\n");
+  assert.equal(extractGeminiAnswer(f, Date.now()), null);
+});
+
+test("B8f: resolveSlugDir matches by .project_root content", () => {
+  const { resolveSlugDir } = require("../server/gemini/index.js");
+  const root = tmpRoot();
+  const slug = path8.join(root, "some-slug");
+  fs8.mkdirSync(path8.join(slug, "chats"), { recursive: true });
+  const cwd = fs8.mkdtempSync(path8.join(os8.tmpdir(), "cdg-cwd-"));
+  fs8.writeFileSync(path8.join(slug, ".project_root"), cwd);
+  assert.equal(resolveSlugDir(cwd, root), slug);
+  assert.equal(resolveSlugDir("/nonexistent/path/xyz", root), null);
 });

--- a/test/fixtures/fake-gemini-timeout-recover.sh
+++ b/test/fixtures/fake-gemini-timeout-recover.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fake gemini CLI: simulates the timeout-then-late-flush failure mode.
+# Sleeps past the bridge soft timeout, then persists an answer to the
+# Gemini chat jsonl on disk and exits, mimicking the real CLI ignoring SIGTERM.
+#
+# Env knobs (set by the test harness):
+#   GEMINI_TMP_ROOT   base dir (the bridge's recovery code honors this too)
+#   FAKE_GEMINI_NOWRITE=1   exit without writing any jsonl (no-recovery case)
+#   FAKE_GEMINI_STALE=1     write a gemini record timestamped in the past
+#   FAKE_GEMINI_SLEEP       seconds to sleep before writing (default 2)
+set -euo pipefail
+
+if [ "${1:-}" = "--version" ]; then
+  echo "0.41.2-fake-timeout-recover"
+  exit 0
+fi
+
+printf '%s\0' "$@" >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+printf '\n' >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+
+sleep "${FAKE_GEMINI_SLEEP:-2}"
+
+if [ "${FAKE_GEMINI_NOWRITE:-}" = "1" ]; then
+  exit 0
+fi
+
+ROOT="${GEMINI_TMP_ROOT:?GEMINI_TMP_ROOT required}"
+SLUG_DIR="$ROOT/test-slug"
+CHATS="$SLUG_DIR/chats"
+mkdir -p "$CHATS"
+printf '%s' "$PWD" > "$SLUG_DIR/.project_root"
+
+if [ "${FAKE_GEMINI_STALE:-}" = "1" ]; then
+  TS="2000-01-01T00:00:00.000Z"
+else
+  TS="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+fi
+
+SID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+SESSION_FILE="$CHATS/session-$(date -u +%Y-%m-%dT%H-%M)-aaaaaaaa.jsonl"
+
+{
+  printf '%s\n' "{\"sessionId\":\"$SID\",\"projectHash\":\"deadbeef\",\"startTime\":\"$TS\",\"lastUpdated\":\"$TS\",\"kind\":\"main\"}"
+  printf '%s\n' "{\"id\":\"u1\",\"timestamp\":\"$TS\",\"type\":\"user\",\"content\":\"ping\"}"
+  printf '%s\n' "{\"id\":\"g1\",\"timestamp\":\"$TS\",\"type\":\"gemini\",\"content\":\"RECOVERED ANSWER OK\",\"thoughts\":\"\",\"tokens\":1,\"model\":\"fake\"}"
+} > "$SESSION_FILE"
+
+exit 0


### PR DESCRIPTION
## Summary

The Gemini CLI ignores SIGTERM and writes its full answer to
`~/.gemini/tmp/<slug>/chats/session-*.jsonl` regardless. The bridge used to
SIGTERM/SIGKILL at `timeout` and return a hard `errorKind: "timeout"`, throwing
away an answer that was already on (or about to land on) disk. Proof:
SIGTERM at 180000ms, Gemini actually finished ~255s, full 7641-char answer
written then discarded. Gemini 3 deep prompts run 200-260s so the 120000ms
default misfired routinely.

`timeout` is now a **soft** deadline. On expiry the bridge drains - keeps Gemini
alive and polls the jsonl for a record newer than the call's start, up to
`recovery-grace` ms - and returns the recovered answer as a normal success with
top-level `recovered: true` (content unmodified). Legacy hard-timeout behavior is
preserved via `recovery-grace: 0` or `GEMINI_DISABLE_TIMEOUT_RECOVERY=1`.

## Changes

- `server/gemini/index.js`: recovery helpers (`geminiTmpRoot`, `resolveSlugDir`,
  `newestSessionFile`, `extractGeminiAnswer`, `recoverAfterTimeout`); `runGemini`
  drain logic; `DEFAULT_TIMEOUT_MS` 120000 -> 300000; new validated
  `recovery-grace` param on `gemini` + `gemini-reply`; `serverInfo` 1.5.0.
- `test/bridge.test.js` + `test/fixtures/fake-gemini-timeout-recover.sh`:
  B8a-f; B1 pinned to `recovery-grace: 0`.
- `README.md`, `rules/model-selection.md`, `rules/orchestration.md`.
- Version 1.5.0 in `plugin.json`, `marketplace.json` (catalogue - stale last
  release), `package.json`.

## Design

- Stale-answer guard: only `type:"gemini"` records with
  `timestamp >= spawnStart - 2000ms` are accepted.
- On child exit during drain: prefer real stdout JSON; else one final disk
  recovery; else timeout (no point waiting the rest of the grace).
- Total wall bounded by `timeout + recovery-grace`.
- Known limitation: heavy parallel same-cwd calls can race on newest session
  file; timestamp guard makes mis-attribution unlikely but not impossible
  (documented in README).

## Test plan

- [x] `npm test` - 27/27 (B1-B7 unchanged behavior; B8a-f new).
- [x] B8a: drain recovers, `recovered: true`, content + threadId correct.
- [x] B8b: `GEMINI_DISABLE_TIMEOUT_RECOVERY=1` -> legacy `errorKind: "timeout"`.
- [x] B8c: no disk answer -> timeout after soft+grace.
- [x] B8d: stale answer not returned.
- [x] B8e/B8f: `extractGeminiAnswer` + `resolveSlugDir` units incl. stale guard.
- [ ] Manual: real deep prompt, `timeout: 5000, "recovery-grace": 300000` ->
  delayed success with `recovered: true` + stderr log line.

## Backwards compatibility

- API additive: new `recovery-grace` optional; new `recovered` response field
  only present on recovery. Existing args unchanged.
- `errorKind: "timeout"` still emitted (and `retryable`) when recovery fails.