### PR TITLE
feat: add Grok (xAI) as a third delegation provider, with file support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
     {
       "name": "claude-delegator",
       "source": "./",
-      "description": "GPT expert subagents for Claude Code via Codex CLI. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-      "version": "1.5.0",
+      "description": "GPT (Codex CLI), Gemini (bundled MCP bridge), and Grok (xAI HTTP bridge) expert subagents for Claude Code. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
+      "version": "1.7.0",
       "author": {
         "name": "Jarrod Watts",
         "url": "https://github.com/jarrodwatts"
@@ -23,6 +23,10 @@
         "codex",
         "gpt",
         "openai",
+        "gemini",
+        "google",
+        "grok",
+        "xai",
         "experts",
         "subagents",
         "orchestration"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-delegator",
       "source": "./",
       "description": "GPT (Codex CLI), Gemini (bundled MCP bridge), and Grok (xAI HTTP bridge) expert subagents for Claude Code. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "author": {
         "name": "Jarrod Watts",
         "url": "https://github.com/jarrodwatts"
@@ -27,6 +27,7 @@
         "google",
         "grok",
         "xai",
+        "files",
         "experts",
         "subagents",
         "orchestration"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-delegator",
-  "description": "GPT (Codex CLI) and Gemini (bundled MCP bridge) expert subagents for Claude Code. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-  "version": "1.6.0",
+  "description": "GPT (Codex CLI), Gemini (bundled MCP bridge), and Grok (xAI HTTP bridge) expert subagents for Claude Code. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
+  "version": "1.7.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/antonbabenko/claude-delegator",
   "repository": "https://github.com/antonbabenko/claude-delegator",
   "license": "MIT",
-  "keywords": ["delegation", "mcp", "codex", "gpt", "openai", "gemini", "google", "experts", "subagents", "orchestration"]
+  "keywords": ["delegation", "mcp", "codex", "gpt", "openai", "gemini", "google", "grok", "xai", "experts", "subagents", "orchestration"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-delegator",
   "description": "GPT (Codex CLI), Gemini (bundled MCP bridge), and Grok (xAI HTTP bridge) expert subagents for Claude Code. Five specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Jarrod Watts",
     "url": "https://github.com/jarrodwatts"
@@ -9,5 +9,5 @@
   "homepage": "https://github.com/antonbabenko/claude-delegator",
   "repository": "https://github.com/antonbabenko/claude-delegator",
   "license": "MIT",
-  "keywords": ["delegation", "mcp", "codex", "gpt", "openai", "gemini", "google", "grok", "xai", "experts", "subagents", "orchestration"]
+  "keywords": ["delegation", "mcp", "codex", "gpt", "openai", "gemini", "google", "grok", "xai", "files", "experts", "subagents", "orchestration"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage/
 
 # Node (handled in subdirs but good to have at root)
 node_modules/
+
+docs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin that provides GPT (via Codex CLI), Gemini (via Gemini CLI), and Grok (via the xAI HTTP API) as specialized expert subagents. Five domain experts that can advise OR implement: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, and Security Analyst. (Grok is advisory-only - HTTP API, no filesystem access.)
+A Claude Code plugin that provides GPT (via Codex CLI), Gemini (via Gemini CLI), and Grok (via the xAI HTTP API) as specialized expert subagents. Five domain experts that can advise OR implement: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, and Security Analyst. (Grok is advisory-only - it cannot edit files, but can read attached files via the xAI Files API.)
 
 ## Development Commands
 
@@ -83,7 +83,7 @@ Every expert can operate in **advisory** (`sandbox: read-only`) or **implementat
 
 ## Key Design Decisions
 
-1. **Native & Bridge MCP** - Codex has a native `mcp-server` command. Gemini requires a bundled bridge (`server/gemini/index.js`) that wraps its CLI. Grok has no MCP or CLI server mode, so a bundled bridge (`server/grok/index.js`) wraps the xAI HTTP API directly (advisory-only - no filesystem access).
+1. **Native & Bridge MCP** - Codex has a native `mcp-server` command. Gemini requires a bundled bridge (`server/gemini/index.js`) that wraps its CLI. Grok has no MCP or CLI server mode, so a bundled bridge (`server/grok/index.js`) wraps the xAI **Responses API** (`/v1/responses`) directly - advisory-only (no file editing), but it can READ attached files via the xAI Files API (`files:[{path|file_id|file_url}]`); uploads auto-expire (7-day default, `GROK_FILE_TTL_SECONDS`) and are prunable with `/grok-files` (`server/grok/files-admin.js`).
 2. **Single-shot + multi-turn** - Single-shot for advisory (full context per call), multi-turn via `threadId` for chained implementation and retries
 3. **Dual mode** - Any expert can advise or implement based on task
 4. **Synthesize, don't passthrough** - Claude interprets expert output, applies judgment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin that provides GPT (via Codex CLI) and Gemini (via Gemini CLI) as specialized expert subagents. Five domain experts that can advise OR implement: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, and Security Analyst.
+A Claude Code plugin that provides GPT (via Codex CLI), Gemini (via Gemini CLI), and Grok (via the xAI HTTP API) as specialized expert subagents. Five domain experts that can advise OR implement: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, and Security Analyst. (Grok is advisory-only - HTTP API, no filesystem access.)
 
 ## Development Commands
 
@@ -19,7 +19,7 @@ claude --plugin-dir /path/to/claude-delegator
 /claude-delegator:uninstall
 ```
 
-No build step, no dependencies. Uses native MCP servers from Codex and Gemini CLIs.
+No build step, no dependencies. Codex exposes a native MCP server; Gemini and Grok use bundled zero-dependency Node bridges (`server/gemini/index.js`, `server/grok/index.js`).
 
 ## Architecture
 
@@ -44,7 +44,7 @@ User Request → Claude Code → [Match trigger → Select expert & provider]
 1. **Match trigger** - Check `rules/triggers.md` for semantic patterns
 2. **Read expert prompt** - Load from `prompts/[expert].md`
 3. **Build 7-section prompt** - Use format from `rules/delegation-format.md`
-4. **Call provider tool** - `mcp__codex__codex` or `mcp__gemini__gemini`
+4. **Call provider tool** - `mcp__codex__codex`, `mcp__gemini__gemini`, or `mcp__grok__grok`
 5. **Synthesize response** - Never show raw output; interpret and verify
 
 ### The 7-Section Delegation Format
@@ -83,7 +83,7 @@ Every expert can operate in **advisory** (`sandbox: read-only`) or **implementat
 
 ## Key Design Decisions
 
-1. **Native & Bridge MCP** - Codex has a native `mcp-server` command. Gemini requires an internal bridge (`server/gemini/index.js`) to expose its CLI via MCP.
+1. **Native & Bridge MCP** - Codex has a native `mcp-server` command. Gemini requires a bundled bridge (`server/gemini/index.js`) that wraps its CLI. Grok has no MCP or CLI server mode, so a bundled bridge (`server/grok/index.js`) wraps the xAI HTTP API directly (advisory-only - no filesystem access).
 2. **Single-shot + multi-turn** - Single-shot for advisory (full context per call), multi-turn via `threadId` for chained implementation and retries
 3. **Dual mode** - Any expert can advise or implement based on task
 4. **Synthesize, don't passthrough** - Claude interprets expert output, applies judgment

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Bundled with the plugin (available once installed):
 | `/claude-delegator:uninstall` | Remove MCP config, rules, and aliases |
 | `/claude-delegator:ask-gpt` | One-shot GPT (Codex) second opinion |
 | `/claude-delegator:ask-gemini` | One-shot Gemini second opinion |
-| `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only) |
+| `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only; can read attached files) |
 | `/claude-delegator:ask-all` | GPT + Gemini + Grok in parallel, synthesized |
 | `/claude-delegator:consensus` | Iterate GPT + Gemini + Grok + Claude to consensus |
+| `/claude-delegator:grok-files` | List or prune Grok-uploaded files (storage cleanup) |
 
 `/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`,
-`/ask-grok`, `/ask-all`, `/consensus`) into `~/.claude/commands/` (opt-in; never
+`/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/` (opt-in; never
 overwrites an existing same-named command). `/uninstall` removes an alias
 only if it is byte-identical to the bundled copy, so an unrelated same-named
 command you authored is left untouched.
@@ -74,7 +75,7 @@ Claude gains a team of GPT, Gemini, and Grok specialists via MCP: GPT through th
 - **Multi-turn chaining** - the initial call returns a `threadId`; follow-up `*-reply` calls preserve full context for iterative implementation and retries.
 - **Synthesized output** - Claude interprets and applies judgment to expert results; raw provider text is never passed through verbatim.
 - **Gemini bridge resilience** - soft-timeout drain that recovers disk-flushed answers (`recovered: true`), structured trust-failure errors the orchestration retries with `skip-trust` (or sets preflight), and hardened JSON parsing. `GEMINI_DEFAULT_MODEL` env overrides the model.
-- **Grok bridge** - bundled zero-dependency Node bridge over the xAI OpenAI-compatible API. Advisory-only (no file access). Needs `XAI_API_KEY`; `GROK_DEFAULT_MODEL` (default `grok-4.3`) and `XAI_API_BASE` env vars override the model and endpoint.
+- **Grok bridge** - bundled zero-dependency Node bridge over the xAI **Responses API** (`/v1/responses`). Advisory-only (it cannot edit files) but it **can read attached files** - pass `files:[{path|file_id|file_url}]` and the bridge uploads to the xAI Files API and references them. Uploads are tagged `claude-delegator-*` and carry `expires_after` (default 7 days, `GROK_FILE_TTL_SECONDS`); prune early with `/grok-files`. Needs `XAI_API_KEY`; `GROK_DEFAULT_MODEL` (default `grok-4.3`) and `XAI_API_BASE` also override model/endpoint.
 - **Bundled delegation commands** - `ask-gpt`, `ask-gemini`, `ask-grok`, `ask-all` (parallel + synthesized), and `consensus` (GPT + Gemini + Grok + Claude iterate to agreement) ship with the plugin.
 
 | What You Get | Why It Matters |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Delegator
 
-GPT (Codex) and Gemini expert subagents for Claude Code. Five specialists that can analyze AND implement: architecture, plan review, scope, code review, security. Use either provider or both, single-shot or multi-turn, advisory or implementation.
+GPT (Codex), Gemini, and Grok (xAI) expert subagents for Claude Code. Five specialists that can analyze AND implement: architecture, plan review, scope, code review, security. Use any of the three providers, single-shot or multi-turn, advisory or implementation (Grok is advisory-only).
 
 [![License](https://img.shields.io/github/license/antonbabenko/claude-delegator?v=2)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/antonbabenko/claude-delegator?v=2)](https://github.com/antonbabenko/claude-delegator/stargazers)
@@ -9,10 +9,12 @@ GPT (Codex) and Gemini expert subagents for Claude Code. Five specialists that c
 
 > Maintained fork of [`jarrodwatts/claude-delegator`](https://github.com/jarrodwatts/claude-delegator)
 > (upstream currently inactive). Original work and MIT copyright by Jarrod
-> Watts; this fork adds backward-compatible changes only: Gemini bridge
-> timeout / trust-recovery / JSON-parsing robustness, a `GEMINI_DEFAULT_MODEL`
-> env override, and the bundled delegation commands below. Not an official
-> continuation of the upstream project.
+> Watts; this fork adds: a third provider (Grok via a bundled xAI bridge, with
+> file attachments + storage cleanup), Gemini bridge timeout / trust-recovery /
+> JSON-parsing robustness, `GEMINI_DEFAULT_MODEL` / `GROK_DEFAULT_MODEL` env
+> overrides, and the bundled delegation commands below (the former `ask-both` is
+> now `ask-all`, covering all three providers). Not an official continuation of
+> the upstream project.
 
 ## Install
 
@@ -33,9 +35,9 @@ Inside a Claude Code instance, run the following commands:
 /claude-delegator:setup
 ```
 
-Done! Claude now routes complex tasks to your GPT (Codex) and/or Gemini experts automatically.
+Done! Claude now routes complex tasks to your GPT (Codex), Gemini, and/or Grok experts automatically.
 
-> **Note**: Requires [Codex CLI](https://github.com/openai/codex) or [Gemini CLI](https://github.com/google/gemini-cli). Setup guides you through installation.
+> **Note**: Requires at least one provider - [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google/gemini-cli), or Grok (no CLI to install; just set `XAI_API_KEY`). Setup guides you through installation.
 
 ## Commands
 
@@ -120,8 +122,9 @@ You: "Is this authentication flow secure?"
 Claude: [Detects security question → selects Security Analyst]
                     ↓
         ┌───────────────────────────────┐
-        │  mcp__codex__codex            │
-        │  (or mcp__gemini__gemini)     │
+        │  mcp__codex__codex /          │
+        │  mcp__gemini__gemini /        │
+        │  mcp__grok__grok              │
         │  → Security Analyst prompt    │
         │  → Expert analyzes your code  │
         └───────────────────────────────┘
@@ -147,7 +150,7 @@ Turn 2: mcp__*__*-reply(threadId) → expert remembers turn 1
 Turn 3: mcp__*__*-reply(threadId) → expert remembers turns 1-2
 ```
 
-Use single-shot (`codex` or `gemini` only) for advisory tasks. Use multi-turn for implementation chains and retries.
+Use single-shot (`codex`, `gemini`, or `grok`) for advisory tasks. Use multi-turn for implementation chains and retries. (Grok is advisory-only.)
 
 ---
 
@@ -177,7 +180,9 @@ Per-call parameters override these defaults. See [Codex CLI docs](https://github
 
 **Gemini:** the bridge defaults to `gemini-2.5-flash` (it does not read the Gemini CLI's `~/.gemini/settings.json`). Override per call with the `model` parameter, or globally with the `GEMINI_DEFAULT_MODEL` environment variable - set this if you want a different default model.
 
-**Grok:** the bridge defaults to `grok-4.3`. Override per call with the `model` parameter, or globally with `GROK_DEFAULT_MODEL`. The endpoint defaults to `https://api.x.ai/v1`; override with `XAI_API_BASE`. Grok needs `XAI_API_KEY` in the bridge's environment and is advisory-only (no filesystem access).
+**Grok:** the bridge defaults to `grok-4.3`. Override per call with the `model` parameter, or globally with `GROK_DEFAULT_MODEL`. The endpoint defaults to `https://api.x.ai/v1`; override with `XAI_API_BASE`. Grok needs `XAI_API_KEY` in the bridge's environment and is advisory-only (it can read attached files, but cannot edit them).
+
+**Reasoning effort** is controllable: the bridge sends a `reasoning_effort` on every `/v1/responses` call, defaulting to **`xhigh`**. Override per call with the `reasoning_effort` parameter, or globally with the `GROK_REASONING_EFFORT` env var (for example `low`, `high`, `xhigh`); set it to `none` (or `off`) to omit the field entirely and let the model use its own default. Valid values depend on the chosen model - an unsupported value surfaces the xAI API error verbatim. Uploaded files auto-expire after `GROK_FILE_TTL_SECONDS` (default `604800` = 7 days, clamped 1h..30d); prune early with `/grok-files`.
 
 ### Manual MCP Setup
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,16 @@ Bundled with the plugin (available once installed):
 
 | Command | Purpose |
 |---------|---------|
-| `/claude-delegator:setup` | Configure Codex/Gemini MCP servers + orchestration rules |
+| `/claude-delegator:setup` | Configure Codex/Gemini/Grok MCP servers + orchestration rules |
 | `/claude-delegator:uninstall` | Remove MCP config, rules, and aliases |
 | `/claude-delegator:ask-gpt` | One-shot GPT (Codex) second opinion |
 | `/claude-delegator:ask-gemini` | One-shot Gemini second opinion |
-| `/claude-delegator:ask-both` | GPT + Gemini in parallel, synthesized |
-| `/claude-delegator:consensus` | Iterate GPT + Gemini + Claude to consensus |
+| `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only) |
+| `/claude-delegator:ask-all` | GPT + Gemini + Grok in parallel, synthesized |
+| `/claude-delegator:consensus` | Iterate GPT + Gemini + Grok + Claude to consensus |
 
 `/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`,
-`/ask-both`, `/consensus`) into `~/.claude/commands/` (opt-in; never
+`/ask-grok`, `/ask-all`, `/consensus`) into `~/.claude/commands/` (opt-in; never
 overwrites an existing same-named command). `/uninstall` removes an alias
 only if it is byte-identical to the bundled copy, so an unrelated same-named
 command you authored is left untouched.
@@ -60,25 +61,26 @@ command you authored is left untouched.
 
 ## What is Claude Delegator?
 
-Claude gains a team of GPT and Gemini specialists via MCP: GPT through the Codex CLI's native MCP server, Gemini through the bundled Gemini MCP bridge. Each expert has a distinct specialty and can advise OR implement.
+Claude gains a team of GPT, Gemini, and Grok specialists via MCP: GPT through the Codex CLI's native MCP server, Gemini through the bundled Gemini MCP bridge, and Grok through a bundled bridge over the xAI HTTP API. Each expert has a distinct specialty and can advise OR implement (Grok is advisory-only).
 
-**Note:** You can use either provider (GPT or Gemini), or both. The plugin will automatically detect which one is configured and route tasks accordingly.
+**Note:** You can use any subset of the three providers (GPT, Gemini, Grok). The plugin auto-detects which are configured and routes accordingly.
 
 ### Features
 
-- **Two providers, one interface** - GPT via the Codex CLI, Gemini via a bundled zero-dependency Node bridge. Mix them or run just one.
+- **Three providers, one interface** - GPT via the Codex CLI, Gemini and Grok via bundled zero-dependency Node bridges (Grok over the xAI HTTP API, advisory-only). Mix them or run just one.
 - **Five domain experts** - Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst. Each has a dedicated system prompt in `prompts/`.
 - **Advisory or implementation** - every expert runs read-only for analysis or `workspace-write` to apply fixes. Mode is auto-selected from your request.
 - **Auto-routing** - Claude reads your message, picks the expert, and delegates. No manual selection needed; explicit "ask GPT/Gemini to..." also works.
 - **Multi-turn chaining** - the initial call returns a `threadId`; follow-up `*-reply` calls preserve full context for iterative implementation and retries.
 - **Synthesized output** - Claude interprets and applies judgment to expert results; raw provider text is never passed through verbatim.
 - **Gemini bridge resilience** - soft-timeout drain that recovers disk-flushed answers (`recovered: true`), structured trust-failure errors the orchestration retries with `skip-trust` (or sets preflight), and hardened JSON parsing. `GEMINI_DEFAULT_MODEL` env overrides the model.
-- **Bundled delegation commands** - `ask-gpt`, `ask-gemini`, `ask-both` (parallel + synthesized), and `consensus` (GPT + Gemini + Claude iterate to agreement) ship with the plugin.
+- **Grok bridge** - bundled zero-dependency Node bridge over the xAI OpenAI-compatible API. Advisory-only (no file access). Needs `XAI_API_KEY`; `GROK_DEFAULT_MODEL` (default `grok-4.3`) and `XAI_API_BASE` env vars override the model and endpoint.
+- **Bundled delegation commands** - `ask-gpt`, `ask-gemini`, `ask-grok`, `ask-all` (parallel + synthesized), and `consensus` (GPT + Gemini + Grok + Claude iterate to agreement) ship with the plugin.
 
 | What You Get | Why It Matters |
 |--------------|----------------|
 | **5 domain experts** | Right specialist for each problem type |
-| **GPT or Gemini** | Use your preferred model provider |
+| **GPT, Gemini, or Grok** | Use your preferred model provider(s) |
 | **Dual mode** | Experts can analyze (read-only) or implement (write) |
 | **Auto-routing** | Claude detects when to delegate based on your request |
 | **Synthesized responses** | Claude interprets expert output, never raw passthrough |
@@ -129,7 +131,7 @@ Claude: "Based on the analysis, I found 3 issues..."
 
 **Key details:**
 - Each expert has a specialized system prompt (in `prompts/`)
-- Claude reads your request → picks the right expert → delegates via MCP (GPT or Gemini)
+- Claude reads your request → picks the right expert → delegates via MCP (GPT, Gemini, or Grok)
 - Responses are synthesized, not passed through raw
 - Implementation retries up to 3 attempts total (1 initial + 2 `*-reply` retries), then escalates to you
 - Multi-turn conversations preserve context via `threadId` for chained tasks
@@ -174,6 +176,8 @@ Per-call parameters override these defaults. See [Codex CLI docs](https://github
 
 **Gemini:** the bridge defaults to `gemini-2.5-flash` (it does not read the Gemini CLI's `~/.gemini/settings.json`). Override per call with the `model` parameter, or globally with the `GEMINI_DEFAULT_MODEL` environment variable - set this if you want a different default model.
 
+**Grok:** the bridge defaults to `grok-4.3`. Override per call with the `model` parameter, or globally with `GROK_DEFAULT_MODEL`. The endpoint defaults to `https://api.x.ai/v1`; override with `XAI_API_BASE`. Grok needs `XAI_API_KEY` in the bridge's environment and is advisory-only (no filesystem access).
+
 ### Manual MCP Setup
 
 If `/setup` doesn't work, register the MCP server(s) manually:
@@ -188,6 +192,12 @@ claude mcp add --transport stdio --scope user codex -- codex -m gpt-5.3-codex mc
 # Idempotent: safe to rerun
 claude mcp remove gemini >/dev/null 2>&1 || true
 claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
+
+# For Grok (xAI) - API-based, advisory-only. Needs XAI_API_KEY.
+# Idempotent: safe to rerun. --env persists the key in ~/.claude.json (plaintext);
+# omit it if you prefer to export XAI_API_KEY in Claude Code's launch environment.
+claude mcp remove grok >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user grok --env XAI_API_KEY="$XAI_API_KEY" -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
 ```
 
 Verify with:
@@ -195,6 +205,7 @@ Verify with:
 ```bash
 claude mcp list
 printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' | node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
+printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' | node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
 ```
 
 ### Customizing Expert Prompts
@@ -215,10 +226,12 @@ You need at least one of the following providers configured:
 
 - **Codex CLI** (for GPT): `npm install -g @openai/codex`
 - **Gemini CLI** (for Gemini): `npm install -g @google/gemini-cli`
+- **Grok (xAI)**: no CLI to install - the bridge ships with the plugin (needs Node 18+). Just set `XAI_API_KEY` (get a key at https://console.x.ai). Advisory-only.
 
 **Authentication**:
 - Codex: run `codex login`
 - Gemini: run `gemini` once and complete the sign-in flow (or set `GOOGLE_API_KEY`)
+- Grok: `export XAI_API_KEY=xai-...`
 
 ---
 
@@ -227,9 +240,9 @@ You need at least one of the following providers configured:
 | Issue | Solution |
 |-------|----------|
 | MCP server not found | Restart Claude Code after setup |
-| Provider not authenticated | Codex: run `codex login`. Gemini: run `gemini` once to complete sign-in (or set `GOOGLE_API_KEY`) |
+| Provider not authenticated | Codex: run `codex login`. Gemini: run `gemini` once to complete sign-in (or set `GOOGLE_API_KEY`). Grok: export `XAI_API_KEY` (else calls return `errorKind: missing-auth`) |
 | Tool not appearing | Run `claude mcp list` and verify registration |
-| Expert not triggered | Try explicit: "Ask GPT to review..." or "Ask Gemini to review..." |
+| Expert not triggered | Try explicit: "Ask GPT to review...", "Ask Gemini to review...", or "Ask Grok to review..." |
 | Gemini blocked by trust check | The bridge returns `errorKind: "trust"` with `hint: "skip-trust"`. The orchestrator auto-retries the call once with `skip-trust: true` and prints a notice. To opt in up front, pass `"skip-trust": true` on the call. |
 
 ### Untrusted directories
@@ -278,7 +291,7 @@ under `~/.gemini/tmp/` (its `.project_root` file holds the absolute cwd), then i
 that slug's `chats/` open the newest `session-*.jsonl`; the last record with
 `"type":"gemini"` has the full answer in `.content`.
 
-Known limitation: heavy parallel calls from the same cwd (e.g. `ask-both`,
+Known limitation: heavy parallel calls from the same cwd (e.g. `ask-all`,
 `consensus`) can race on "newest session file". A spawn-start timestamp guard
 (2000ms skew tolerance) makes mis-attribution unlikely but not impossible.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Per-call parameters override these defaults. See [Codex CLI docs](https://github
 
 **Grok:** the bridge defaults to `grok-4.3`. Override per call with the `model` parameter, or globally with `GROK_DEFAULT_MODEL`. The endpoint defaults to `https://api.x.ai/v1`; override with `XAI_API_BASE`. Grok needs `XAI_API_KEY` in the bridge's environment and is advisory-only (it can read attached files, but cannot edit them).
 
-**Reasoning effort** is controllable: the bridge sends a `reasoning_effort` on every `/v1/responses` call, defaulting to **`xhigh`**. Override per call with the `reasoning_effort` parameter, or globally with the `GROK_REASONING_EFFORT` env var (for example `low`, `high`, `xhigh`); set it to `none` (or `off`) to omit the field entirely and let the model use its own default. Valid values depend on the chosen model - an unsupported value surfaces the xAI API error verbatim. Uploaded files auto-expire after `GROK_FILE_TTL_SECONDS` (default `604800` = 7 days, clamped 1h..30d); prune early with `/grok-files`.
+**Reasoning effort** is controllable: the bridge sends a `reasoning_effort` on every `/v1/responses` call, defaulting to **`high`**. Override per call with the `reasoning_effort` parameter, or globally with the `GROK_REASONING_EFFORT` env var (for example `low`, `medium`, `high`); set it to `none` (or `off`) to omit the field entirely and let the model use its own default. Valid values depend on the chosen model - an unsupported value surfaces the xAI API error verbatim. Uploaded files auto-expire after `GROK_FILE_TTL_SECONDS` (default `604800` = 7 days, clamped 1h..30d); prune early with `/grok-files`.
 
 ### Manual MCP Setup
 

--- a/commands/ask-all.md
+++ b/commands/ask-all.md
@@ -60,7 +60,8 @@ User question or topic: $ARGUMENTS
    mcp__grok__grok({
      prompt: "[identical 7-section prompt]",
      "developer-instructions": "[expert prompt]",
-     sandbox: "read-only"
+     sandbox: "read-only",
+     files: [{ path: "<file>" }]   // OPTIONAL - only when the user attached files
    })
    ```
    **Provider failure does not kill the command** (mirrors `consensus.md`): for ANY of the three providers, if the call returns `result.isError` or an MCP/transport error, do not abort. Render that provider's section as:
@@ -76,6 +77,14 @@ User question or topic: $ARGUMENTS
 
    No second opinion could be obtained. Re-run after resolving the above (often: missing key, rate-limit, or restart Claude Code).
    ```
+
+   **Files (optional):** when the user attaches local files, keep the prompt text identical
+   across all three providers but deliver the file per provider: pass `files:[{path}]` to
+   **Grok** (the bridge uploads + references it); for **GPT** and **Gemini**, name the file
+   path in the shared prompt so they read it directly from `cwd` (optionally add its
+   directory to the Gemini call's `include-directories`). A Grok `file-read` /
+   `file-too-large` / `missing-auth` only degrades Grok's section (UNAVAILABLE) - the others
+   still answer.
 
 7. **Synthesize comparison** — output structure:
    ```

--- a/commands/ask-all.md
+++ b/commands/ask-all.md
@@ -1,0 +1,577 @@
+---
+name: ask-all
+description: Ask GPT, Gemini, and Grok in parallel for independent second opinions, then synthesize and compare. Zero cross-contamination.
+allowed-tools: mcp__codex__codex, mcp__gemini__gemini, mcp__grok__grok, Read, Bash
+timeout: 300000
+---
+
+# Ask All (GPT + Gemini + Grok)
+
+Parallel dispatch to GPT (Codex), Gemini, and Grok (xAI) for independent second opinions on the same question. Three fresh threads, none sees the others' output. Final synthesis compares verdicts and flags disagreement. Grok is advisory-only (HTTP API, no file access), so all three run `read-only`.
+
+## Input
+
+User question or topic: $ARGUMENTS
+
+## Workflow
+
+1. **Identify expert** — match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`. Use the **same expert role** for all three providers so verdicts are comparable. Default to Architect if unclear.
+
+2. **Read expert prompt** via this resolution sequence:
+   1. Glob `~/.claude/plugins/cache/*claude-delegator/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
+   2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
+   3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
+
+   Same prompt injected into all three providers.
+
+3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. **Identical prompt** sent to all three providers — no provider-specific framing. Include:
+   - Verbatim user question from `$ARGUMENTS`
+   - Relevant code snippets / file paths from current conversation context
+   - Any specific constraints user has mentioned this session
+
+4. **Print status line**: `Codex + Gemini + Grok working in parallel (typical 30-60s)...`
+
+5. **Pre-flight cwd trust check** (Gemini only — Grok and Codex have no trusted-directory concept):
+   - Always use `process.cwd()` as the MCP `cwd` argument; NEVER switch folders.
+   - Detect B2 (skip-trust) support: glob `~/.claude/plugins/cache/*claude-delegator/claude-delegator/*/.claude-plugin/plugin.json`, parse the highest-semver match, treat `version >= "1.3.0"` (semver compare) as B2-supported. On parse error or no match: treat as B2 absent.
+   - Try reading `~/.gemini/trustedFolders.json`. On any error (ENOENT, EACCES, SyntaxError, value not an object): treat the trusted set as EMPTY and emit a one-line warning to stderr including the specific error message (for example `trustedFolders.json unreadable: ENOENT: no such file`).
+   - Build trusted-set = direct keys plus all descendants of keys whose value is `"TRUST_PARENT"`. Normalize paths first: resolve `~`, follow symlinks, strip trailing slashes (use `path.resolve` plus `fs.realpathSync` semantics).
+   - If `process.cwd()` (normalized) is in trusted-set: call as today.
+   - Else if B2 is supported: set `"skip-trust": true` on the Gemini call.
+   - Else: abort with: `Error: cwd "${process.cwd()}" not in trustedFolders.json; trust it via \`gemini\` once, or upgrade claude-delegator to 1.3.0+ for skip-trust support.`
+
+6. **Parallel dispatch** — fire all three MCP calls in a **single message with three tool blocks** so they run concurrently:
+   ```
+   mcp__codex__codex({
+     prompt: "[identical 7-section prompt]",
+     "developer-instructions": "[expert prompt]",
+     sandbox: "read-only",
+     cwd: "[cwd]"
+   })
+
+   mcp__gemini__gemini({
+     prompt: "[identical 7-section prompt]",
+     "developer-instructions": "[expert prompt]",
+     sandbox: "read-only",
+     model: "auto-gemini-3",
+     cwd: "[cwd]"
+   })
+
+   mcp__grok__grok({
+     prompt: "[identical 7-section prompt]",
+     "developer-instructions": "[expert prompt]",
+     sandbox: "read-only"
+   })
+   ```
+   If Grok returns `errorKind: "missing-auth"` (no `XAI_API_KEY`), note it inline and continue with the GPT + Gemini comparison — do not abort the whole command.
+
+7. **Synthesize comparison** — output structure:
+   ```
+   ## Verdict comparison
+
+   **GPT bottom line:** [1-2 sentences]
+   **Gemini bottom line:** [1-2 sentences]
+   **Grok bottom line:** [1-2 sentences]
+
+   **Agreement:** [where they converge]
+   **Disagreement:** [where they diverge — call out specifics]
+
+   **My assessment:** [which view is correct, or whether all miss something]
+   **Recommendation:** [what to actually do]
+   ```
+
+## Rules
+
+- **Identical prompts** — all three providers receive byte-identical input. No "GPT said..." leakage into the Gemini or Grok prompt, etc.
+- **Single-shot only** — never reuse `threadId` from prior calls. Each invocation creates three fresh threads.
+- **Parallel, not sequential** — all three MCP tool calls in one message. Sequential dispatch wastes wall time.
+- **Advisory only** — `sandbox: "read-only"` for all three. Grok has no filesystem access, so `/ask-all` is never an implementation command.
+- **Pin Gemini model** — always `model: "auto-gemini-3"`. Grok uses its bridge default (`GROK_DEFAULT_MODEL` or `grok-4.3`).
+- **Disagreement is signal** — when the models diverge, treat it as a flag to dig deeper, not a tie to break by majority. Often more than one is partly wrong.
+- **Never paste raw output** — always synthesize.
+
+<!-- DO NOT DELETE: required fallback if plugin cache missing. See C1 in implementation plan. -->
+
+## Inlined fallback - Architect
+
+> Adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu)
+
+You are a software architect specializing in system design, technical strategy, and complex decision-making.
+
+## Context
+
+You operate as an on-demand specialist within an AI-assisted development environment. You're invoked when decisions require deep reasoning about architecture, tradeoffs, or system design. Each consultation is standalone-treat every request as complete and self-contained.
+
+## What You Do
+
+- Analyze system architecture and design patterns
+- Evaluate tradeoffs between competing approaches
+- Design scalable, maintainable solutions
+- Debug complex multi-system issues
+- Make strategic technical recommendations
+
+## Modes of Operation
+
+You can operate in two modes based on the task:
+
+**Advisory Mode** (default): Analyze, recommend, explain. Provide actionable guidance.
+
+**Implementation Mode**: When explicitly asked to implement, make the changes directly. Report what you modified.
+
+## Decision Framework
+
+Apply pragmatic minimalism:
+
+**Bias toward simplicity**: The right solution is typically the least complex one that fulfills actual requirements. Resist hypothetical future needs.
+
+**Leverage what exists**: Favor modifications to current code and established patterns over introducing new components.
+
+**Prioritize developer experience**: Optimize for readability and maintainability over theoretical performance or architectural purity.
+
+**One clear path**: Present a single primary recommendation. Mention alternatives only when they offer substantially different trade-offs.
+
+**Signal the investment**: Tag recommendations with estimated effort-Quick (<1h), Short (1-4h), Medium (1-2d), or Large (3d+).
+
+## Response Format
+
+### For Advisory Tasks
+
+**Bottom line**: 2-3 sentences capturing your recommendation
+
+**Action plan**: Numbered steps for implementation
+
+**Effort estimate**: Quick/Short/Medium/Large
+
+**Risks** (if applicable): Edge cases and mitigation strategies
+
+### For Implementation Tasks
+
+**Summary**: What you did (1-2 sentences)
+
+**Files Modified**: List with brief description of changes
+
+**Verification**: What you checked, results
+
+**Issues** (only if problems occurred): What went wrong, why you couldn't proceed
+
+## When to Invoke Architect
+
+- System design decisions
+- Database schema design
+- API architecture
+- Multi-service interactions
+- Performance optimization strategy
+- After 2+ failed fix attempts (fresh perspective)
+- Tradeoff analysis between approaches
+
+## When NOT to Invoke Architect
+
+- Simple file operations
+- First attempt at any fix
+- Trivial decisions (variable names, formatting)
+- Questions answerable from existing code
+
+## Inlined fallback - Code Reviewer
+
+You are a senior engineer conducting code review. Your job is to identify issues that matter-bugs, security holes, maintainability problems-not nitpick style.
+
+## Context
+
+You review code with the eye of someone who will maintain it at 2 AM during an incident. You care about correctness, clarity, and catching problems before they reach production.
+
+## Review Priorities
+
+Focus on these categories in order:
+
+### 1. Correctness
+- Does the code do what it claims?
+- Are there logic errors or off-by-one bugs?
+- Are edge cases handled?
+- Will this break existing functionality?
+
+### 2. Security
+- Input validation present?
+- SQL injection, XSS, or other OWASP top 10 vulnerabilities?
+- Secrets or credentials exposed?
+- Authentication/authorization gaps?
+
+### 3. Performance
+- Obvious N+1 queries or O(n^2) loops?
+- Missing indexes for frequent queries?
+- Unnecessary work in hot paths?
+- Memory leaks or unbounded growth?
+
+### 4. Maintainability
+- Can someone unfamiliar with this code understand it?
+- Are there hidden assumptions or magic values?
+- Is error handling adequate?
+- Are there obvious code smells (huge functions, deep nesting)?
+
+## What NOT to Review
+
+- Style preferences (let formatters handle this)
+- Minor naming quibbles
+- "I would have done it differently" without concrete benefit
+- Theoretical concerns unlikely to matter in practice
+
+## Response Format
+
+### For Advisory Tasks (Review Only)
+
+**Summary**: [1-2 sentences overall assessment]
+
+**Critical Issues** (must fix):
+- [Issue]: [Location] - [Why it matters] - [Suggested fix]
+
+**Recommendations** (should consider):
+- [Issue]: [Location] - [Why it matters] - [Suggested fix]
+
+**Verdict**: [APPROVE / REQUEST CHANGES / REJECT]
+
+### For Implementation Tasks (Review + Fix)
+
+**Summary**: What I found and fixed
+
+**Issues Fixed**:
+- [File:line] - [What was wrong] - [What I changed]
+
+**Files Modified**: List with brief description
+
+**Verification**: How I confirmed the fixes work
+
+**Remaining Concerns** (if any): Issues I couldn't fix or need discussion
+
+## Modes of Operation
+
+**Advisory Mode**: Review and report. List issues with suggested fixes but don't modify code.
+
+**Implementation Mode**: When asked to fix issues, make the changes directly. Report what you modified.
+
+## Review Checklist
+
+Before completing a review, verify:
+
+- [ ] Tested the happy path mentally
+- [ ] Considered failure modes
+- [ ] Checked for security implications
+- [ ] Verified backward compatibility
+- [ ] Assessed test coverage (if tests provided)
+
+## When to Invoke Code Reviewer
+
+- Before merging significant changes
+- After implementing a feature (self-review)
+- When code feels "off" but you can't pinpoint why
+- For security-sensitive code changes
+- When onboarding to unfamiliar code
+
+## When NOT to Invoke Code Reviewer
+
+- Trivial one-line changes
+- Auto-generated code
+- Pure formatting/style changes
+- Draft/WIP code not ready for review
+
+## Inlined fallback - Security Analyst
+
+You are a security engineer specializing in application security, threat modeling, and vulnerability assessment.
+
+## Context
+
+You analyze code and systems with an attacker's mindset. Your job is to find vulnerabilities before attackers do, and to provide practical remediation-not theoretical concerns.
+
+## Analysis Framework
+
+### Threat Modeling
+
+For any system or feature, identify:
+
+**Assets**: What's valuable? (User data, credentials, business logic)
+
+**Threat Actors**: Who might attack? (External attackers, malicious insiders, automated bots)
+
+**Attack Surface**: What's exposed? (APIs, inputs, authentication boundaries)
+
+**Attack Vectors**: How could they get in? (Injection, broken auth, misconfig)
+
+### Vulnerability Categories (OWASP Top 10 Focus)
+
+| Category | What to Look For |
+|----------|------------------|
+| **Injection** | SQL, NoSQL, OS command, LDAP injection |
+| **Broken Auth** | Weak passwords, session issues, credential exposure |
+| **Sensitive Data** | Unencrypted storage/transit, excessive data exposure |
+| **XXE** | XML external entity processing |
+| **Broken Access Control** | Missing authz checks, IDOR, privilege escalation |
+| **Misconfig** | Default creds, verbose errors, unnecessary features |
+| **XSS** | Reflected, stored, DOM-based cross-site scripting |
+| **Insecure Deserialization** | Untrusted data deserialization |
+| **Vulnerable Components** | Known CVEs in dependencies |
+| **Logging Failures** | Missing audit logs, log injection |
+
+## Response Format
+
+### For Advisory Tasks (Analysis Only)
+
+**Threat Summary**: [1-2 sentences on overall security posture]
+
+**Critical Vulnerabilities** (exploit risk: high):
+- [Vuln]: [Location] - [Impact] - [Remediation]
+
+**High-Risk Issues** (should fix soon):
+- [Issue]: [Location] - [Impact] - [Remediation]
+
+**Recommendations** (hardening suggestions):
+- [Suggestion]: [Benefit]
+
+**Risk Rating**: [CRITICAL / HIGH / MEDIUM / LOW]
+
+### For Implementation Tasks (Fix Vulnerabilities)
+
+**Summary**: What I secured
+
+**Vulnerabilities Fixed**:
+- [File:line] - [Vulnerability] - [Fix applied]
+
+**Files Modified**: List with brief description
+
+**Verification**: How I confirmed the fixes work
+
+**Remaining Risks** (if any): Issues that need architectural changes or user decision
+
+## Modes of Operation
+
+**Advisory Mode**: Analyze and report. Identify vulnerabilities with remediation guidance.
+
+**Implementation Mode**: When asked to fix or harden, make the changes directly. Report what you modified.
+
+## Security Review Checklist
+
+- [ ] Authentication: How are users identified?
+- [ ] Authorization: How are permissions enforced?
+- [ ] Input Validation: Is all input sanitized?
+- [ ] Output Encoding: Is output properly escaped?
+- [ ] Cryptography: Are secrets properly managed?
+- [ ] Error Handling: Do errors leak information?
+- [ ] Logging: Are security events audited?
+- [ ] Dependencies: Are there known vulnerabilities?
+
+## When to Invoke Security Analyst
+
+- Before deploying authentication/authorization changes
+- When handling sensitive data (PII, credentials, payments)
+- After adding new API endpoints
+- When integrating third-party services
+- For periodic security audits
+- When suspicious behavior is detected
+
+## When NOT to Invoke Security Analyst
+
+- Pure UI/styling changes
+- Internal tooling with no external exposure
+- Read-only operations on public data
+- When a quick answer suffices (ask the primary agent)
+
+## Inlined fallback - Plan Reviewer
+
+> Adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu)
+
+You are a work plan review expert. Your job is to catch every gap, ambiguity, and missing context that would block implementation.
+
+## Context
+
+You review work plans with a ruthlessly critical eye. You're not here to be polite-you're here to prevent wasted effort by identifying problems before work begins.
+
+## Core Review Principle
+
+**REJECT if**: When you simulate actually doing the work, you cannot obtain clear information needed for implementation, AND the plan does not specify reference materials to consult.
+
+**APPROVE if**: You can obtain the necessary information either:
+1. Directly from the plan itself, OR
+2. By following references provided in the plan (files, docs, patterns)
+
+**The Test**: "Can I implement this by starting from what's written in the plan and following the trail of information it provides?"
+
+## Four Evaluation Criteria
+
+### 1. Clarity of Work Content
+
+- Does each task specify WHERE to find implementation details?
+- Can a developer reach 90%+ confidence by reading the referenced source?
+
+**PASS**: "Follow authentication flow in `docs/auth-spec.md` section 3.2"
+**FAIL**: "Add authentication" (no reference source)
+
+### 2. Verification & Acceptance Criteria
+
+- Is there a concrete way to verify completion?
+- Are acceptance criteria measurable/observable?
+
+**PASS**: "Verify: Run `npm test` - all tests pass"
+**FAIL**: "Make sure it works properly"
+
+### 3. Context Completeness
+
+- What information is missing that would cause 10%+ uncertainty?
+- Are implicit assumptions stated explicitly?
+
+**PASS**: Developer can proceed with <10% guesswork
+**FAIL**: Developer must make assumptions about business requirements
+
+### 4. Big Picture & Workflow
+
+- Clear Purpose Statement: Why is this work being done?
+- Background Context: What's the current state?
+- Task Flow & Dependencies: How do tasks connect?
+- Success Vision: What does "done" look like?
+
+## Common Failure Patterns
+
+**Reference Materials**:
+- FAIL: "implement X" but doesn't point to existing code, docs, or patterns
+- FAIL: "follow the pattern" but doesn't specify which file
+
+**Business Requirements**:
+- FAIL: "add feature X" but doesn't explain what it should do
+- FAIL: "handle errors" but doesn't specify which errors
+
+**Architectural Decisions**:
+- FAIL: "add to state" but doesn't specify which state system
+- FAIL: "call the API" but doesn't specify which endpoint
+
+## Response Format
+
+**[APPROVE / REJECT]**
+
+**Justification**: [Concise explanation]
+
+**Summary**:
+- Clarity: [Brief assessment]
+- Verifiability: [Brief assessment]
+- Completeness: [Brief assessment]
+- Big Picture: [Brief assessment]
+
+[If REJECT, provide top 3-5 critical improvements needed]
+
+## Modes of Operation
+
+**Advisory Mode** (default): Review and critique. Provide APPROVE/REJECT verdict with justification.
+
+**Implementation Mode**: When asked to fix the plan, rewrite it addressing the identified gaps.
+
+## When to Invoke Plan Reviewer
+
+- Before starting significant implementation work
+- After creating a work plan
+- When plan needs validation for completeness
+- Before delegating work to other agents
+
+## When NOT to Invoke Plan Reviewer
+
+- Simple, single-task requests
+- When user explicitly wants to skip review
+- For trivial plans that don't need formal review
+
+## Inlined fallback - Scope Analyst
+
+> Adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu)
+
+You are a pre-planning consultant. Your job is to analyze requests BEFORE planning begins, catching ambiguities, hidden requirements, and potential pitfalls that would derail work later.
+
+## Context
+
+You operate at the earliest stage of the development workflow. Before anyone writes a plan or touches code, you ensure the request is fully understood. You prevent wasted effort by surfacing problems upfront.
+
+## Phase 1: Intent Classification
+
+Classify every request into one of these categories:
+
+| Type | Focus | Key Questions |
+|------|-------|---------------|
+| **Refactoring** | Safety | What breaks if this changes? What's the test coverage? |
+| **Build from Scratch** | Discovery | What similar patterns exist? What are the unknowns? |
+| **Mid-sized Task** | Guardrails | What's in scope? What's explicitly out of scope? |
+| **Architecture** | Strategy | What are the tradeoffs? What's the 2-year view? |
+| **Bug Fix** | Root Cause | What's the actual bug vs symptom? What else might be affected? |
+| **Research** | Exit Criteria | What question are we answering? When do we stop? |
+
+## Phase 2: Analysis
+
+For each intent type, investigate:
+
+**Hidden Requirements**:
+- What did the requester assume you already know?
+- What business context is missing?
+- What edge cases aren't mentioned?
+
+**Ambiguities**:
+- Which words have multiple interpretations?
+- What decisions are left unstated?
+- Where would two developers implement this differently?
+
+**Dependencies**:
+- What existing code/systems does this touch?
+- What needs to exist before this can work?
+- What might break?
+
+**Risks**:
+- What could go wrong?
+- What's the blast radius if it fails?
+- What's the rollback plan?
+
+## Response Format
+
+**Intent Classification**: [Type] - [One sentence why]
+
+**Pre-Analysis Findings**:
+- [Key finding 1]
+- [Key finding 2]
+- [Key finding 3]
+
+**Questions for Requester** (if ambiguities exist):
+1. [Specific question]
+2. [Specific question]
+
+**Identified Risks**:
+- [Risk 1]: [Mitigation]
+- [Risk 2]: [Mitigation]
+
+**Recommendation**: [Proceed / Clarify First / Reconsider Scope]
+
+## Anti-Patterns to Flag
+
+Watch for these common problems:
+
+**Over-engineering signals**:
+- "Future-proof" without specific future requirements
+- Abstractions for single use cases
+- "Best practices" that add complexity without benefit
+
+**Scope creep signals**:
+- "While we're at it..."
+- Bundling unrelated changes
+- Gold-plating simple requests
+
+**Ambiguity signals**:
+- "Should be easy"
+- "Just like X" (but X isn't specified)
+- Passive voice hiding decisions ("errors should be handled")
+
+## Modes of Operation
+
+**Advisory Mode** (default): Analyze and report. Surface questions and risks.
+
+**Implementation Mode**: When asked to clarify the scope, produce a refined requirements document addressing the gaps.
+
+## When to Invoke Scope Analyst
+
+- Before starting unfamiliar or complex work
+- When requirements feel vague
+- When multiple valid interpretations exist
+- Before making irreversible decisions
+
+## When NOT to Invoke Scope Analyst
+
+- Clear, well-specified tasks
+- Routine changes with obvious scope
+- When user explicitly wants to skip analysis

--- a/commands/ask-all.md
+++ b/commands/ask-all.md
@@ -63,7 +63,19 @@ User question or topic: $ARGUMENTS
      sandbox: "read-only"
    })
    ```
-   If Grok returns `errorKind: "missing-auth"` (no `XAI_API_KEY`), note it inline and continue with the GPT + Gemini comparison — do not abort the whole command.
+   **Provider failure does not kill the command** (mirrors `consensus.md`): for ANY of the three providers, if the call returns `result.isError` or an MCP/transport error, do not abort. Render that provider's section as:
+   ```
+   **<Provider> bottom line:** UNAVAILABLE (<errorKind|"error">: <message truncated to 200 chars>)
+   ```
+   and continue the comparison with the surviving providers. Common cases: Grok `missing-auth` (no `XAI_API_KEY`), `rate-limit`, `timeout`, Gemini `trust`. Require **at least one** successful provider. If ALL THREE fail, skip the verdict comparison and emit exactly:
+   ```
+   ## All providers unavailable
+   - GPT: <errorKind|error>: <truncated msg>
+   - Gemini: <errorKind|error>: <truncated msg>
+   - Grok: <errorKind|error>: <truncated msg>
+
+   No second opinion could be obtained. Re-run after resolving the above (often: missing key, rate-limit, or restart Claude Code).
+   ```
 
 7. **Synthesize comparison** — output structure:
    ```

--- a/commands/ask-grok.md
+++ b/commands/ask-grok.md
@@ -38,9 +38,15 @@ User question or topic: $ARGUMENTS
    mcp__grok__grok({
      prompt: "[7-section delegation prompt]",
      "developer-instructions": "[contents of expert prompt file]",
-     sandbox: "read-only"
+     sandbox: "read-only",
+     files: [{ path: "relative/or/abs/path" }]   // OPTIONAL - omit when no files
    })
    ```
+   **Files (optional):** when the user wants Grok to read a local file, pass it in `files`
+   as `[{ path }]` - the bridge uploads it to the xAI Files API and references it. You may
+   also pass `{ file_id }` (already uploaded) or `{ file_url }` (public URL). Uploaded files
+   are tagged and auto-expire (default 7 days, `GROK_FILE_TTL_SECONDS`); prune early with
+   `/grok-files`.
 
 5. **Synthesize response** — never paste raw output. Extract:
    - Bottom-line recommendation
@@ -51,7 +57,8 @@ User question or topic: $ARGUMENTS
 ## Rules
 
 - **Single-shot only** — never reuse a `threadId` from a prior `/ask-grok` call. Each invocation is independent.
-- **Advisory only** — the Grok bridge has no filesystem access; there is no implementation mode. For file-editing delegation use `/ask-gpt` or `/ask-gemini`.
+- **Advisory only** — the Grok bridge cannot edit files; there is no implementation mode. For file-editing delegation use `/ask-gpt` or `/ask-gemini`. (It can READ attached files via `files`.)
+- **Files** — `files:[{path|file_id|file_url}]` attaches documents (PDF, code, md, csv, json, txt; <= 48 MB) to the query. On `errorKind: "file-read"` / `"file-too-large"`, tell the user which file failed.
 - **No model pin in-command** — the bridge defaults to `GROK_DEFAULT_MODEL` (or `grok-4.3`). To change it, set `GROK_DEFAULT_MODEL` in the MCP server's environment rather than hardcoding a (drift-prone) id here.
 - **No contamination** — do not include prior GPT or Gemini opinions in the Grok prompt. Each expert reasons independently.
 - **Auth required** — Grok needs `XAI_API_KEY`. If the call returns `errorKind: "missing-auth"`, tell the user to `export XAI_API_KEY=xai-...` (or rerun `/claude-delegator:setup`) and restart Claude Code.

--- a/commands/ask-grok.md
+++ b/commands/ask-grok.md
@@ -1,13 +1,13 @@
 ---
-name: ask-both
-description: Ask GPT and Gemini in parallel for independent second opinions, then synthesize and compare. Zero cross-contamination.
-allowed-tools: mcp__codex__codex, mcp__gemini__gemini, Read, Bash
-timeout: 300000
+name: ask-grok
+description: Get Grok (xAI) second opinion on a question or current work. Single-shot, advisory, no contamination.
+allowed-tools: mcp__grok__grok, Read, Bash
+timeout: 180000
 ---
 
-# Ask Both (GPT + Gemini)
+# Ask Grok
 
-Parallel dispatch to GPT (Codex) and Gemini for independent second opinions on the same question. Two fresh threads, neither sees the other's output. Final synthesis compares verdicts and flags disagreement.
+Single-shot delegation to Grok (xAI) via MCP for an independent second opinion. Fresh thread, no shared context with prior calls. Advisory only - the Grok bridge talks to the xAI HTTP API and has no filesystem access, so it cannot implement changes (unlike `/ask-gpt` and `/ask-gemini`, which can). Model defaults to `GROK_DEFAULT_MODEL` (or `grok-4.3`).
 
 ## Input
 
@@ -15,72 +15,47 @@ User question or topic: $ARGUMENTS
 
 ## Workflow
 
-1. **Identify expert** — match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`. Use the **same expert role** for both providers so verdicts are comparable. Default to Architect if unclear.
+1. **Identify expert** — match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`:
+   - Architecture / design / tradeoffs → Architect
+   - Plan validation → Plan Reviewer
+   - Requirements / scope → Scope Analyst
+   - Code review / find bugs → Code Reviewer
+   - Security / vulnerabilities → Security Analyst
+   - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
    1. Glob `~/.claude/plugins/cache/*claude-delegator/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
    3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
 
-   Same prompt injected into both providers.
-
-3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. **Identical prompt** sent to both providers — no provider-specific framing. Include:
+3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. Include:
    - Verbatim user question from `$ARGUMENTS`
-   - Relevant code snippets / file paths from current conversation context
+   - Relevant code snippets / file paths from current conversation context (Grok has no file access, so inline everything it needs)
    - Any specific constraints user has mentioned this session
 
-4. **Print status line**: `Codex + Gemini working in parallel (typical 30-60s)...`
-
-5. **Pre-flight cwd trust check**:
-   - Always use `process.cwd()` as the MCP `cwd` argument; NEVER switch folders.
-   - Detect B2 (skip-trust) support: glob `~/.claude/plugins/cache/*claude-delegator/claude-delegator/*/.claude-plugin/plugin.json`, parse the highest-semver match, treat `version >= "1.3.0"` (semver compare) as B2-supported. On parse error or no match: treat as B2 absent.
-   - Try reading `~/.gemini/trustedFolders.json`. On any error (ENOENT, EACCES, SyntaxError, value not an object): treat the trusted set as EMPTY and emit a one-line warning to stderr including the specific error message (for example `trustedFolders.json unreadable: ENOENT: no such file`).
-   - Build trusted-set = direct keys plus all descendants of keys whose value is `"TRUST_PARENT"`. Normalize paths first: resolve `~`, follow symlinks, strip trailing slashes (use `path.resolve` plus `fs.realpathSync` semantics).
-   - If `process.cwd()` (normalized) is in trusted-set: call as today.
-   - Else if B2 is supported: set `"skip-trust": true` on the call.
-   - Else: abort with: `Error: cwd "${process.cwd()}" not in trustedFolders.json; trust it via \`gemini\` once, or upgrade claude-delegator to 1.3.0+ for skip-trust support.`
-
-6. **Parallel dispatch** — fire both MCP calls in a **single message with two tool blocks** so they run concurrently:
+4. **Call Grok** — single-shot, advisory:
    ```
-   mcp__codex__codex({
-     prompt: "[identical 7-section prompt]",
-     "developer-instructions": "[expert prompt]",
-     sandbox: "read-only",
-     cwd: "[cwd]"
-   })
-
-   mcp__gemini__gemini({
-     prompt: "[identical 7-section prompt]",
-     "developer-instructions": "[expert prompt]",
-     sandbox: "read-only",
-     model: "auto-gemini-3",
-     cwd: "[cwd]"
+   mcp__grok__grok({
+     prompt: "[7-section delegation prompt]",
+     "developer-instructions": "[contents of expert prompt file]",
+     sandbox: "read-only"
    })
    ```
 
-7. **Synthesize comparison** — output structure:
-   ```
-   ## Verdict comparison
-
-   **GPT bottom line:** [1-2 sentences]
-   **Gemini bottom line:** [1-2 sentences]
-
-   **Agreement:** [where they converge]
-   **Disagreement:** [where they diverge — call out specifics]
-
-   **My assessment:** [which side is correct, or whether both miss something]
-   **Recommendation:** [what to actually do]
-   ```
+5. **Synthesize response** — never paste raw output. Extract:
+   - Bottom-line recommendation
+   - Key reasoning points
+   - Where Grok diverges from your prior analysis (if applicable)
+   - Your assessment of whether Grok is correct
 
 ## Rules
 
-- **Identical prompts** — both providers receive byte-identical input. No leading "GPT said..." in the Gemini prompt or vice versa.
-- **Single-shot only** — never reuse `threadId` from prior calls. Each invocation creates two fresh threads.
-- **Parallel, not sequential** — both MCP tool calls in one message. Sequential dispatch wastes wall time.
-- **Advisory by default** — `sandbox: "read-only"` for both unless user explicitly asks for implementation.
-- **Pin Gemini model** — always `model: "auto-gemini-3"`.
-- **Disagreement is signal** — when GPT and Gemini diverge, treat as a flag to dig deeper, not a tie to break by majority. Often both are partly wrong.
-- **Never paste raw output** — always synthesize.
+- **Single-shot only** — never reuse a `threadId` from a prior `/ask-grok` call. Each invocation is independent.
+- **Advisory only** — the Grok bridge has no filesystem access; there is no implementation mode. For file-editing delegation use `/ask-gpt` or `/ask-gemini`.
+- **No model pin in-command** — the bridge defaults to `GROK_DEFAULT_MODEL` (or `grok-4.3`). To change it, set `GROK_DEFAULT_MODEL` in the MCP server's environment rather than hardcoding a (drift-prone) id here.
+- **No contamination** — do not include prior GPT or Gemini opinions in the Grok prompt. Each expert reasons independently.
+- **Auth required** — Grok needs `XAI_API_KEY`. If the call returns `errorKind: "missing-auth"`, tell the user to `export XAI_API_KEY=xai-...` (or rerun `/claude-delegator:setup`) and restart Claude Code.
+- **Print status line** immediately before the MCP dispatch: `Grok working (typical 30-60s)...`
 
 <!-- DO NOT DELETE: required fallback if plugin cache missing. See C1 in implementation plan. -->
 

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -98,9 +98,13 @@ For each round R:
    mcp__grok__grok({
      prompt: "[identical 7-section prompt for round R]",
      "developer-instructions": "[expert prompt]",
-     sandbox: "read-only"
+     sandbox: "read-only",
+     files: [{ path: "<file>" }]   // OPTIONAL - only when files are attached to the round
    })
    ```
+   **Files (optional):** if the plan under review references attached files, pass them to
+   Grok via `files:[{path}]` each round; GPT and Gemini read the named paths from their
+   trusted `cwd`.
 
 4. **Stream short status as each return arrives**. Do not wait until all are back to print anything. Examples:
    ```

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -1,13 +1,13 @@
 ---
 name: consensus
-description: Iteratively converge GPT + Gemini + Claude on a plan/design until all three agree. Max 5 rounds. Best for plan refinement.
-allowed-tools: mcp__codex__codex, mcp__gemini__gemini, Read, Bash
+description: Iteratively converge GPT + Gemini + Grok + Claude on a plan/design until all four agree. Max 5 rounds. Best for plan refinement.
+allowed-tools: mcp__codex__codex, mcp__gemini__gemini, mcp__grok__grok, Read, Bash
 timeout: 900000
 ---
 
-# Consensus (GPT + Gemini + Claude convergence loop)
+# Consensus (GPT + Gemini + Grok + Claude convergence loop)
 
-Iterate up to 5 rounds. Each round refines the plan based on GPT + Gemini feedback. Stop when all three (Claude, GPT, Gemini) approve the current revision, or when 5 rounds are exhausted.
+Iterate up to 5 rounds. Each round refines the plan based on GPT + Gemini + Grok feedback. Stop when all four (Claude, GPT, Gemini, Grok) approve the current revision, or when 5 rounds are exhausted.
 
 ## Input
 
@@ -23,7 +23,7 @@ Plan, design, spec, or proposal to refine: $ARGUMENTS
 ## When NOT to use
 
 - One-off lookup or fact check (use `/ask-gpt` or `/ask-gemini`)
-- You only want a single independent opinion (use `/ask-both`)
+- You only want parallel one-shot opinions without the convergence loop (use `/ask-all`)
 - Time-sensitive work — this loop can take several minutes
 
 ## Workflow
@@ -63,7 +63,7 @@ For each round R:
 
 1. **Print round header** before dispatching, so the user knows progress:
    ```
-   --- Round R/5 --- Codex + Gemini working in parallel (typical 30-60s)...
+   --- Round R/5 --- Codex + Gemini + Grok working in parallel (typical 30-60s)...
    ```
 
 2. **Build identical review prompt** (7-section format per `~/.claude/rules/delegator/delegation-format.md`). Include:
@@ -78,7 +78,7 @@ For each round R:
      **Recommendations** (nice-to-have; empty list = none): [bullets]
      **One-line bottom line**: [single sentence]
      ```
-3. **Parallel dispatch** - both calls in ONE message with two tool blocks. Identical prompt body, identical expert prompt:
+3. **Parallel dispatch** - all three calls in ONE message with three tool blocks. Identical prompt body, identical expert prompt:
    ```
    mcp__codex__codex({
      prompt: "[identical 7-section prompt for round R]",
@@ -94,35 +94,43 @@ For each round R:
      model: "auto-gemini-3",
      cwd: "[trusted cwd]"
    })
+
+   mcp__grok__grok({
+     prompt: "[identical 7-section prompt for round R]",
+     "developer-instructions": "[expert prompt]",
+     sandbox: "read-only"
+   })
    ```
 
-4. **Stream short status as each return arrives**. Do not wait until both are back to print anything. Examples:
+4. **Stream short status as each return arrives**. Do not wait until all are back to print anything. Examples:
    ```
    GPT (R{R}): APPROVE
    Gemini (R{R}): REQUEST CHANGES (3 critical)
+   Grok (R{R}): APPROVE
    ```
 
 5. **Parse verdicts and form Claude's own opinion**:
-   - Extract `Verdict`, `Critical issues`, `Recommendations` from each.
+   - Extract `Verdict`, `Critical issues`, `Recommendations` from each of the three reviewers.
    - For each critical issue: Claude marks it as `accept` (real problem, fix), `dismiss` (false positive - record why), or `defer` (legitimate but out of scope for this plan).
-   - Claude's own `verdict` is APPROVE if and only if there are zero accepted critical issues across both reviewers, AND Claude has no critical issues of its own.
+   - Claude's own `verdict` is APPROVE if and only if there are zero accepted critical issues across all three reviewers, AND Claude has no critical issues of its own.
 
-6. **Convergence check** - STOP the loop when ALL THREE are APPROVE:
+6. **Convergence check** - STOP the loop when ALL FOUR are APPROVE:
    - GPT verdict == APPROVE AND
    - Gemini verdict == APPROVE AND
+   - Grok verdict == APPROVE AND
    - Claude verdict == APPROVE (no accepted critical issues anywhere)
 
 7. **If not converged**:
-   - Compile the union of `accept`-ed critical issues from both reviewers plus any Claude found.
+   - Compile the union of `accept`-ed critical issues from all three reviewers plus any Claude found.
    - Revise the plan to address them. Be explicit about what changed and what was deliberately not changed.
-   - Record this round in `history` with: GPT verdict, Gemini verdict, Claude's per-issue decisions, the diff summary applied to the plan.
+   - Record this round in `history` with: GPT verdict, Gemini verdict, Grok verdict, Claude's per-issue decisions, the diff summary applied to the plan.
    - Print the revised plan ONLY if it has changed materially (don't spam on small wording tweaks).
    - Continue to round R+1.
-   - **Backoff after dual error**: if BOTH providers returned a provider-error in round R (not a regular REQUEST CHANGES verdict, but an MCP error or `result.isError`), wait 1-2 seconds before dispatching round R+1 to let transient API hiccups clear.
+   - **Backoff after multi error**: if MORE THAN ONE provider returned a provider-error in round R (not a regular REQUEST CHANGES verdict, but an MCP error or `result.isError`), wait 1-2 seconds before dispatching round R+1 to let transient API hiccups clear.
 
 8. **If round R == 5 and still not converged**:
    - Emit the final state with residual disagreements clearly labeled. Do not pretend convergence.
-   - Note which side (GPT, Gemini, or Claude) holds out on which issues.
+   - Note which side (GPT, Gemini, Grok, or Claude) holds out on which issues.
 
 ### Final output
 
@@ -134,10 +142,10 @@ For each round R:
 [full converged plan, or last revision]
 
 **Round history**:
-| Round | GPT | Gemini | Claude | Changes applied |
-| 1     | RC  | RC     | RC     | added rollback step, clarified ownership |
-| 2     | RC  | APPR   | APPR   | tightened error handling on step 3 |
-| 3     | APPR | APPR  | APPR   | - (no change; consensus reached) |
+| Round | GPT | Gemini | Grok | Claude | Changes applied |
+| 1     | RC  | RC     | RC   | RC     | added rollback step, clarified ownership |
+| 2     | RC  | APPR   | APPR | APPR   | tightened error handling on step 3 |
+| 3     | APPR | APPR  | APPR | APPR   | - (no change; consensus reached) |
 
 **Residual disagreements** (if any):
 - GPT (held out on R5): [issue + reason Claude dismissed it]
@@ -145,11 +153,11 @@ For each round R:
 
 ## Stability rules
 
-- **Always dispatch in parallel** - both MCP calls in the same message. Sequential doubles wall time.
+- **Always dispatch in parallel** - all three MCP calls in the same message. Sequential triples wall time.
 - **Single-shot per round** - fresh thread each call. Do NOT use `*-reply` with stored threadId. Cross-round state lives in the prompt body, not in provider memory. Avoids contamination if one provider went off track.
 - **Trusted `cwd` for Gemini** - run the Pre-flight cwd trust check from Setup step 3. NEVER switch folders; use skip-trust when supported, abort otherwise.
-- **Provider failure does not kill the loop** - if one provider errors (timeout, trust failure, transient API error), treat its verdict as `REQUEST CHANGES` with a note `"provider error: <truncated msg>"`. Continue the round. Loop can still converge if the surviving provider agrees with Claude.
-- **Pin Gemini model** - always `model: "auto-gemini-3"`.
+- **Provider failure does not kill the loop** - if a provider errors (timeout, trust failure, Grok `missing-auth`, transient API error), treat its verdict as `REQUEST CHANGES` with a note `"provider error: <truncated msg>"`. Continue the round. The loop can still converge if the surviving reviewers agree with Claude.
+- **Pin Gemini model** - always `model: "auto-gemini-3"`. Grok uses its bridge default (`GROK_DEFAULT_MODEL` or `grok-4.3`); no in-command pin.
 - **Hard cap at 5 rounds** - even if one reviewer is being stubborn, terminate. Diverging too many rounds usually means the plan has an unresolved ambiguity, not that the reviewer is wrong.
 - **Report as you go** - print a status line after each round dispatch and after each return. Long silences look like a hang.
 - **Synthesize, never paste raw** - reviewers' raw output never appears verbatim in the final report.

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -51,7 +51,7 @@ Plan, design, spec, or proposal to refine: $ARGUMENTS
 4. Initialize state:
    - `plan` = original `$ARGUMENTS`
    - `round` = 0
-   - `history` = empty list of `{round, plan_diff_summary, gpt_verdict, gemini_verdict, claude_decision}`
+   - `history` = empty list of `{round, plan_diff_summary, gpt_verdict, gemini_verdict, grok_verdict, claude_decision}`
 5. Print:
    ```
    /consensus: starting consensus loop (max 5 rounds, expert=[Expert])

--- a/commands/grok-files.md
+++ b/commands/grok-files.md
@@ -1,0 +1,47 @@
+---
+name: grok-files
+description: List or prune Grok (xAI) uploaded files. Cleanup for bridge-owned uploads only.
+allowed-tools: Bash, Read
+timeout: 120000
+---
+
+# Grok Files (storage cleanup)
+
+List or prune the xAI files uploaded by the Grok bridge. Uploads are tagged with the
+filename prefix `claude-delegator-`, so prune ONLY ever targets those - your own xAI
+files are never touched. Uploads also carry `expires_after` (default 7 days) so they
+self-delete; this command is for pruning orphans early or auditing what exists.
+
+## Input
+
+Sub-command + flags: $ARGUMENTS
+(e.g. `list`, `prune --older-than 24h`, `prune --older-than 7d --yes`)
+
+## Workflow
+
+1. **Resolve the admin script** via this sequence:
+   1. Glob `~/.claude/plugins/cache/*claude-delegator/claude-delegator/*/server/grok/files-admin.js`;
+      pick the highest-semver match.
+   2. Fall back to `${CLAUDE_PLUGIN_ROOT}/server/grok/files-admin.js`.
+   3. If neither exists, abort: `Error: claude-delegator plugin cache missing. Run /plugin install claude-delegator.`
+
+2. **Check auth**: the script needs `XAI_API_KEY` in the environment. If it is unset, tell the
+   user to `export XAI_API_KEY=xai-...` and stop (the script will error otherwise).
+
+3. **Run the script** with the user's sub-command (default `list` when `$ARGUMENTS` is empty):
+   ```bash
+   node "<resolved files-admin.js>" $ARGUMENTS
+   ```
+   - `list` - prints total file count and every `claude-delegator-*` upload (id, created, expires, name).
+   - `prune --older-than <30m|24h|7d|seconds>` - **dry run** by default; prints what it WOULD delete.
+   - `prune --older-than <...> --yes` - actually deletes the matched bridge-owned files.
+
+4. **Report** the script's output to the user. For `prune` without `--yes`, remind them to
+   re-run with `--yes` to actually delete.
+
+## Rules
+
+- **Never** pass `--prefix ""` or any prefix that would match non-bridge files; the default
+  `claude-delegator-` prefix is the safety boundary.
+- Always run `prune` as a dry run first and show the user the candidate list before suggesting `--yes`.
+- This command does not need the Grok MCP server; it calls the xAI Files API directly via `XAI_API_KEY`.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -21,6 +21,12 @@ which codex 2>/dev/null && codex --version 2>&1 | head -1 || echo "CODEX_MISSING
 which gemini 2>/dev/null && gemini --version 2>&1 | head -1 || echo "GEMINI_MISSING"
 ```
 
+### Grok (xAI)
+```bash
+# Grok is API-based (no CLI). It needs XAI_API_KEY in the environment.
+[ -n "$XAI_API_KEY" ] && echo "Grok: XAI_API_KEY set" || echo "XAI_API_KEY_MISSING"
+```
+
 ### If Missing
 
 **Codex Missing:**
@@ -35,6 +41,13 @@ Then authenticate: codex login
 Gemini CLI not found.
 Install with: npm install -g @google/gemini-cli
 Then authenticate: launch `gemini` once and complete sign-in (or set `GOOGLE_API_KEY`)
+```
+
+**Grok key missing (XAI_API_KEY_MISSING):**
+```
+XAI_API_KEY is not set.
+Grok is API-based - there is no CLI to install. Get a key at https://console.x.ai
+then: export XAI_API_KEY=xai-...   (add it to your shell profile to persist)
 ```
 
 **STOP here if no providers are installed.**
@@ -57,6 +70,21 @@ claude mcp remove gemini >/dev/null 2>&1 || true
 claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
 ```
 
+### Grok (xAI)
+```bash
+# Idempotent: safe to rerun setup. The key is passed via --env so the bridge
+# inherits it. WARNING: --env persists XAI_API_KEY in plaintext in ~/.claude.json.
+# To avoid that, drop --env and instead export XAI_API_KEY in the environment that
+# launches Claude Code.
+claude mcp remove grok >/dev/null 2>&1 || true
+if [ -n "$XAI_API_KEY" ]; then
+  claude mcp add --transport stdio --scope user grok --env XAI_API_KEY="$XAI_API_KEY" -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+else
+  echo "XAI_API_KEY not set; registering grok without it (calls return missing-auth until you export it and re-run setup)."
+  claude mcp add --transport stdio --scope user grok -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+fi
+```
+
 This registers the MCP servers at user scope (available across all projects).
 
 **Note:** To customise Codex behaviour, add CLI flags before `mcp-server`.
@@ -71,8 +99,8 @@ mkdir -p ~/.claude/rules/delegator && cp ${CLAUDE_PLUGIN_ROOT}/rules/*.md ~/.cla
 ## Step 3b: Optional Short Command Names
 
 The delegation commands ship with the plugin and are always available
-namespaced: `/claude-delegator:ask-gpt`, `:ask-gemini`, `:ask-both`,
-`:consensus`.
+namespaced: `/claude-delegator:ask-gpt`, `:ask-gemini`, `:ask-grok`,
+`:ask-all`, `:consensus`.
 
 Offer the short, unnamespaced aliases (`/ask-gpt` etc.) by copying them into
 `~/.claude/commands/`.
@@ -84,7 +112,7 @@ Use AskUserQuestion: "Also install short command names (/ask-gpt etc.) into
 with a notice so an unrelated command of the same name is left untouched):
 ```bash
 mkdir -p ~/.claude/commands
-for c in ask-gpt ask-gemini ask-both consensus; do
+for c in ask-gpt ask-gemini ask-grok ask-all consensus; do
   dest=~/.claude/commands/$c.md
   if [ -e "$dest" ]; then
     echo "skip $c: ~/.claude/commands/$c.md already exists (left untouched)"
@@ -132,6 +160,18 @@ else
   echo "Gemini Bridge: SKIPPED (Gemini MCP not configured)"
 fi
 
+# Check 4b: Grok MCP server + bridge health
+GROK_CONFIG=$(claude mcp get grok 2>/dev/null)
+if echo "$GROK_CONFIG" | grep -q "server/grok/index.js"; then
+  GROK_HEALTH=$(printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' \
+    | node "${CLAUDE_PLUGIN_ROOT}/server/grok/index.js" 2>/dev/null \
+    | grep -q '"id":"health"' && echo "Grok Bridge: HEALTHY" || echo "Grok Bridge: UNHEALTHY")
+  echo "$GROK_HEALTH"
+  [ -n "$XAI_API_KEY" ] && echo "Grok Auth: XAI_API_KEY set" || echo "Grok Auth: XAI_API_KEY NOT set (calls return missing-auth)"
+else
+  echo "Grok: NOT CONFIGURED"
+fi
+
 # Check 5: Rules installed (count files)
 ls ~/.claude/rules/delegator/*.md 2>/dev/null | wc -l
 
@@ -151,8 +191,10 @@ Gemini CLI:    [version from check 1]
 Codex MCP:     [status from check 2]
 Gemini MCP:    [status from check 3]
 Gemini Bridge: [status from check 4]
+Grok MCP:      [status from check 4b]
 Rules:         ✓ [N] files in ~/.claude/rules/delegator/
 Codex Auth:    [status from check 6]
+Grok Auth:     [XAI_API_KEY status from check 4b]
 ───────────────────────────────────────────────────
 ```
 
@@ -168,6 +210,7 @@ Next steps:
 2. Authenticate providers as needed:
    - Codex: Run `codex login`
    - Gemini: Run `gemini` once and complete the sign-in flow (or set `GOOGLE_API_KEY`)
+   - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai), then re-run setup
 
 Five experts available:
 
@@ -195,7 +238,7 @@ Five experts available:
 
 Every expert can advise (read-only) OR implement (write).
 Expert is auto-detected based on your request.
-Explicit: "Ask GPT to..." or "Ask Gemini to..."
+Explicit: "Ask GPT to...", "Ask Gemini to...", or "Ask Grok to..."
 ```
 
 ## Step 7: Ask About Starring

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -87,6 +87,11 @@ fi
 
 This registers the MCP servers at user scope (available across all projects).
 
+**Grok file TTL (optional):** files Grok uploads default to a 7-day `expires_after` so they
+self-delete. To change it, also pass `--env GROK_FILE_TTL_SECONDS=<seconds>` (1h..30d, i.e.
+3600..2592000) on the `grok` registration, or export it in Claude Code's launch environment.
+Prune bridge-owned files early any time with `/grok-files prune --older-than <age>`.
+
 **Note:** To customise Codex behaviour, add CLI flags before `mcp-server`.
 - For Codex: `-p nosandbox`
 
@@ -112,7 +117,7 @@ Use AskUserQuestion: "Also install short command names (/ask-gpt etc.) into
 with a notice so an unrelated command of the same name is left untouched):
 ```bash
 mkdir -p ~/.claude/commands
-for c in ask-gpt ask-gemini ask-grok ask-all consensus; do
+for c in ask-gpt ask-gemini ask-grok ask-all consensus grok-files; do
   dest=~/.claude/commands/$c.md
   if [ -e "$dest" ]; then
     echo "skip $c: ~/.claude/commands/$c.md already exists (left untouched)"

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -92,6 +92,10 @@ self-delete. To change it, also pass `--env GROK_FILE_TTL_SECONDS=<seconds>` (1h
 3600..2592000) on the `grok` registration, or export it in Claude Code's launch environment.
 Prune bridge-owned files early any time with `/grok-files prune --older-than <age>`.
 
+**Grok reasoning effort (optional):** defaults to `xhigh`. Override globally with
+`--env GROK_REASONING_EFFORT=<low|high|xhigh|none>` on the `grok` registration (or export it),
+or per call with the `reasoning_effort` parameter; `none` omits the field so the model uses its default.
+
 **Note:** To customise Codex behaviour, add CLI flags before `mcp-server`.
 - For Codex: `-p nosandbox`
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -92,8 +92,8 @@ self-delete. To change it, also pass `--env GROK_FILE_TTL_SECONDS=<seconds>` (1h
 3600..2592000) on the `grok` registration, or export it in Claude Code's launch environment.
 Prune bridge-owned files early any time with `/grok-files prune --older-than <age>`.
 
-**Grok reasoning effort (optional):** defaults to `xhigh`. Override globally with
-`--env GROK_REASONING_EFFORT=<low|high|xhigh|none>` on the `grok` registration (or export it),
+**Grok reasoning effort (optional):** defaults to `high`. Override globally with
+`--env GROK_REASONING_EFFORT=<low|medium|high|none>` on the `grok` registration (or export it),
 or per call with the `reasoning_effort` parameter; `none` omits the field so the model uses its default.
 
 **Note:** To customise Codex behaviour, add CLI flags before `mcp-server`.

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -40,7 +40,7 @@ Ownership-aware: a copied alias is removed only if it is byte-identical to the
 plugin's bundled command (so an unrelated user-authored same-named command,
 which `/setup` would have skipped rather than overwritten, is left untouched).
 ```bash
-for c in ask-gpt ask-gemini ask-grok ask-all consensus; do
+for c in ask-gpt ask-gemini ask-grok ask-all consensus grok-files; do
   dest=~/.claude/commands/$c.md
   src="${CLAUDE_PLUGIN_ROOT}/commands/$c.md"
   if [ ! -e "$dest" ]; then

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -11,7 +11,7 @@ Remove claude-delegator from Claude Code.
 
 ## Confirm Removal
 
-**Question**: "Remove Codex/Gemini MCP configuration and plugin rules?"
+**Question**: "Remove Codex/Gemini/Grok MCP configuration and plugin rules?"
 **Options**:
 - "Yes, uninstall"
 - "No, cancel"
@@ -23,6 +23,7 @@ If cancelled, stop here.
 ```bash
 claude mcp remove --scope user codex
 claude mcp remove --scope user gemini
+claude mcp remove --scope user grok
 ```
 
 ## Remove Installed Rules
@@ -33,13 +34,13 @@ rm -rf ~/.claude/rules/delegator/
 
 ## Remove Short Command Aliases (if installed)
 
-Only the four aliases that `/setup` may have copied; the namespaced
+Only the aliases that `/setup` may have copied; the namespaced
 `claude-delegator:*` commands are removed by uninstalling the plugin itself.
 Ownership-aware: a copied alias is removed only if it is byte-identical to the
 plugin's bundled command (so an unrelated user-authored same-named command,
 which `/setup` would have skipped rather than overwritten, is left untouched).
 ```bash
-for c in ask-gpt ask-gemini ask-both consensus; do
+for c in ask-gpt ask-gemini ask-grok ask-all consensus; do
   dest=~/.claude/commands/$c.md
   src="${CLAUDE_PLUGIN_ROOT}/commands/$c.md"
   if [ ! -e "$dest" ]; then
@@ -50,6 +51,16 @@ for c in ask-gpt ask-gemini ask-both consensus; do
     echo "skip $c: ~/.claude/commands/$c.md differs from plugin copy (left untouched)"
   fi
 done
+
+# ask-both was renamed to ask-all in 1.7.0; the plugin no longer ships ask-both.md.
+# Remove a copied ask-both alias only when it carries the delegator fingerprint
+# (so a user-authored ask-both.md is left untouched).
+olddest=~/.claude/commands/ask-both.md
+if [ -e "$olddest" ] && grep -q "claude-delegator/claude-delegator" "$olddest" && grep -q "name: ask-both" "$olddest"; then
+  rm -f "$olddest" && echo "removed obsolete /ask-both (renamed to /ask-all)"
+elif [ -e "$olddest" ]; then
+  echo "skip ask-both: ~/.claude/commands/ask-both.md not recognized as a plugin alias (left untouched)"
+fi
 ```
 
 ## Confirm Completion

--- a/config/providers.json
+++ b/config/providers.json
@@ -29,6 +29,21 @@
       "experts": ["architect", "plan-reviewer", "scope-analyst", "code-reviewer", "security-analyst"],
       "strengths": ["reasoning", "large context", "code generation", "multimodal analysis"],
       "avoid": ["simple-operations", "trivial-decisions", "research", "first-attempt-fixes"]
+    },
+    "grok": {
+      "name": "Grok (xAI)",
+      "description": "xAI Grok models via bundled MCP bridge over the xAI HTTP API - advisory expert subagents",
+      "cli": null,
+      "api": "https://api.x.ai/v1/chat/completions",
+      "auth": "export XAI_API_KEY=xai-...",
+      "mcp": {
+        "type": "stdio",
+        "command": "node",
+        "args": ["${CLAUDE_PLUGIN_ROOT}/server/grok/index.js"]
+      },
+      "experts": ["architect", "plan-reviewer", "scope-analyst", "code-reviewer", "security-analyst"],
+      "strengths": ["reasoning", "architecture", "code-review", "security", "large context"],
+      "avoid": ["simple-operations", "trivial-decisions", "research", "first-attempt-fixes", "file-editing"]
     }
   }
 }

--- a/rules/model-selection.md
+++ b/rules/model-selection.md
@@ -9,7 +9,7 @@ Before delegating, check which MCP tools are available in the current environmen
 1. **If multiple are available**:
    - Use **Gemini** for tasks requiring large context or multimodal analysis.
    - Use **GPT (Codex)** when the user explicitly asks for "GPT" or "Codex".
-   - Use **Grok (xAI)** when the user explicitly asks for "Grok". Grok is advisory-only (HTTP API, no filesystem access), so never route file-editing / implementation tasks to it.
+   - Use **Grok (xAI)** when the user explicitly asks for "Grok". Grok is advisory-only (it cannot edit files), so never route file-editing / implementation tasks to it. It CAN read attached files (PDF/code/docs) via `files:[{path|file_id|file_url}]` on the `mcp__grok__grok` call.
    - Default to **Gemini** for general reasoning.
 2. **If only one is available**: Use the available provider regardless of the task type (but Grok cannot implement file changes - only advise).
 3. **If none are available**: Do not delegate; inform the user that they need to run `/claude-delegator:setup`.

--- a/rules/model-selection.md
+++ b/rules/model-selection.md
@@ -1,17 +1,18 @@
 # Model Selection Guidelines
 
-GPT (Codex) and Gemini experts serve as specialized consultants for complex problems.
+GPT (Codex), Gemini, and Grok (xAI) experts serve as specialized consultants for complex problems.
 
 ## Provider Selection
 
 Before delegating, check which MCP tools are available in the current environment:
 
-1. **If both are available**: 
+1. **If multiple are available**:
    - Use **Gemini** for tasks requiring large context or multimodal analysis.
-   - Use **GPT (Codex)** for tasks where the user explicitly asked for "GPT" or "Codex".
+   - Use **GPT (Codex)** when the user explicitly asks for "GPT" or "Codex".
+   - Use **Grok (xAI)** when the user explicitly asks for "Grok". Grok is advisory-only (HTTP API, no filesystem access), so never route file-editing / implementation tasks to it.
    - Default to **Gemini** for general reasoning.
-2. **If only one is available**: Use the available provider regardless of the task type.
-3. **If neither is available**: Do not delegate; inform the user that they need to run `/claude-delegator:setup`.
+2. **If only one is available**: Use the available provider regardless of the task type (but Grok cannot implement file changes - only advise).
+3. **If none are available**: Do not delegate; inform the user that they need to run `/claude-delegator:setup`.
 
 ## Expert Directory
 

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -10,6 +10,10 @@ You have access to GPT experts via MCP tools. Use them strategically based on th
 | `mcp__codex__codex-reply` | GPT | Continue an existing session (multi-turn) |
 | `mcp__gemini__gemini` | Gemini | Start a new expert session |
 | `mcp__gemini__gemini-reply` | Gemini | Continue an existing session (multi-turn) |
+| `mcp__grok__grok` | Grok (xAI) | Start a new expert session (advisory-only; no file access) |
+| `mcp__grok__grok-reply` | Grok (xAI) | Continue a session (in-memory; lost on MCP restart) |
+
+> **Grok notes:** the Grok bridge talks to the xAI HTTP API, so it is advisory-only (it cannot edit files) and has no trusted-directory concept (no trust-recovery applies). It needs `XAI_API_KEY`; a missing key surfaces `errorKind: "missing-auth"`.
 
 ## Available Experts
 
@@ -119,7 +123,7 @@ For example, for Architect: `Read ${CLAUDE_PLUGIN_ROOT}/prompts/architect.md`
 
 ### Step 4: Notify User
 
-Status line is owned by each command file (see ask-gpt.md, ask-gemini.md, ask-both.md, agree-both.md). Commands print exactly one line immediately before the MCP tool dispatch:
+Status line is owned by each command file (see ask-gpt.md, ask-gemini.md, ask-grok.md, ask-all.md, consensus.md). Commands print exactly one line immediately before the MCP tool dispatch:
 
 - single-provider: `Codex working (typical 30-60s)...` or `Gemini working (typical 30-60s)...`
 - parallel: `Codex + Gemini working in parallel (typical 30-60s)...`

--- a/server/grok/files-admin.js
+++ b/server/grok/files-admin.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Delegator - Grok file storage admin (cleanup)
+ *
+ * Zero-dependency CLI to list and prune xAI files uploaded by the Grok bridge.
+ * The bridge tags every upload with the filename prefix `claude-delegator-`, so
+ * prune ONLY ever targets those - the user's own xAI files are never touched.
+ *
+ *   node server/grok/files-admin.js list
+ *   node server/grok/files-admin.js prune --older-than 24h [--yes] [--prefix claude-delegator-]
+ *
+ * Auth: XAI_API_KEY (env). Endpoint: XAI_API_BASE (env) or https://api.x.ai/v1.
+ * Without --yes, prune is a dry run (prints what it WOULD delete).
+ */
+
+const DEFAULT_API_BASE = process.env.XAI_API_BASE || "https://api.x.ai/v1";
+const DEFAULT_PREFIX = "claude-delegator-";
+
+// Parse a human duration into seconds. Accepts Ns, Nm, Nh, Nd, or a plain
+// integer (seconds). Returns a non-negative number or throws on bad input.
+function parseOlderThan(str) {
+  const m = String(str).trim().match(/^(\d+)\s*([smhd]?)$/i);
+  if (!m) throw new Error(`Invalid --older-than value: "${str}" (use e.g. 30m, 24h, 7d, or seconds)`);
+  const n = Number(m[1]);
+  const unit = m[2].toLowerCase();
+  const mult = unit === "d" ? 86400 : unit === "h" ? 3600 : unit === "m" ? 60 : 1;
+  return n * mult;
+}
+
+// Pure: pick files that are bridge-owned (filename prefix) AND older than the
+// cutoff. `cutoffEpochSec` is the threshold; a file is prunable when its
+// created_at is strictly less than the cutoff. The DEFAULT_PREFIX floor is a HARD
+// safety invariant - even a caller-supplied `prefix` of "" can never select a file
+// that is not bridge-owned.
+function selectPrunable(files, { prefix = DEFAULT_PREFIX, cutoffEpochSec }) {
+  return (files || []).filter(
+    (f) =>
+      f &&
+      typeof f.filename === "string" &&
+      f.filename.startsWith(DEFAULT_PREFIX) &&
+      f.filename.startsWith(prefix) &&
+      typeof f.created_at === "number" &&
+      f.created_at < cutoffEpochSec
+  );
+}
+
+function authHeader(apiKey) {
+  if (!apiKey || !String(apiKey).trim()) {
+    throw new Error("XAI_API_KEY is not set; export it before running files-admin.");
+  }
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+// List ALL files, following pagination_token. `fetchImpl` injectable for tests.
+async function listFiles({ apiKey, apiBase, fetchImpl, pageLimit = 1000 }) {
+  const f = fetchImpl || globalThis.fetch;
+  const base = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
+  const headers = authHeader(apiKey);
+  const all = [];
+  let token = null;
+  let lastToken = null;
+  // Bound the loop so a misbehaving server can't spin forever.
+  for (let i = 0; i < 10_000; i++) {
+    const url = new URL(`${base}/files`);
+    url.searchParams.set("limit", String(pageLimit));
+    if (token) url.searchParams.set("pagination_token", token);
+    const res = await f(url.toString(), { method: "GET", headers });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`List files failed ${res.status}: ${text.slice(0, 300)}`);
+    const data = JSON.parse(text);
+    const page = Array.isArray(data.data) ? data.data : [];
+    for (const item of page) all.push(item);
+    token = data.pagination_token || null;
+    // Stop at a short/empty page, when there is no token, or if the token did not
+    // advance (defensive against a server that echoes the same token).
+    if (!token || token === lastToken || page.length < pageLimit) break;
+    lastToken = token;
+  }
+  return all;
+}
+
+async function deleteFile(id, { apiKey, apiBase, fetchImpl }) {
+  const f = fetchImpl || globalThis.fetch;
+  const base = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
+  const res = await f(`${base}/files/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: authHeader(apiKey),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Delete ${id} failed ${res.status}: ${text.slice(0, 200)}`);
+  return true;
+}
+
+// Orchestrate a prune. Returns { candidates, deleted, failed } (deleted/failed
+// empty on dry run). One delete failure does not abort the rest.
+async function prune({ olderThanSec, prefix = DEFAULT_PREFIX, apiKey, apiBase, fetchImpl, dryRun = true, now = Date.now() }) {
+  const cutoffEpochSec = Math.floor(now / 1000) - olderThanSec;
+  const files = await listFiles({ apiKey, apiBase, fetchImpl });
+  const candidates = selectPrunable(files, { prefix, cutoffEpochSec });
+  const deleted = [];
+  const failed = [];
+  if (!dryRun) {
+    for (const file of candidates) {
+      try {
+        await deleteFile(file.id, { apiKey, apiBase, fetchImpl });
+        deleted.push(file.id);
+      } catch (e) {
+        failed.push({ id: file.id, error: (e && e.message) || String(e) });
+      }
+    }
+  }
+  return { candidates, deleted, failed };
+}
+
+// --- CLI ---
+
+function parseArgs(argv) {
+  const out = { _: [], "older-than": null, yes: false, prefix: DEFAULT_PREFIX };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--yes" || a === "-y") out.yes = true;
+    else if (a === "--older-than") out["older-than"] = argv[++i];
+    else if (a === "--prefix") out.prefix = argv[++i];
+    else out._.push(a);
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cmd = args._[0];
+  const apiKey = process.env.XAI_API_KEY;
+
+  if (cmd === "list") {
+    const files = await listFiles({ apiKey });
+    const mine = files.filter((f) => typeof f.filename === "string" && f.filename.startsWith(args.prefix));
+    console.log(`Total xAI files: ${files.length}; bridge-owned (${args.prefix}*): ${mine.length}`);
+    for (const f of mine) {
+      const created = new Date((f.created_at || 0) * 1000).toISOString();
+      const expires = f.expires_at ? new Date(f.expires_at * 1000).toISOString() : "never";
+      console.log(`  ${f.id}  ${created}  expires:${expires}  ${f.filename}`);
+    }
+    return;
+  }
+
+  if (cmd === "prune") {
+    if (!args["older-than"]) throw new Error("prune requires --older-than (e.g. --older-than 24h)");
+    const olderThanSec = parseOlderThan(args["older-than"]);
+    const dryRun = !args.yes;
+    const { candidates, deleted, failed } = await prune({
+      olderThanSec,
+      prefix: args.prefix,
+      apiKey,
+      dryRun,
+    });
+    if (dryRun) {
+      console.log(`[dry run] ${candidates.length} file(s) older than ${args["older-than"]} would be deleted (pass --yes to delete):`);
+      for (const f of candidates) console.log(`  ${f.id}  ${f.filename}`);
+    } else {
+      console.log(`Deleted ${deleted.length} file(s) older than ${args["older-than"]}.`);
+      if (failed.length) {
+        console.error(`Failed to delete ${failed.length} file(s):`);
+        for (const x of failed) console.error(`  ${x.id}: ${x.error}`);
+        process.exitCode = 1;
+      }
+    }
+    return;
+  }
+
+  console.error("Usage:\n  files-admin.js list\n  files-admin.js prune --older-than <30m|24h|7d|seconds> [--yes] [--prefix claude-delegator-]");
+  process.exitCode = 2;
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(`files-admin error: ${(e && e.message) || e}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { parseOlderThan, selectPrunable, listFiles, deleteFile, prune, parseArgs, DEFAULT_PREFIX };

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -3,18 +3,22 @@
 /**
  * Claude Delegator - Grok (xAI) MCP Bridge
  *
- * A zero-dependency MCP server that calls the xAI OpenAI-compatible Chat
- * Completions API. Speaks JSON-RPC 2.0 over stdio.
+ * A zero-dependency MCP server that calls the xAI **Responses API**
+ * (`POST /v1/responses`). Speaks JSON-RPC 2.0 over stdio.
  *
- * Unlike the Gemini bridge (which wraps a one-shot CLI and recovers answers
- * from disk), this bridge owns the conversation state directly, so multi-turn
- * (grok-reply) is an in-memory threadId -> messages map.
+ * The Responses endpoint (not chat/completions) is required to attach uploaded
+ * files (`{type:"input_file", file_id}`). The bridge owns conversation state
+ * directly, so multi-turn (grok-reply) is an in-memory threadId -> turns map and
+ * we resend the full `input` each turn (no reliance on previous_response_id).
  *
  * Auth: XAI_API_KEY (env). Model: GROK_DEFAULT_MODEL (env) or grok-4.3.
  * Endpoint: XAI_API_BASE (env) or https://api.x.ai/v1.
+ * File TTL: GROK_FILE_TTL_SECONDS (env) or 604800 (7 days).
  */
 
 const crypto = require("node:crypto");
+const path = require("node:path");
+const { stat, readFile } = require("node:fs/promises");
 
 const DEFAULT_MODEL = process.env.GROK_DEFAULT_MODEL || "grok-4.3";
 const DEFAULT_API_BASE = process.env.XAI_API_BASE || "https://api.x.ai/v1";
@@ -22,7 +26,23 @@ const DEFAULT_TIMEOUT_MS = 180_000; // 3 minutes
 const MAX_MS = 600_000;
 const VALID_SANDBOX_VALUES = new Set(["read-only", "workspace-write"]);
 
-// In-memory session store: threadId -> messages[]. Lives for the MCP process
+// xAI accepts expires_after between 1 hour and 30 days. Default 7 days.
+const FILE_TTL_MIN = 3600;
+const FILE_TTL_MAX = 2_592_000;
+function resolveFileTtl() {
+  const raw = Number(process.env.GROK_FILE_TTL_SECONDS);
+  const v = Number.isFinite(raw) && raw > 0 ? raw : 604_800;
+  return Math.min(FILE_TTL_MAX, Math.max(FILE_TTL_MIN, Math.round(v)));
+}
+const FILE_TTL_SECONDS = resolveFileTtl();
+// Stay safely under the documented ~50 MB upload cap.
+const MAX_FILE_BYTES = 48 * 1024 * 1024;
+// Filename prefix marks bridge-owned uploads so cleanup never touches the
+// user's own xAI files. Flat (no slashes/colons) to avoid filename mangling.
+const FILE_PREFIX = "claude-delegator-";
+const UPLOAD_PURPOSE = "assistants";
+
+// In-memory session store: threadId -> turns[]. Lives for the MCP process
 // lifetime only; lost on restart (grok-reply then returns unknown-thread).
 const sessions = new Map();
 
@@ -34,19 +54,11 @@ const sessions = new Map();
 // --- MCP Protocol Helpers ---
 
 function sendResponse(id, result) {
-  process.stdout.write(JSON.stringify({
-    jsonrpc: "2.0",
-    id,
-    result
-  }) + "\n");
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
 }
 
 function sendError(id, code, message) {
-  process.stdout.write(JSON.stringify({
-    jsonrpc: "2.0",
-    id,
-    error: { code, message }
-  }) + "\n");
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } }) + "\n");
 }
 
 function isObject(value) {
@@ -79,11 +91,14 @@ function logCall(cid, tool, outcome, ms) {
 // tests. `.code` is checked first (transport-level), then HTTP status.
 function classifyGrokError(status, errCode) {
   switch (errCode) {
-    case "missing-auth":   return { errorKind: "missing-auth",   retryable: false };
-    case "unknown-thread": return { errorKind: "unknown-thread", retryable: false };
-    case "timeout":        return { errorKind: "timeout",        retryable: true };
-    case "network":        return { errorKind: "network",        retryable: true };
-    case "parse":          return { errorKind: "parse",          retryable: false };
+    case "missing-auth":    return { errorKind: "missing-auth",    retryable: false };
+    case "unknown-thread":  return { errorKind: "unknown-thread",  retryable: false };
+    case "timeout":         return { errorKind: "timeout",         retryable: true };
+    case "network":         return { errorKind: "network",         retryable: true };
+    case "parse":           return { errorKind: "parse",           retryable: false };
+    case "file-too-large":  return { errorKind: "file-too-large",  retryable: false };
+    case "file-read":       return { errorKind: "file-read",       retryable: false };
+    case "file-upload":     return { errorKind: "file-upload",     retryable: true };
   }
   const s = Number(status);
   if (s === 401 || s === 403) return { errorKind: "auth", retryable: false };
@@ -94,40 +109,193 @@ function classifyGrokError(status, errCode) {
 
 // --- Pure helpers (exported for tests) ---
 
-// Build the OpenAI-style messages array. developer-instructions become a
-// leading system message; the prompt is the user turn.
-function buildMessages(developerInstructions, prompt) {
-  const messages = [];
+// A "turn" is { role, text, fileRefs? } where fileRefs is an array of
+// { file_id } | { file_url }. buildInitialTurns seeds a fresh conversation.
+function buildInitialTurns(developerInstructions, prompt, fileRefs) {
+  const turns = [];
   if (isNonEmptyString(developerInstructions)) {
-    messages.push({ role: "system", content: developerInstructions });
+    turns.push({ role: "system", text: developerInstructions });
   }
-  messages.push({ role: "user", content: prompt });
-  return messages;
+  turns.push({ role: "user", text: prompt, fileRefs: fileRefs || [] });
+  return turns;
 }
 
-// Extract the assistant text from a chat/completions response body. Throws a
-// `.code = "parse"` error on a malformed shape.
-function parseChatCompletion(data) {
+// Convert internal turns into the /v1/responses `input` array. User content uses
+// input_text + input_file parts; system stays text. Assistant turns replay the
+// server's own `output` items verbatim when we captured them (documented stateless
+// chaining - a server always accepts the shape it emitted); otherwise fall back to
+// a minimal text item.
+function turnsToInput(turns) {
+  const input = [];
+  for (const turn of turns) {
+    if (turn.role === "assistant") {
+      if (Array.isArray(turn.items) && turn.items.length) {
+        for (const item of turn.items) input.push(item);
+      } else {
+        input.push({ role: "assistant", content: [{ type: "output_text", text: turn.text }] });
+      }
+      continue;
+    }
+    if (turn.role === "system") {
+      input.push({ role: "system", content: [{ type: "input_text", text: turn.text }] });
+      continue;
+    }
+    const content = [{ type: "input_text", text: turn.text }];
+    for (const ref of turn.fileRefs || []) {
+      if (ref.file_id) content.push({ type: "input_file", file_id: ref.file_id });
+      else if (ref.file_url) content.push({ type: "input_file", file_url: ref.file_url });
+    }
+    input.push({ role: "user", content });
+  }
+  return input;
+}
+
+// Extract the assistant text from a /v1/responses body. Throws `.code="parse"`
+// on a malformed shape. Tolerates the convenience `output_text` field and the
+// nested output[].content[].text shape.
+function parseResponsesOutput(data) {
   const fail = (why) => {
     const e = new Error(`Parse error: ${why}`);
     e.code = "parse";
     return e;
   };
   if (!isObject(data)) throw fail("response was not a JSON object");
-  const choices = data.choices;
-  if (!Array.isArray(choices) || choices.length === 0) throw fail("no choices in response");
-  const message = choices[0] && choices[0].message;
-  const content = message && message.content;
-  if (typeof content !== "string") throw fail("choices[0].message.content missing");
-  return content;
+  if (isNonEmptyString(data.output_text)) return data.output_text;
+  const output = data.output;
+  if (!Array.isArray(output) || output.length === 0) throw fail("no output in response");
+  // Prefer the last message item that carries text content; concatenate all of its
+  // text parts (a message may interleave multiple text segments).
+  for (let i = output.length - 1; i >= 0; i--) {
+    const item = output[i];
+    const parts = item && item.content;
+    if (!Array.isArray(parts)) continue;
+    const texts = parts
+      .filter((p) => p && typeof p.text === "string" && (p.type === "output_text" || p.type === "text" || p.type === undefined))
+      .map((p) => p.text);
+    if (texts.length) return texts.join("");
+  }
+  throw fail("no text part found in output");
 }
 
-// --- xAI API Call ---
+// --- xAI Files API ---
 
-// Performs one chat/completions call and returns the assistant text. Errors
-// carry `.code` (transport: timeout/network/parse/missing-auth) and/or `.status`
-// (HTTP) so classifyGrokError can map them. `fetchImpl` is injectable for tests.
-async function runGrok({ messages, model, timeoutMs, apiKey, apiBase, fetchImpl }) {
+// Upload one local file and return its file object. Errors carry `.code`
+// (file-too-large/file-read/file-upload/missing-auth) and/or `.status`.
+// `fetchImpl` is injectable for tests.
+async function uploadFile({ filePath, filename, apiKey, apiBase, ttl, cwd, fetchImpl }) {
+  if (!isNonEmptyString(apiKey)) {
+    const e = new Error("XAI_API_KEY is not set; cannot upload files.");
+    e.code = "missing-auth";
+    throw e;
+  }
+  const f = fetchImpl || globalThis.fetch;
+  const base = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
+  // Containment: the resolved path must stay within the base dir. Blocks absolute
+  // paths and `../` escapes from exfiltrating arbitrary local files to xAI.
+  const root = path.resolve(cwd || process.cwd());
+  const resolved = path.resolve(root, filePath);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    const e = new Error(`File "${filePath}" resolves outside the working directory (${root}); refused.`);
+    e.code = "file-read";
+    throw e;
+  }
+
+  let info;
+  try {
+    info = await stat(resolved);
+  } catch (err) {
+    const e = new Error(`Cannot read file "${filePath}": ${(err && err.message) || err}`);
+    e.code = "file-read";
+    throw e;
+  }
+  if (!info.isFile()) {
+    const e = new Error(`Not a regular file: "${filePath}"`);
+    e.code = "file-read";
+    throw e;
+  }
+  if (info.size > MAX_FILE_BYTES) {
+    const e = new Error(`File "${filePath}" is ${info.size} bytes; exceeds the ${MAX_FILE_BYTES}-byte cap.`);
+    e.code = "file-too-large";
+    throw e;
+  }
+
+  let buf;
+  try {
+    buf = await readFile(resolved);
+  } catch (err) {
+    const e = new Error(`Cannot read file "${filePath}": ${(err && err.message) || err}`);
+    e.code = "file-read";
+    throw e;
+  }
+
+  const baseName = path.basename(filename || resolved);
+  const storedName = `${FILE_PREFIX}${Date.now()}-${baseName}`;
+  // Append scalar fields BEFORE the (potentially large, streamed) file part so a
+  // streaming multipart parser sees expires_after/purpose regardless of body size.
+  const form = new FormData();
+  form.append("expires_after", String(ttl != null ? ttl : FILE_TTL_SECONDS));
+  form.append("purpose", UPLOAD_PURPOSE);
+  form.append("file", new Blob([buf]), storedName);
+
+  let res;
+  try {
+    res = await f(`${base}/files`, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${apiKey}` }, // no Content-Type: fetch sets the multipart boundary
+      body: form,
+    });
+  } catch (err) {
+    const e = new Error(`File upload network error: ${(err && err.message) || err}`);
+    e.code = "file-upload";
+    throw e;
+  }
+
+  let bodyText = "";
+  try { bodyText = await res.text(); } catch (_) { bodyText = ""; }
+  if (!res.ok) {
+    const e = new Error(`xAI file upload error ${res.status}: ${truncate(bodyText, 300)}`);
+    e.status = res.status;
+    if (res.status < 400 || res.status >= 500) e.code = "file-upload";
+    throw e;
+  }
+  try {
+    return JSON.parse(bodyText);
+  } catch (e2) {
+    const e = new Error(`File upload parse error: ${e2.message}`);
+    e.code = "parse";
+    throw e;
+  }
+}
+
+// Resolve a `files` param into { refs, ownedIds }. `path` entries are uploaded
+// (bridge-owned); `file_id`/`file_url` pass through untouched.
+async function resolveFiles(files, opts) {
+  const refs = [];
+  const ownedIds = [];
+  for (const entry of files || []) {
+    if (entry.file_id) {
+      refs.push({ file_id: entry.file_id });
+    } else if (entry.file_url) {
+      refs.push({ file_url: entry.file_url });
+    } else if (entry.path) {
+      const uploaded = await uploadFile({ filePath: entry.path, filename: entry.filename, ...opts });
+      if (!isNonEmptyString(uploaded && uploaded.id)) {
+        const e = new Error("File upload returned no file id");
+        e.code = "parse";
+        throw e;
+      }
+      refs.push({ file_id: uploaded.id });
+      ownedIds.push(uploaded.id);
+    }
+  }
+  return { refs, ownedIds };
+}
+
+// --- xAI Responses API Call ---
+
+// One /v1/responses call returning the assistant text. Errors carry `.code`
+// and/or `.status`. `fetchImpl` is injectable for tests.
+async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl }) {
   if (!isNonEmptyString(apiKey)) {
     const e = new Error("XAI_API_KEY is not set. Export it (export XAI_API_KEY=xai-...) or rerun /claude-delegator:setup.");
     e.code = "missing-auth";
@@ -141,7 +309,7 @@ async function runGrok({ messages, model, timeoutMs, apiKey, apiBase, fetchImpl 
   }
 
   const base = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
-  const url = `${base}/chat/completions`;
+  const url = `${base}/responses`;
   const t = (typeof timeoutMs === "number" && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), t);
@@ -154,7 +322,7 @@ async function runGrok({ messages, model, timeoutMs, apiKey, apiBase, fetchImpl 
         "Content-Type": "application/json",
         "Authorization": `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({ model: model || DEFAULT_MODEL, messages, stream: false }),
+      body: JSON.stringify({ model: model || DEFAULT_MODEL, input: turnsToInput(turns), stream: false }),
       signal: controller.signal,
     });
   } catch (err) {
@@ -188,19 +356,50 @@ async function runGrok({ messages, model, timeoutMs, apiKey, apiBase, fetchImpl 
     e.code = "parse";
     throw e;
   }
-  return parseChatCompletion(data);
+  const text = parseResponsesOutput(data);
+  // `output` is captured so grok-reply can replay the server's own items verbatim.
+  return { text, output: Array.isArray(data.output) ? data.output : null };
 }
 
 // --- Request Handlers ---
+
+const FILES_SCHEMA = {
+  type: "array",
+  description: "Optional files to attach. Each item has EXACTLY ONE of: path (local file the bridge uploads), file_id (an already-uploaded xAI file id), or file_url (a public URL). Optional filename overrides the stored upload name.",
+  items: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Local file path; bridge uploads it (resolved against cwd)" },
+      file_id: { type: "string", description: "Existing xAI file id" },
+      file_url: { type: "string", description: "Public URL to a file" },
+      filename: { type: "string", description: "Override stored filename for a path upload" },
+    },
+  },
+};
 
 const GROK_PROPERTIES = {
   prompt: { type: "string", description: "The delegation prompt" },
   "developer-instructions": { type: "string", description: "Expert system instructions (sent as a system message)" },
   model: { type: "string", description: "xAI model id. Defaults to GROK_DEFAULT_MODEL or grok-4.3.", default: DEFAULT_MODEL },
   timeout: { type: "number", description: "Soft timeout in ms. 1..600000. Default 180000.", default: DEFAULT_TIMEOUT_MS },
-  sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only", description: "Accepted for call-shape parity with other providers; ignored (the HTTP API has no filesystem access)." },
-  cwd: { type: "string", description: "Accepted for parity; ignored." },
+  files: FILES_SCHEMA,
+  sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only", description: "Accepted for call-shape parity with other providers; ignored (Grok cannot edit files)." },
+  cwd: { type: "string", description: "Base directory for resolving relative file `path` uploads. Defaults to the server's cwd." },
 };
+
+// Validate a `files` param. Returns an error string, or null when valid/absent.
+function validateFiles(files) {
+  if (files === undefined) return null;
+  if (!Array.isArray(files)) return "'files' must be an array when provided";
+  for (const entry of files) {
+    if (!isObject(entry)) return "each 'files' entry must be an object";
+    const keys = ["path", "file_id", "file_url"].filter((k) => entry[k] !== undefined);
+    if (keys.length !== 1) return "each 'files' entry needs exactly one of path, file_id, or file_url";
+    if (!isNonEmptyString(entry[keys[0]])) return `'files' entry ${keys[0]} must be a non-empty string`;
+    if (entry.filename !== undefined && !isNonEmptyString(entry.filename)) return "'files' entry filename must be a non-empty string when provided";
+  }
+  return null;
+}
 
 const handlers = {
   "initialize": (id, _params, shouldRespond) => {
@@ -208,7 +407,7 @@ const handlers = {
     sendResponse(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
-      serverInfo: { name: "claude-delegator-grok", version: "1.7.0" }
+      serverInfo: { name: "claude-delegator-grok", version: "1.8.0" }
     });
   },
 
@@ -218,12 +417,8 @@ const handlers = {
       tools: [
         {
           name: "grok",
-          description: "Start a new Grok (xAI) expert session. Advisory only (no filesystem access).",
-          inputSchema: {
-            type: "object",
-            properties: GROK_PROPERTIES,
-            required: ["prompt"]
-          }
+          description: "Start a new Grok (xAI) expert session. Advisory only (no filesystem editing). Supports attaching files.",
+          inputSchema: { type: "object", properties: GROK_PROPERTIES, required: ["prompt"] }
         },
         {
           name: "grok-reply",
@@ -233,8 +428,10 @@ const handlers = {
             properties: {
               threadId: { type: "string", description: "Session ID returned by a previous grok call" },
               prompt: { type: "string", description: "Follow-up prompt" },
+              files: FILES_SCHEMA,
               model: { type: "string", default: DEFAULT_MODEL },
-              timeout: { type: "number", default: DEFAULT_TIMEOUT_MS }
+              timeout: { type: "number", default: DEFAULT_TIMEOUT_MS },
+              cwd: { type: "string", description: "Base directory for relative file path uploads" },
             },
             required: ["threadId", "prompt"]
           }
@@ -276,12 +473,17 @@ const handlers = {
         return;
       }
     }
+    const filesErr = validateFiles(args.files);
+    if (filesErr) {
+      if (shouldRespond) sendError(id, -32602, `Invalid params: ${filesErr}`);
+      return;
+    }
     if (!isNonEmptyString(args.prompt)) {
       if (shouldRespond) sendError(id, -32602, "Invalid params: 'prompt' is required");
       return;
     }
 
-    let messages;
+    let priorTurns = null;
     let threadId;
 
     if (name === "grok") {
@@ -289,7 +491,6 @@ const handlers = {
         if (shouldRespond) sendError(id, -32602, "Invalid params: 'developer-instructions' must be a string when provided");
         return;
       }
-      messages = buildMessages(args["developer-instructions"], args.prompt);
       threadId = crypto.randomUUID();
     } else if (name === "grok-reply") {
       if (!isNonEmptyString(args.threadId)) {
@@ -297,9 +498,8 @@ const handlers = {
         return;
       }
       threadId = args.threadId.trim();
-      const prior = sessions.get(threadId);
-      if (!prior) {
-        // Structured error (not a JSON-RPC error) so the orchestrator can react.
+      priorTurns = sessions.get(threadId);
+      if (!priorTurns) {
         const { errorKind, retryable } = classifyGrokError(null, "unknown-thread");
         logCall((id != null) ? id : threadId, "grok-reply", errorKind, 0);
         if (shouldRespond) {
@@ -312,7 +512,6 @@ const handlers = {
         }
         return;
       }
-      messages = [...prior, { role: "user", content: args.prompt }];
     } else {
       if (shouldRespond) sendError(id, -32601, `Tool not found: ${name}`);
       return;
@@ -321,22 +520,34 @@ const handlers = {
     const startedAt = Date.now();
     let outcome = "ok";
     try {
-      const text = await runGrok({
-        messages,
+      // Upload/resolve any attached files first (so an upload failure short-circuits).
+      const { refs, ownedIds } = await resolveFiles(args.files, {
+        apiKey: process.env.XAI_API_KEY,
+        apiBase: DEFAULT_API_BASE,
+        ttl: FILE_TTL_SECONDS,
+        cwd: args.cwd,
+      });
+
+      const turns = priorTurns
+        ? [...priorTurns, { role: "user", text: args.prompt, fileRefs: refs }]
+        : buildInitialTurns(args["developer-instructions"], args.prompt, refs);
+
+      const { text, output } = await runGrok({
+        turns,
         model: args.model,
         timeoutMs: args.timeout,
         apiKey: process.env.XAI_API_KEY,
         apiBase: DEFAULT_API_BASE,
       });
 
-      // Persist the turn so grok-reply can continue this thread.
-      sessions.set(threadId, [...messages, { role: "assistant", content: text }]);
+      // Persist the turn so grok-reply can continue this thread. `items` holds the
+      // server's raw output for verbatim replay (falls back to `text` if absent).
+      sessions.set(threadId, [...turns, { role: "assistant", text, items: output || undefined }]);
 
       if (shouldRespond) {
-        sendResponse(id, {
-          content: [{ type: "text", text }],
-          threadId,
-        });
+        const result = { content: [{ type: "text", text }], threadId };
+        if (ownedIds.length) result.uploadedFileIds = ownedIds;
+        sendResponse(id, result);
       }
     } catch (e) {
       const errMsg = (e && e.message) || String(e);
@@ -394,52 +605,28 @@ async function processLine(line) {
   }
 }
 
-let buffer = "";
-
 if (require.main === module) {
-  // F2: after an uncaught throw / rejection the process is in an undefined state
-  // (Node guarantees no safe resumption). Log the stack, then exit non-zero in
-  // the write callback (so the line is not truncated) and let the MCP host
-  // restart the bridge. In-memory sessions are already ephemeral across restarts.
-  process.on("uncaughtException", (e) => {
-    process.stderr.write(`[grok] fatal-guard uncaughtException: ${e && e.stack ? e.stack : String((e && e.message) || e)}\n`, () => process.exit(1));
-  });
-  process.on("unhandledRejection", (e) => {
-    process.stderr.write(`[grok] fatal-guard unhandledRejection: ${e && e.stack ? e.stack : String((e && e.message) || e)}\n`, () => process.exit(1));
-  });
+  let buffer = "";
+  let chain = Promise.resolve();
 
-  // F2: a broken input pipe is terminal -- the bridge can no longer receive
-  // requests. Exit 1 after the stderr line flushes (exit from the write callback).
-  process.stdin.on("error", (e) => {
-    process.stderr.write(`[grok] stdin error (input pipe broken): ${String((e && e.message) || e)}\n`, () => process.exit(1));
-  });
+  // Serialize processing so responses are emitted in request order even when a
+  // chunk carries multiple messages.
+  const enqueue = (line) => { chain = chain.then(() => processLine(line)); };
 
-  process.stdin.on("data", async (chunk) => {
+  process.stdin.on("data", (chunk) => {
     buffer += chunk.toString();
     const lines = buffer.split("\n");
-    buffer = lines.pop(); // keep any partial trailing line
-    for (const line of lines) await processLine(line);
+    buffer = lines.pop();
+    for (const line of lines) enqueue(line);
   });
 
-  // F2: a clean EOF means the client is done. Flush a final line that arrived
-  // without a trailing newline, then let the event loop drain naturally -- any
-  // in-flight call finishes and flushes its stdout response, and the process
-  // exits 0 once no handles remain. No forced process.exit: that would truncate
-  // buffered stdout and could drop sibling lines from the same chunk.
-  let ended = false;
-  const onEnd = () => {
-    if (ended) return; // 'end' and 'close' can both fire; flush at most once
-    ended = true;
-    const tail = buffer;
-    buffer = "";
-    if (tail.trim()) processLine(tail);
-  };
-  process.stdin.on("end", onEnd);
-  process.stdin.on("close", onEnd);
+  process.stdin.on("end", () => {
+    if (buffer) { enqueue(buffer); buffer = ""; }
+  });
 
-  // Startup Check: the bridge needs global fetch (Node 18+). The API key is NOT
+  // Startup check: the bridge needs global fetch (Node 18+). The API key is NOT
   // required at startup so the initialize handshake and missing-auth error path
-  // both stay reachable; it is validated per-call in runGrok.
+  // both stay reachable; it is validated per-call.
   if (typeof globalThis.fetch !== "function") {
     console.error("Grok bridge requires Node 18+ (global fetch unavailable).");
     process.exit(1);
@@ -447,22 +634,18 @@ if (require.main === module) {
   if (!isNonEmptyString(process.env.XAI_API_KEY)) {
     console.error("[claude-delegator] warning: XAI_API_KEY is not set; grok calls will return errorKind:missing-auth until it is.");
   }
-
-  // Test-only seams (never triggered in normal operation). They exercise the F2
-  // process-level guards from a child process where the real signals are hard to
-  // synthesize deterministically.
-  if (process.env.GROK_TEST_EMIT_STDIN_ERROR === "1") {
-    process.nextTick(() => process.stdin.emit("error", new Error("pipe boom (test seam)")));
-  }
-  if (process.env.GROK_TEST_THROW_ASYNC === "1") {
-    setTimeout(() => { throw new Error("async boom (test seam)"); }, 30);
-  }
 }
 
 // Test-only exports
 if (typeof module !== "undefined" && module.exports) {
   module.exports.classifyGrokError = classifyGrokError;
-  module.exports.buildMessages = buildMessages;
-  module.exports.parseChatCompletion = parseChatCompletion;
+  module.exports.buildInitialTurns = buildInitialTurns;
+  module.exports.turnsToInput = turnsToInput;
+  module.exports.parseResponsesOutput = parseResponsesOutput;
   module.exports.runGrok = runGrok;
+  module.exports.uploadFile = uploadFile;
+  module.exports.resolveFiles = resolveFiles;
+  module.exports.validateFiles = validateFiles;
+  module.exports.FILE_PREFIX = FILE_PREFIX;
+  module.exports.FILE_TTL_SECONDS = FILE_TTL_SECONDS;
 }

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -14,6 +14,7 @@
  * Auth: XAI_API_KEY (env). Model: GROK_DEFAULT_MODEL (env) or grok-4.3.
  * Endpoint: XAI_API_BASE (env) or https://api.x.ai/v1.
  * File TTL: GROK_FILE_TTL_SECONDS (env) or 604800 (7 days).
+ * Reasoning effort: GROK_REASONING_EFFORT (env) or "xhigh"; per-call reasoning_effort overrides.
  */
 
 const crypto = require("node:crypto");
@@ -41,6 +42,18 @@ const MAX_FILE_BYTES = 48 * 1024 * 1024;
 // user's own xAI files. Flat (no slashes/colons) to avoid filename mangling.
 const FILE_PREFIX = "claude-delegator-";
 const UPLOAD_PURPOSE = "assistants";
+
+// Reasoning effort: per-call value wins, then GROK_REASONING_EFFORT, then the
+// default. "", "none", or "off" omit the field so the model uses its own default.
+const DEFAULT_REASONING_EFFORT = "xhigh";
+function resolveReasoningEffort(perCall) {
+  let raw = perCall;
+  if (raw === undefined || raw === null) raw = process.env.GROK_REASONING_EFFORT;
+  if (raw === undefined || raw === null) raw = DEFAULT_REASONING_EFFORT;
+  const v = String(raw).trim();
+  if (v === "" || v.toLowerCase() === "none" || v.toLowerCase() === "off") return null;
+  return v;
+}
 
 // In-memory session store: threadId -> turns[]. Lives for the MCP process
 // lifetime only; lost on restart (grok-reply then returns unknown-thread).
@@ -295,7 +308,7 @@ async function resolveFiles(files, opts) {
 
 // One /v1/responses call returning the assistant text. Errors carry `.code`
 // and/or `.status`. `fetchImpl` is injectable for tests.
-async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl }) {
+async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl, reasoningEffort }) {
   if (!isNonEmptyString(apiKey)) {
     const e = new Error("XAI_API_KEY is not set. Export it (export XAI_API_KEY=xai-...) or rerun /claude-delegator:setup.");
     e.code = "missing-auth";
@@ -310,6 +323,8 @@ async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl }) 
 
   const base = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
   const url = `${base}/responses`;
+  const payload = { model: model || DEFAULT_MODEL, input: turnsToInput(turns), stream: false };
+  if (isNonEmptyString(reasoningEffort)) payload.reasoning_effort = reasoningEffort;
   const t = (typeof timeoutMs === "number" && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), t);
@@ -322,7 +337,7 @@ async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl }) 
         "Content-Type": "application/json",
         "Authorization": `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({ model: model || DEFAULT_MODEL, input: turnsToInput(turns), stream: false }),
+      body: JSON.stringify(payload),
       signal: controller.signal,
     });
   } catch (err) {
@@ -381,6 +396,7 @@ const GROK_PROPERTIES = {
   prompt: { type: "string", description: "The delegation prompt" },
   "developer-instructions": { type: "string", description: "Expert system instructions (sent as a system message)" },
   model: { type: "string", description: "xAI model id. Defaults to GROK_DEFAULT_MODEL or grok-4.3.", default: DEFAULT_MODEL },
+  reasoning_effort: { type: "string", description: "Reasoning effort (e.g. low, high, xhigh). Defaults to GROK_REASONING_EFFORT or xhigh. Use 'none' to omit the field.", default: DEFAULT_REASONING_EFFORT },
   timeout: { type: "number", description: "Soft timeout in ms. 1..600000. Default 180000.", default: DEFAULT_TIMEOUT_MS },
   files: FILES_SCHEMA,
   sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only", description: "Accepted for call-shape parity with other providers; ignored (Grok cannot edit files)." },
@@ -430,6 +446,7 @@ const handlers = {
               prompt: { type: "string", description: "Follow-up prompt" },
               files: FILES_SCHEMA,
               model: { type: "string", default: DEFAULT_MODEL },
+              reasoning_effort: { type: "string", default: DEFAULT_REASONING_EFFORT, description: "Reasoning effort; defaults to GROK_REASONING_EFFORT or xhigh. Use 'none' to omit." },
               timeout: { type: "number", default: DEFAULT_TIMEOUT_MS },
               cwd: { type: "string", description: "Base directory for relative file path uploads" },
             },
@@ -465,6 +482,10 @@ const handlers = {
     }
     if (args.model !== undefined && !isNonEmptyString(args.model)) {
       if (shouldRespond) sendError(id, -32602, "Invalid params: 'model' must be a non-empty string when provided");
+      return;
+    }
+    if (args.reasoning_effort !== undefined && typeof args.reasoning_effort !== "string") {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'reasoning_effort' must be a string when provided");
       return;
     }
     if (args.timeout !== undefined) {
@@ -536,6 +557,7 @@ const handlers = {
         turns,
         model: args.model,
         timeoutMs: args.timeout,
+        reasoningEffort: resolveReasoningEffort(args.reasoning_effort),
         apiKey: process.env.XAI_API_KEY,
         apiBase: DEFAULT_API_BASE,
       });
@@ -639,6 +661,7 @@ if (require.main === module) {
 // Test-only exports
 if (typeof module !== "undefined" && module.exports) {
   module.exports.classifyGrokError = classifyGrokError;
+  module.exports.resolveReasoningEffort = resolveReasoningEffort;
   module.exports.buildInitialTurns = buildInitialTurns;
   module.exports.turnsToInput = turnsToInput;
   module.exports.parseResponsesOutput = parseResponsesOutput;

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Delegator - Grok (xAI) MCP Bridge
+ *
+ * A zero-dependency MCP server that calls the xAI OpenAI-compatible Chat
+ * Completions API. Speaks JSON-RPC 2.0 over stdio.
+ *
+ * Unlike the Gemini bridge (which wraps a one-shot CLI and recovers answers
+ * from disk), this bridge owns the conversation state directly, so multi-turn
+ * (grok-reply) is an in-memory threadId -> messages map.
+ *
+ * Auth: XAI_API_KEY (env). Model: GROK_DEFAULT_MODEL (env) or grok-4.3.
+ * Endpoint: XAI_API_BASE (env) or https://api.x.ai/v1.
+ */
+
+const crypto = require("node:crypto");
+
+const DEFAULT_MODEL = process.env.GROK_DEFAULT_MODEL || "grok-4.3";
+const DEFAULT_API_BASE = process.env.XAI_API_BASE || "https://api.x.ai/v1";
+const DEFAULT_TIMEOUT_MS = 180_000; // 3 minutes
+const MAX_MS = 600_000;
+const VALID_SANDBOX_VALUES = new Set(["read-only", "workspace-write"]);
+
+// In-memory session store: threadId -> messages[]. Lives for the MCP process
+// lifetime only; lost on restart (grok-reply then returns unknown-thread).
+const sessions = new Map();
+
+// --- MCP Protocol Helpers ---
+
+function sendResponse(id, result) {
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    result
+  }) + "\n");
+}
+
+function sendError(id, code, message) {
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    error: { code, message }
+  }) + "\n");
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasRequestId(request) {
+  return isObject(request) && Object.prototype.hasOwnProperty.call(request, "id");
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function truncate(str, max) {
+  const s = String(str == null ? "" : str);
+  return s.length > max ? s.slice(0, max) + "..." : s;
+}
+
+// --- Error Classification ---
+
+// Pure helper: given an HTTP status (or null) and a thrown error's `.code`,
+// produce the structured error fields the orchestrator consumes. Exported for
+// tests. `.code` is checked first (transport-level), then HTTP status.
+function classifyGrokError(status, errCode) {
+  switch (errCode) {
+    case "missing-auth":   return { errorKind: "missing-auth",   retryable: false };
+    case "unknown-thread": return { errorKind: "unknown-thread", retryable: false };
+    case "timeout":        return { errorKind: "timeout",        retryable: true };
+    case "network":        return { errorKind: "network",        retryable: true };
+    case "parse":          return { errorKind: "parse",          retryable: false };
+  }
+  const s = Number(status);
+  if (s === 401 || s === 403) return { errorKind: "auth", retryable: false };
+  if (s === 429)              return { errorKind: "rate-limit", retryable: true };
+  if (s >= 500 && s <= 599)   return { errorKind: "upstream", retryable: true };
+  return { errorKind: "unknown", retryable: false };
+}
+
+// --- Pure helpers (exported for tests) ---
+
+// Build the OpenAI-style messages array. developer-instructions become a
+// leading system message; the prompt is the user turn.
+function buildMessages(developerInstructions, prompt) {
+  const messages = [];
+  if (isNonEmptyString(developerInstructions)) {
+    messages.push({ role: "system", content: developerInstructions });
+  }
+  messages.push({ role: "user", content: prompt });
+  return messages;
+}
+
+// Extract the assistant text from a chat/completions response body. Throws a
+// `.code = "parse"` error on a malformed shape.
+function parseChatCompletion(data) {
+  const fail = (why) => {
+    const e = new Error(`Parse error: ${why}`);
+    e.code = "parse";
+    return e;
+  };
+  if (!isObject(data)) throw fail("response was not a JSON object");
+  const choices = data.choices;
+  if (!Array.isArray(choices) || choices.length === 0) throw fail("no choices in response");
+  const message = choices[0] && choices[0].message;
+  const content = message && message.content;
+  if (typeof content !== "string") throw fail("choices[0].message.content missing");
+  return content;
+}
+
+// --- xAI API Call ---
+
+// Performs one chat/completions call and returns the assistant text. Errors
+// carry `.code` (transport: timeout/network/parse/missing-auth) and/or `.status`
+// (HTTP) so classifyGrokError can map them. `fetchImpl` is injectable for tests.
+async function runGrok({ messages, model, timeoutMs, apiKey, apiBase, fetchImpl }) {
+  if (!isNonEmptyString(apiKey)) {
+    const e = new Error("XAI_API_KEY is not set. Export it (export XAI_API_KEY=xai-...) or rerun /claude-delegator:setup.");
+    e.code = "missing-auth";
+    throw e;
+  }
+  const f = fetchImpl || globalThis.fetch;
+  if (typeof f !== "function") {
+    const e = new Error("global fetch is unavailable; Node 18+ is required for the Grok bridge.");
+    e.code = "network";
+    throw e;
+  }
+
+  const base = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
+  const url = `${base}/chat/completions`;
+  const t = (typeof timeoutMs === "number" && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), t);
+
+  let res;
+  try {
+    res = await f(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model: model || DEFAULT_MODEL, messages, stream: false }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const name = err && err.name;
+    const msg = String((err && err.message) || err);
+    if (name === "AbortError" || /abort/i.test(msg)) {
+      const e = new Error(`Grok timed out after ${Math.round(t / 1000)}s`);
+      e.code = "timeout";
+      throw e;
+    }
+    const e = new Error(`Network error: ${msg}`);
+    e.code = "network";
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let bodyText = "";
+  try { bodyText = await res.text(); } catch (_) { bodyText = ""; }
+
+  if (!res.ok) {
+    const e = new Error(`xAI API error ${res.status}: ${truncate(bodyText, 500)}`);
+    e.status = res.status;
+    throw e;
+  }
+
+  let data;
+  try { data = JSON.parse(bodyText); }
+  catch (e2) {
+    const e = new Error(`Parse error: invalid JSON body: ${e2.message}`);
+    e.code = "parse";
+    throw e;
+  }
+  return parseChatCompletion(data);
+}
+
+// --- Request Handlers ---
+
+const GROK_PROPERTIES = {
+  prompt: { type: "string", description: "The delegation prompt" },
+  "developer-instructions": { type: "string", description: "Expert system instructions (sent as a system message)" },
+  model: { type: "string", description: "xAI model id. Defaults to GROK_DEFAULT_MODEL or grok-4.3.", default: DEFAULT_MODEL },
+  timeout: { type: "number", description: "Soft timeout in ms. 1..600000. Default 180000.", default: DEFAULT_TIMEOUT_MS },
+  sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only", description: "Accepted for call-shape parity with other providers; ignored (the HTTP API has no filesystem access)." },
+  cwd: { type: "string", description: "Accepted for parity; ignored." },
+};
+
+const handlers = {
+  "initialize": (id, _params, shouldRespond) => {
+    if (!shouldRespond) return;
+    sendResponse(id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: { name: "claude-delegator-grok", version: "1.7.0" }
+    });
+  },
+
+  "tools/list": (id, _params, shouldRespond) => {
+    if (!shouldRespond) return;
+    sendResponse(id, {
+      tools: [
+        {
+          name: "grok",
+          description: "Start a new Grok (xAI) expert session. Advisory only (no filesystem access).",
+          inputSchema: {
+            type: "object",
+            properties: GROK_PROPERTIES,
+            required: ["prompt"]
+          }
+        },
+        {
+          name: "grok-reply",
+          description: "Continue an existing Grok session (in-memory; lost if the MCP server restarts).",
+          inputSchema: {
+            type: "object",
+            properties: {
+              threadId: { type: "string", description: "Session ID returned by a previous grok call" },
+              prompt: { type: "string", description: "Follow-up prompt" },
+              model: { type: "string", default: DEFAULT_MODEL },
+              timeout: { type: "number", default: DEFAULT_TIMEOUT_MS }
+            },
+            required: ["threadId", "prompt"]
+          }
+        }
+      ]
+    });
+  },
+
+  "tools/call": async (id, params, shouldRespond) => {
+    if (!isObject(params)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: expected an object");
+      return;
+    }
+
+    const { name, arguments: args } = params;
+    if (!isNonEmptyString(name)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'name' must be a non-empty string");
+      return;
+    }
+    if (!isObject(args)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'arguments' must be an object");
+      return;
+    }
+    if (args.sandbox !== undefined && !VALID_SANDBOX_VALUES.has(args.sandbox)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'sandbox' must be 'read-only' or 'workspace-write'");
+      return;
+    }
+    if (args.cwd !== undefined && !isNonEmptyString(args.cwd)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'cwd' must be a non-empty string when provided");
+      return;
+    }
+    if (args.model !== undefined && !isNonEmptyString(args.model)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'model' must be a non-empty string when provided");
+      return;
+    }
+    if (args.timeout !== undefined) {
+      if (typeof args.timeout !== "number" || !Number.isFinite(args.timeout) || args.timeout <= 0 || args.timeout > MAX_MS) {
+        if (shouldRespond) sendError(id, -32602, "Invalid params: 'timeout' must be a number > 0 and <= 600000 milliseconds");
+        return;
+      }
+    }
+    if (!isNonEmptyString(args.prompt)) {
+      if (shouldRespond) sendError(id, -32602, "Invalid params: 'prompt' is required");
+      return;
+    }
+
+    let messages;
+    let threadId;
+
+    if (name === "grok") {
+      if (args["developer-instructions"] !== undefined && typeof args["developer-instructions"] !== "string") {
+        if (shouldRespond) sendError(id, -32602, "Invalid params: 'developer-instructions' must be a string when provided");
+        return;
+      }
+      messages = buildMessages(args["developer-instructions"], args.prompt);
+      threadId = crypto.randomUUID();
+    } else if (name === "grok-reply") {
+      if (!isNonEmptyString(args.threadId)) {
+        if (shouldRespond) sendError(id, -32602, "Invalid params: 'threadId' is required for grok-reply");
+        return;
+      }
+      threadId = args.threadId.trim();
+      const prior = sessions.get(threadId);
+      if (!prior) {
+        // Structured error (not a JSON-RPC error) so the orchestrator can react.
+        const { errorKind, retryable } = classifyGrokError(null, "unknown-thread");
+        if (shouldRespond) {
+          sendResponse(id, {
+            content: [{ type: "text", text: `Error: unknown threadId "${threadId}". Start a fresh grok call (in-memory sessions do not survive an MCP restart).` }],
+            isError: true,
+            errorKind,
+            retryable,
+          });
+        }
+        return;
+      }
+      messages = [...prior, { role: "user", content: args.prompt }];
+    } else {
+      if (shouldRespond) sendError(id, -32601, `Tool not found: ${name}`);
+      return;
+    }
+
+    try {
+      const text = await runGrok({
+        messages,
+        model: args.model,
+        timeoutMs: args.timeout,
+        apiKey: process.env.XAI_API_KEY,
+        apiBase: DEFAULT_API_BASE,
+      });
+
+      // Persist the turn so grok-reply can continue this thread.
+      sessions.set(threadId, [...messages, { role: "assistant", content: text }]);
+
+      if (shouldRespond) {
+        sendResponse(id, {
+          content: [{ type: "text", text }],
+          threadId,
+        });
+      }
+    } catch (e) {
+      const errMsg = (e && e.message) || String(e);
+      const { errorKind, retryable } = classifyGrokError(e && e.status, e && e.code);
+      if (shouldRespond) {
+        sendResponse(id, {
+          content: [{ type: "text", text: `Error: ${errMsg}` }],
+          isError: true,
+          errorKind,
+          retryable,
+        });
+      }
+    }
+  },
+
+  "notifications/initialized": () => {}
+};
+
+// --- Main Loop (Robust JSON-RPC stream handling) ---
+
+let buffer = "";
+
+if (require.main === module) {
+  process.stdin.on("data", async (chunk) => {
+    buffer += chunk.toString();
+    let lines = buffer.split("\n");
+    buffer = lines.pop(); // Keep partial line in buffer
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      let request;
+      try {
+        request = JSON.parse(line);
+      } catch (e) {
+        // Ignore parse errors from noise
+        continue;
+      }
+
+      const shouldRespond = hasRequestId(request);
+      if (!isObject(request) || typeof request.method !== "string") {
+        if (shouldRespond) sendError(request.id, -32600, "Invalid Request");
+        continue;
+      }
+
+      const handler = handlers[request.method];
+      if (!handler) {
+        if (shouldRespond) sendError(request.id, -32601, `Method not found: ${request.method}`);
+        continue;
+      }
+
+      try {
+        await handler(request.id, request.params, shouldRespond);
+      } catch (e) {
+        if (shouldRespond) sendError(request.id, -32603, `Internal error: ${e.message}`);
+      }
+    }
+  });
+
+  // Startup Check: the bridge needs global fetch (Node 18+). The API key is NOT
+  // required at startup so the initialize handshake and missing-auth error path
+  // both stay reachable; it is validated per-call in runGrok.
+  if (typeof globalThis.fetch !== "function") {
+    console.error("Grok bridge requires Node 18+ (global fetch unavailable).");
+    process.exit(1);
+  }
+  if (!isNonEmptyString(process.env.XAI_API_KEY)) {
+    console.error("[claude-delegator] warning: XAI_API_KEY is not set; grok calls will return errorKind:missing-auth until it is.");
+  }
+}
+
+// Test-only exports
+if (typeof module !== "undefined" && module.exports) {
+  module.exports.classifyGrokError = classifyGrokError;
+  module.exports.buildMessages = buildMessages;
+  module.exports.parseChatCompletion = parseChatCompletion;
+  module.exports.runGrok = runGrok;
+}

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -26,6 +26,11 @@ const VALID_SANDBOX_VALUES = new Set(["read-only", "workspace-write"]);
 // lifetime only; lost on restart (grok-reply then returns unknown-thread).
 const sessions = new Map();
 
+// NOTE: multi-turn assumes serial use per threadId. Two concurrent grok-reply
+// calls on the same thread would race on the read-then-set below (last write
+// wins). Acceptable for v1 -- every shipped caller (/ask-*, /consensus) is
+// single-shot and never replies to one thread in parallel.
+
 // --- MCP Protocol Helpers ---
 
 function sendResponse(id, result) {
@@ -59,6 +64,12 @@ function isNonEmptyString(value) {
 function truncate(str, max) {
   const s = String(str == null ? "" : str);
   return s.length > max ? s.slice(0, max) + "..." : s;
+}
+
+// F3: one structured stderr line per dispatched call. stderr ONLY -- stdout is
+// the JSON-RPC channel. Never logs payloads, the API key, or prompt text.
+function logCall(cid, tool, outcome, ms) {
+  process.stderr.write(`[grok] ${cid} ${tool} -> ${outcome} in ${ms}ms\n`);
 }
 
 // --- Error Classification ---
@@ -290,6 +301,7 @@ const handlers = {
       if (!prior) {
         // Structured error (not a JSON-RPC error) so the orchestrator can react.
         const { errorKind, retryable } = classifyGrokError(null, "unknown-thread");
+        logCall((id != null) ? id : threadId, "grok-reply", errorKind, 0);
         if (shouldRespond) {
           sendResponse(id, {
             content: [{ type: "text", text: `Error: unknown threadId "${threadId}". Start a fresh grok call (in-memory sessions do not survive an MCP restart).` }],
@@ -306,6 +318,8 @@ const handlers = {
       return;
     }
 
+    const startedAt = Date.now();
+    let outcome = "ok";
     try {
       const text = await runGrok({
         messages,
@@ -327,6 +341,7 @@ const handlers = {
     } catch (e) {
       const errMsg = (e && e.message) || String(e);
       const { errorKind, retryable } = classifyGrokError(e && e.status, e && e.code);
+      outcome = errorKind;
       if (shouldRespond) {
         sendResponse(id, {
           content: [{ type: "text", text: `Error: ${errMsg}` }],
@@ -335,6 +350,10 @@ const handlers = {
           retryable,
         });
       }
+    } finally {
+      const cid = (id != null) ? id : (threadId != null ? threadId : "-");
+      const toolName = isNonEmptyString(name) ? name : "unknown";
+      logCall(cid, toolName, outcome, Date.now() - startedAt);
     }
   },
 
@@ -343,44 +362,80 @@ const handlers = {
 
 // --- Main Loop (Robust JSON-RPC stream handling) ---
 
+// Parse and dispatch a single newline-delimited JSON-RPC message. Shared by the
+// stdin 'data' loop and the clean-EOF tail flush, so a final line that arrives
+// without a trailing newline is still handled.
+async function processLine(line) {
+  if (!line.trim()) return;
+
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch (e) {
+    return; // ignore non-JSON noise
+  }
+
+  const shouldRespond = hasRequestId(request);
+  if (!isObject(request) || typeof request.method !== "string") {
+    if (shouldRespond) sendError(request.id, -32600, "Invalid Request");
+    return;
+  }
+
+  const handler = handlers[request.method];
+  if (!handler) {
+    if (shouldRespond) sendError(request.id, -32601, `Method not found: ${request.method}`);
+    return;
+  }
+
+  try {
+    await handler(request.id, request.params, shouldRespond);
+  } catch (e) {
+    if (shouldRespond) sendError(request.id, -32603, `Internal error: ${e.message}`);
+  }
+}
+
 let buffer = "";
 
 if (require.main === module) {
+  // F2: after an uncaught throw / rejection the process is in an undefined state
+  // (Node guarantees no safe resumption). Log the stack, then exit non-zero in
+  // the write callback (so the line is not truncated) and let the MCP host
+  // restart the bridge. In-memory sessions are already ephemeral across restarts.
+  process.on("uncaughtException", (e) => {
+    process.stderr.write(`[grok] fatal-guard uncaughtException: ${e && e.stack ? e.stack : String((e && e.message) || e)}\n`, () => process.exit(1));
+  });
+  process.on("unhandledRejection", (e) => {
+    process.stderr.write(`[grok] fatal-guard unhandledRejection: ${e && e.stack ? e.stack : String((e && e.message) || e)}\n`, () => process.exit(1));
+  });
+
+  // F2: a broken input pipe is terminal -- the bridge can no longer receive
+  // requests. Exit 1 after the stderr line flushes (exit from the write callback).
+  process.stdin.on("error", (e) => {
+    process.stderr.write(`[grok] stdin error (input pipe broken): ${String((e && e.message) || e)}\n`, () => process.exit(1));
+  });
+
   process.stdin.on("data", async (chunk) => {
     buffer += chunk.toString();
-    let lines = buffer.split("\n");
-    buffer = lines.pop(); // Keep partial line in buffer
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      let request;
-      try {
-        request = JSON.parse(line);
-      } catch (e) {
-        // Ignore parse errors from noise
-        continue;
-      }
-
-      const shouldRespond = hasRequestId(request);
-      if (!isObject(request) || typeof request.method !== "string") {
-        if (shouldRespond) sendError(request.id, -32600, "Invalid Request");
-        continue;
-      }
-
-      const handler = handlers[request.method];
-      if (!handler) {
-        if (shouldRespond) sendError(request.id, -32601, `Method not found: ${request.method}`);
-        continue;
-      }
-
-      try {
-        await handler(request.id, request.params, shouldRespond);
-      } catch (e) {
-        if (shouldRespond) sendError(request.id, -32603, `Internal error: ${e.message}`);
-      }
-    }
+    const lines = buffer.split("\n");
+    buffer = lines.pop(); // keep any partial trailing line
+    for (const line of lines) await processLine(line);
   });
+
+  // F2: a clean EOF means the client is done. Flush a final line that arrived
+  // without a trailing newline, then let the event loop drain naturally -- any
+  // in-flight call finishes and flushes its stdout response, and the process
+  // exits 0 once no handles remain. No forced process.exit: that would truncate
+  // buffered stdout and could drop sibling lines from the same chunk.
+  let ended = false;
+  const onEnd = () => {
+    if (ended) return; // 'end' and 'close' can both fire; flush at most once
+    ended = true;
+    const tail = buffer;
+    buffer = "";
+    if (tail.trim()) processLine(tail);
+  };
+  process.stdin.on("end", onEnd);
+  process.stdin.on("close", onEnd);
 
   // Startup Check: the bridge needs global fetch (Node 18+). The API key is NOT
   // required at startup so the initialize handshake and missing-auth error path
@@ -391,6 +446,16 @@ if (require.main === module) {
   }
   if (!isNonEmptyString(process.env.XAI_API_KEY)) {
     console.error("[claude-delegator] warning: XAI_API_KEY is not set; grok calls will return errorKind:missing-auth until it is.");
+  }
+
+  // Test-only seams (never triggered in normal operation). They exercise the F2
+  // process-level guards from a child process where the real signals are hard to
+  // synthesize deterministically.
+  if (process.env.GROK_TEST_EMIT_STDIN_ERROR === "1") {
+    process.nextTick(() => process.stdin.emit("error", new Error("pipe boom (test seam)")));
+  }
+  if (process.env.GROK_TEST_THROW_ASYNC === "1") {
+    setTimeout(() => { throw new Error("async boom (test seam)"); }, 30);
   }
 }
 

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -14,7 +14,7 @@
  * Auth: XAI_API_KEY (env). Model: GROK_DEFAULT_MODEL (env) or grok-4.3.
  * Endpoint: XAI_API_BASE (env) or https://api.x.ai/v1.
  * File TTL: GROK_FILE_TTL_SECONDS (env) or 604800 (7 days).
- * Reasoning effort: GROK_REASONING_EFFORT (env) or "xhigh"; per-call reasoning_effort overrides.
+ * Reasoning effort: GROK_REASONING_EFFORT (env) or "high"; per-call reasoning_effort overrides.
  */
 
 const crypto = require("node:crypto");
@@ -45,7 +45,7 @@ const UPLOAD_PURPOSE = "assistants";
 
 // Reasoning effort: per-call value wins, then GROK_REASONING_EFFORT, then the
 // default. "", "none", or "off" omit the field so the model uses its own default.
-const DEFAULT_REASONING_EFFORT = "xhigh";
+const DEFAULT_REASONING_EFFORT = "high";
 function resolveReasoningEffort(perCall) {
   let raw = perCall;
   if (raw === undefined || raw === null) raw = process.env.GROK_REASONING_EFFORT;
@@ -396,7 +396,7 @@ const GROK_PROPERTIES = {
   prompt: { type: "string", description: "The delegation prompt" },
   "developer-instructions": { type: "string", description: "Expert system instructions (sent as a system message)" },
   model: { type: "string", description: "xAI model id. Defaults to GROK_DEFAULT_MODEL or grok-4.3.", default: DEFAULT_MODEL },
-  reasoning_effort: { type: "string", description: "Reasoning effort (e.g. low, high, xhigh). Defaults to GROK_REASONING_EFFORT or xhigh. Use 'none' to omit the field.", default: DEFAULT_REASONING_EFFORT },
+  reasoning_effort: { type: "string", description: "Reasoning effort (e.g. low, medium, high). Defaults to GROK_REASONING_EFFORT or high. Use 'none' to omit the field.", default: DEFAULT_REASONING_EFFORT },
   timeout: { type: "number", description: "Soft timeout in ms. 1..600000. Default 180000.", default: DEFAULT_TIMEOUT_MS },
   files: FILES_SCHEMA,
   sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only", description: "Accepted for call-shape parity with other providers; ignored (Grok cannot edit files)." },
@@ -446,7 +446,7 @@ const handlers = {
               prompt: { type: "string", description: "Follow-up prompt" },
               files: FILES_SCHEMA,
               model: { type: "string", default: DEFAULT_MODEL },
-              reasoning_effort: { type: "string", default: DEFAULT_REASONING_EFFORT, description: "Reasoning effort; defaults to GROK_REASONING_EFFORT or xhigh. Use 'none' to omit." },
+              reasoning_effort: { type: "string", default: DEFAULT_REASONING_EFFORT, description: "Reasoning effort; defaults to GROK_REASONING_EFFORT or high. Use 'none' to omit." },
               timeout: { type: "number", default: DEFAULT_TIMEOUT_MS },
               cwd: { type: "string", description: "Base directory for relative file path uploads" },
             },

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -1,0 +1,235 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const http = require("node:http");
+const path = require("node:path");
+
+const BRIDGE = path.join(__dirname, "..", "server", "grok", "index.js");
+
+// Spawn the Grok bridge with a controlled environment.
+function startGrokBridge(env = {}) {
+  return spawn(process.execPath, [BRIDGE], {
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+// Minimal request/response-correlated JSON-RPC client over the child's stdio.
+function rpcClient(child) {
+  let buf = "";
+  const waiters = new Map();
+  child.stdout.on("data", (d) => {
+    buf += d.toString();
+    const lines = buf.split("\n");
+    buf = lines.pop();
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let msg;
+      try { msg = JSON.parse(line); } catch (_) { continue; }
+      if (msg.id !== undefined && waiters.has(msg.id)) {
+        waiters.get(msg.id)(msg);
+        waiters.delete(msg.id);
+      }
+    }
+  });
+  return {
+    request(obj) {
+      return new Promise((resolve) => {
+        waiters.set(obj.id, resolve);
+        child.stdin.write(JSON.stringify(obj) + "\n");
+      });
+    },
+  };
+}
+
+// Start a localhost mock of the xAI chat/completions endpoint.
+function startMockXai(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (d) => (body += d));
+      req.on("end", () => handler(req, res, body));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, base: `http://127.0.0.1:${port}/v1` });
+    });
+  });
+}
+
+test("G1: grok then grok-reply accumulates the transcript", async () => {
+  const received = [];
+  const { server, base } = await startMockXai((req, res, body) => {
+    received.push(JSON.parse(body));
+    const turn = received.length;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ choices: [{ message: { role: "assistant", content: `reply-${turn}` } }] }));
+  });
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    const r1 = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "hello", "developer-instructions": "sys" } },
+    });
+    assert.equal(r1.result.isError, undefined, "no error on first call");
+    assert.equal(r1.result.content[0].text, "reply-1");
+    const threadId = r1.result.threadId;
+    assert.ok(threadId, "threadId returned");
+
+    const r2 = await rpc.request({
+      jsonrpc: "2.0", id: 3, method: "tools/call",
+      params: { name: "grok-reply", arguments: { threadId, prompt: "again" } },
+    });
+    assert.equal(r2.result.content[0].text, "reply-2");
+    assert.equal(r2.result.threadId, threadId, "same threadId preserved");
+
+    assert.deepEqual(received[0].messages, [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hello" },
+    ]);
+    assert.deepEqual(received[1].messages, [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "reply-1" },
+      { role: "user", content: "again" },
+    ]);
+  } finally {
+    child.stdin.end();
+    server.close();
+  }
+});
+
+test("G2: missing XAI_API_KEY returns errorKind missing-auth", async () => {
+  const child = startGrokBridge({ XAI_API_KEY: "", XAI_API_BASE: "http://127.0.0.1:1/v1" });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "hi" } },
+    });
+    assert.equal(r.result.isError, true);
+    assert.equal(r.result.errorKind, "missing-auth");
+    assert.equal(r.result.retryable, false);
+  } finally {
+    child.stdin.end();
+  }
+});
+
+test("G3: grok-reply on an unknown threadId returns unknown-thread", async () => {
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: "http://127.0.0.1:1/v1" });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok-reply", arguments: { threadId: "does-not-exist", prompt: "x" } },
+    });
+    assert.equal(r.result.isError, true);
+    assert.equal(r.result.errorKind, "unknown-thread");
+    assert.equal(r.result.retryable, false);
+  } finally {
+    child.stdin.end();
+  }
+});
+
+test("G4: timeout aborts the call and surfaces errorKind timeout", async () => {
+  // Mock that delays past the call timeout so AbortController fires.
+  const { server, base } = await startMockXai((req, res) => {
+    setTimeout(() => {
+      try {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: "late" } }] }));
+      } catch (_) {}
+    }, 5000);
+  });
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "slow", timeout: 300 } },
+    });
+    assert.equal(r.result.isError, true);
+    assert.equal(r.result.errorKind, "timeout");
+    assert.equal(r.result.retryable, true);
+  } finally {
+    child.stdin.end();
+    server.close();
+  }
+});
+
+test("G5: tools/list advertises grok and grok-reply", async () => {
+  const child = startGrokBridge({ XAI_API_KEY: "test" });
+  const rpc = rpcClient(child);
+  try {
+    const r = await rpc.request({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    const names = r.result.tools.map((t) => t.name);
+    assert.deepEqual(names.sort(), ["grok", "grok-reply"]);
+  } finally {
+    child.stdin.end();
+  }
+});
+
+// --- Pure-function unit tests (bridge required as a module) ---
+
+test("G6: classifyGrokError maps transport codes and HTTP statuses", () => {
+  const { classifyGrokError } = require("../server/grok/index.js");
+  assert.deepEqual(classifyGrokError(null, "missing-auth"), { errorKind: "missing-auth", retryable: false });
+  assert.deepEqual(classifyGrokError(null, "unknown-thread"), { errorKind: "unknown-thread", retryable: false });
+  assert.deepEqual(classifyGrokError(null, "timeout"), { errorKind: "timeout", retryable: true });
+  assert.deepEqual(classifyGrokError(null, "network"), { errorKind: "network", retryable: true });
+  assert.deepEqual(classifyGrokError(null, "parse"), { errorKind: "parse", retryable: false });
+  assert.deepEqual(classifyGrokError(401), { errorKind: "auth", retryable: false });
+  assert.deepEqual(classifyGrokError(403), { errorKind: "auth", retryable: false });
+  assert.deepEqual(classifyGrokError(429), { errorKind: "rate-limit", retryable: true });
+  assert.deepEqual(classifyGrokError(503), { errorKind: "upstream", retryable: true });
+  assert.deepEqual(classifyGrokError(200), { errorKind: "unknown", retryable: false });
+});
+
+test("G7: buildMessages adds system only when developer-instructions present", () => {
+  const { buildMessages } = require("../server/grok/index.js");
+  assert.deepEqual(buildMessages("sys", "p"), [
+    { role: "system", content: "sys" },
+    { role: "user", content: "p" },
+  ]);
+  assert.deepEqual(buildMessages("", "p"), [{ role: "user", content: "p" }]);
+  assert.deepEqual(buildMessages(undefined, "p"), [{ role: "user", content: "p" }]);
+});
+
+test("G8: parseChatCompletion extracts content and throws on malformed", () => {
+  const { parseChatCompletion } = require("../server/grok/index.js");
+  assert.equal(parseChatCompletion({ choices: [{ message: { content: "hi" } }] }), "hi");
+  assert.throws(() => parseChatCompletion({}), /Parse error/);
+  assert.throws(() => parseChatCompletion({ choices: [] }), /Parse error/);
+  assert.throws(() => parseChatCompletion({ choices: [{ message: {} }] }), /Parse error/);
+});
+
+test("G9: runGrok uses injected fetch (success, http error, missing key)", async () => {
+  const { runGrok } = require("../server/grok/index.js");
+
+  const okFetch = async () => ({
+    ok: true, status: 200,
+    text: async () => JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+  });
+  assert.equal(
+    await runGrok({ messages: [{ role: "user", content: "x" }], apiKey: "k", fetchImpl: okFetch }),
+    "ok"
+  );
+
+  const errFetch = async () => ({ ok: false, status: 500, text: async () => "boom" });
+  await assert.rejects(
+    runGrok({ messages: [], apiKey: "k", fetchImpl: errFetch }),
+    (e) => e.status === 500
+  );
+
+  await assert.rejects(
+    runGrok({ messages: [], apiKey: "", fetchImpl: okFetch }),
+    (e) => e.code === "missing-auth"
+  );
+});

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -396,6 +396,49 @@ test("G19: uploadFile refuses a path outside cwd (no exfiltration, fetch never c
   }
 });
 
+test("G20: resolveReasoningEffort defaults to xhigh and honors overrides", () => {
+  delete process.env.GROK_REASONING_EFFORT;
+  assert.equal(grok.resolveReasoningEffort(undefined), "xhigh");
+  assert.equal(grok.resolveReasoningEffort("low"), "low");
+  assert.equal(grok.resolveReasoningEffort("  high "), "high");
+  assert.equal(grok.resolveReasoningEffort("none"), null);
+  assert.equal(grok.resolveReasoningEffort("off"), null);
+  assert.equal(grok.resolveReasoningEffort(""), null);
+  process.env.GROK_REASONING_EFFORT = "medium";
+  try {
+    assert.equal(grok.resolveReasoningEffort(undefined), "medium");
+    assert.equal(grok.resolveReasoningEffort("high"), "high"); // per-call wins over env
+  } finally {
+    delete process.env.GROK_REASONING_EFFORT;
+  }
+});
+
+test("G21: reasoning_effort is sent (default xhigh), overridable, and omittable", async () => {
+  delete process.env.GROK_REASONING_EFFORT; // ensure the child inherits no override
+  const bodies = [];
+  const { server, base } = await startMock((req, res, body) => {
+    if (req.method === "POST" && req.url === "/v1/responses") {
+      bodies.push(JSON.parse(body));
+      return reply(res, 200, { output: [{ content: [{ type: "output_text", text: "ok" }] }] });
+    }
+    return reply(res, 404, { error: "unexpected" });
+  });
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await rpc.request({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "grok", arguments: { prompt: "a" } } });
+    await rpc.request({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "grok", arguments: { prompt: "b", reasoning_effort: "low" } } });
+    await rpc.request({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "grok", arguments: { prompt: "c", reasoning_effort: "none" } } });
+    assert.equal(bodies[0].reasoning_effort, "xhigh");
+    assert.equal(bodies[1].reasoning_effort, "low");
+    assert.equal("reasoning_effort" in bodies[2], false);
+  } finally {
+    child.stdin.end();
+    server.close();
+  }
+});
+
 // --- files-admin (cleanup) unit tests ---
 
 const admin = require("../server/grok/files-admin.js");

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -4,6 +4,8 @@ const assert = require("node:assert/strict");
 const { spawn } = require("node:child_process");
 const http = require("node:http");
 const path = require("node:path");
+const os = require("node:os");
+const fs = require("node:fs");
 
 const BRIDGE = path.join(__dirname, "..", "server", "grok", "index.js");
 
@@ -43,8 +45,8 @@ function rpcClient(child) {
   };
 }
 
-// Start a localhost mock of the xAI chat/completions endpoint.
-function startMockXai(handler) {
+// Localhost mock of the xAI API. `handler(req, res, body)` routes per endpoint.
+function startMock(handler) {
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
       let body = "";
@@ -58,13 +60,26 @@ function startMockXai(handler) {
   });
 }
 
-test("G1: grok then grok-reply accumulates the transcript", async () => {
-  const received = [];
-  const { server, base } = await startMockXai((req, res, body) => {
-    received.push(JSON.parse(body));
-    const turn = received.length;
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ choices: [{ message: { role: "assistant", content: `reply-${turn}` } }] }));
+function reply(res, status, obj) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(obj));
+}
+
+function lastUserContent(responsesBody) {
+  const input = responsesBody.input;
+  return input[input.length - 1].content;
+}
+
+// --- Integration (spawned bridge + mock /v1/responses + /v1/files) ---
+
+test("G1: grok then grok-reply build /v1/responses input and accumulate turns", async () => {
+  const bodies = [];
+  const { server, base } = await startMock((req, res, body) => {
+    if (req.method === "POST" && req.url === "/v1/responses") {
+      bodies.push(JSON.parse(body));
+      return reply(res, 200, { output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: `reply-${bodies.length}` }] }] });
+    }
+    return reply(res, 404, { error: "unexpected" });
   });
   const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
   const rpc = rpcClient(child);
@@ -75,27 +90,27 @@ test("G1: grok then grok-reply accumulates the transcript", async () => {
       jsonrpc: "2.0", id: 2, method: "tools/call",
       params: { name: "grok", arguments: { prompt: "hello", "developer-instructions": "sys" } },
     });
-    assert.equal(r1.result.isError, undefined, "no error on first call");
+    assert.equal(r1.result.isError, undefined);
     assert.equal(r1.result.content[0].text, "reply-1");
     const threadId = r1.result.threadId;
-    assert.ok(threadId, "threadId returned");
+    assert.ok(threadId);
 
     const r2 = await rpc.request({
       jsonrpc: "2.0", id: 3, method: "tools/call",
       params: { name: "grok-reply", arguments: { threadId, prompt: "again" } },
     });
     assert.equal(r2.result.content[0].text, "reply-2");
-    assert.equal(r2.result.threadId, threadId, "same threadId preserved");
+    assert.equal(r2.result.threadId, threadId);
 
-    assert.deepEqual(received[0].messages, [
-      { role: "system", content: "sys" },
-      { role: "user", content: "hello" },
+    assert.deepEqual(bodies[0].input, [
+      { role: "system", content: [{ type: "input_text", text: "sys" }] },
+      { role: "user", content: [{ type: "input_text", text: "hello" }] },
     ]);
-    assert.deepEqual(received[1].messages, [
-      { role: "system", content: "sys" },
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "reply-1" },
-      { role: "user", content: "again" },
+    assert.deepEqual(bodies[1].input, [
+      { role: "system", content: [{ type: "input_text", text: "sys" }] },
+      { role: "user", content: [{ type: "input_text", text: "hello" }] },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "reply-1" }] },
+      { role: "user", content: [{ type: "input_text", text: "again" }] },
     ]);
   } finally {
     child.stdin.end();
@@ -131,21 +146,14 @@ test("G3: grok-reply on an unknown threadId returns unknown-thread", async () =>
     });
     assert.equal(r.result.isError, true);
     assert.equal(r.result.errorKind, "unknown-thread");
-    assert.equal(r.result.retryable, false);
   } finally {
     child.stdin.end();
   }
 });
 
 test("G4: timeout aborts the call and surfaces errorKind timeout", async () => {
-  // Mock that delays past the call timeout so AbortController fires.
-  const { server, base } = await startMockXai((req, res) => {
-    setTimeout(() => {
-      try {
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ choices: [{ message: { content: "late" } }] }));
-      } catch (_) {}
-    }, 5000);
+  const { server, base } = await startMock((req, res) => {
+    setTimeout(() => { try { reply(res, 200, { output: [{ content: [{ type: "output_text", text: "late" }] }] }); } catch (_) {} }, 5000);
   });
   const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
   const rpc = rpcClient(child);
@@ -164,191 +172,286 @@ test("G4: timeout aborts the call and surfaces errorKind timeout", async () => {
   }
 });
 
-test("G5: tools/list advertises grok and grok-reply", async () => {
+test("G5: tools/list advertises grok + grok-reply, both with a files param", async () => {
   const child = startGrokBridge({ XAI_API_KEY: "test" });
   const rpc = rpcClient(child);
   try {
     const r = await rpc.request({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
-    const names = r.result.tools.map((t) => t.name);
-    assert.deepEqual(names.sort(), ["grok", "grok-reply"]);
+    const tools = r.result.tools;
+    const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+    assert.deepEqual(Object.keys(byName).sort(), ["grok", "grok-reply"]);
+    assert.ok(byName.grok.inputSchema.properties.files, "grok has files param");
+    assert.ok(byName["grok-reply"].inputSchema.properties.files, "grok-reply has files param");
   } finally {
     child.stdin.end();
   }
 });
 
-// --- Pure-function unit tests (bridge required as a module) ---
-
-test("G6: classifyGrokError maps transport codes and HTTP statuses", () => {
-  const { classifyGrokError } = require("../server/grok/index.js");
-  assert.deepEqual(classifyGrokError(null, "missing-auth"), { errorKind: "missing-auth", retryable: false });
-  assert.deepEqual(classifyGrokError(null, "unknown-thread"), { errorKind: "unknown-thread", retryable: false });
-  assert.deepEqual(classifyGrokError(null, "timeout"), { errorKind: "timeout", retryable: true });
-  assert.deepEqual(classifyGrokError(null, "network"), { errorKind: "network", retryable: true });
-  assert.deepEqual(classifyGrokError(null, "parse"), { errorKind: "parse", retryable: false });
-  assert.deepEqual(classifyGrokError(401), { errorKind: "auth", retryable: false });
-  assert.deepEqual(classifyGrokError(403), { errorKind: "auth", retryable: false });
-  assert.deepEqual(classifyGrokError(429), { errorKind: "rate-limit", retryable: true });
-  assert.deepEqual(classifyGrokError(503), { errorKind: "upstream", retryable: true });
-  assert.deepEqual(classifyGrokError(200), { errorKind: "unknown", retryable: false });
-});
-
-test("G7: buildMessages adds system only when developer-instructions present", () => {
-  const { buildMessages } = require("../server/grok/index.js");
-  assert.deepEqual(buildMessages("sys", "p"), [
-    { role: "system", content: "sys" },
-    { role: "user", content: "p" },
-  ]);
-  assert.deepEqual(buildMessages("", "p"), [{ role: "user", content: "p" }]);
-  assert.deepEqual(buildMessages(undefined, "p"), [{ role: "user", content: "p" }]);
-});
-
-test("G8: parseChatCompletion extracts content and throws on malformed", () => {
-  const { parseChatCompletion } = require("../server/grok/index.js");
-  assert.equal(parseChatCompletion({ choices: [{ message: { content: "hi" } }] }), "hi");
-  assert.throws(() => parseChatCompletion({}), /Parse error/);
-  assert.throws(() => parseChatCompletion({ choices: [] }), /Parse error/);
-  assert.throws(() => parseChatCompletion({ choices: [{ message: {} }] }), /Parse error/);
-});
-
-test("G9: runGrok uses injected fetch (success, http error, missing key)", async () => {
-  const { runGrok } = require("../server/grok/index.js");
-
-  const okFetch = async () => ({
-    ok: true, status: 200,
-    text: async () => JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+test("G6: grok with files:[{file_id}] references it in input without uploading", async () => {
+  let filesHits = 0;
+  const bodies = [];
+  const { server, base } = await startMock((req, res, body) => {
+    if (req.method === "POST" && req.url === "/v1/files") { filesHits++; return reply(res, 200, { id: "should-not-happen" }); }
+    if (req.method === "POST" && req.url === "/v1/responses") {
+      bodies.push(JSON.parse(body));
+      return reply(res, 200, { output: [{ content: [{ type: "output_text", text: "ok" }] }] });
+    }
+    return reply(res, 404, { error: "unexpected" });
   });
-  assert.equal(
-    await runGrok({ messages: [{ role: "user", content: "x" }], apiKey: "k", fetchImpl: okFetch }),
-    "ok"
-  );
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "review", files: [{ file_id: "file_abc" }] } },
+    });
+    assert.equal(r.result.isError, undefined);
+    assert.equal(filesHits, 0, "no upload for an existing file_id");
+    assert.deepEqual(lastUserContent(bodies[0]), [
+      { type: "input_text", text: "review" },
+      { type: "input_file", file_id: "file_abc" },
+    ]);
+  } finally {
+    child.stdin.end();
+    server.close();
+  }
+});
+
+test("G7: grok with files:[{path}] uploads then references the returned file_id", async () => {
+  const tmp = path.join(os.tmpdir(), `grok-up-${Date.now()}.txt`);
+  fs.writeFileSync(tmp, "file body");
+  const bodies = [];
+  let filesHits = 0;
+  const { server, base } = await startMock((req, res, body) => {
+    if (req.method === "POST" && req.url === "/v1/files") {
+      filesHits++;
+      return reply(res, 200, { id: "file_up1", object: "file", bytes: 9, created_at: 1762345678, filename: "x", purpose: "assistants" });
+    }
+    if (req.method === "POST" && req.url === "/v1/responses") {
+      bodies.push(JSON.parse(body));
+      return reply(res, 200, { output: [{ content: [{ type: "output_text", text: "done" }] }] });
+    }
+    return reply(res, 404, { error: "unexpected" });
+  });
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "review", files: [{ path: tmp }], cwd: os.tmpdir() } },
+    });
+    assert.equal(r.result.isError, undefined);
+    assert.equal(filesHits, 1);
+    assert.deepEqual(r.result.uploadedFileIds, ["file_up1"]);
+    assert.deepEqual(lastUserContent(bodies[0]), [
+      { type: "input_text", text: "review" },
+      { type: "input_file", file_id: "file_up1" },
+    ]);
+  } finally {
+    child.stdin.end();
+    server.close();
+    fs.rmSync(tmp, { force: true });
+  }
+});
+
+test("G8: a missing file path short-circuits with errorKind file-read", async () => {
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: "http://127.0.0.1:1/v1" });
+  const rpc = rpcClient(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "x", files: [{ path: "/no/such/grok-file-xyz" }] } },
+    });
+    assert.equal(r.result.isError, true);
+    assert.equal(r.result.errorKind, "file-read");
+  } finally {
+    child.stdin.end();
+  }
+});
+
+// --- Unit tests (bridge required as a module) ---
+
+const grok = require("../server/grok/index.js");
+
+test("G9: classifyGrokError maps transport codes and HTTP statuses", () => {
+  assert.deepEqual(grok.classifyGrokError(null, "missing-auth"), { errorKind: "missing-auth", retryable: false });
+  assert.deepEqual(grok.classifyGrokError(null, "unknown-thread"), { errorKind: "unknown-thread", retryable: false });
+  assert.deepEqual(grok.classifyGrokError(null, "timeout"), { errorKind: "timeout", retryable: true });
+  assert.deepEqual(grok.classifyGrokError(null, "file-too-large"), { errorKind: "file-too-large", retryable: false });
+  assert.deepEqual(grok.classifyGrokError(null, "file-read"), { errorKind: "file-read", retryable: false });
+  assert.deepEqual(grok.classifyGrokError(null, "file-upload"), { errorKind: "file-upload", retryable: true });
+  assert.deepEqual(grok.classifyGrokError(401), { errorKind: "auth", retryable: false });
+  assert.deepEqual(grok.classifyGrokError(429), { errorKind: "rate-limit", retryable: true });
+  assert.deepEqual(grok.classifyGrokError(503), { errorKind: "upstream", retryable: true });
+  assert.deepEqual(grok.classifyGrokError(200), { errorKind: "unknown", retryable: false });
+});
+
+test("G10: buildInitialTurns + turnsToInput produce the responses input shape", () => {
+  const turns = grok.buildInitialTurns("sys", "hi", [{ file_id: "f1" }, { file_url: "https://u/x" }]);
+  assert.deepEqual(grok.turnsToInput(turns), [
+    { role: "system", content: [{ type: "input_text", text: "sys" }] },
+    {
+      role: "user",
+      content: [
+        { type: "input_text", text: "hi" },
+        { type: "input_file", file_id: "f1" },
+        { type: "input_file", file_url: "https://u/x" },
+      ],
+    },
+  ]);
+  // No developer-instructions -> no system turn.
+  assert.deepEqual(grok.buildInitialTurns("", "hi", []), [{ role: "user", text: "hi", fileRefs: [] }]);
+});
+
+test("G11: parseResponsesOutput handles output_text, nested output[], and malformed", () => {
+  assert.equal(grok.parseResponsesOutput({ output_text: "quick" }), "quick");
+  assert.equal(grok.parseResponsesOutput({ output: [{ content: [{ type: "output_text", text: "nested" }] }] }), "nested");
+  assert.equal(grok.parseResponsesOutput({ output: [{ content: [{ type: "text", text: "alt" }] }] }), "alt");
+  assert.throws(() => grok.parseResponsesOutput({}), /Parse error/);
+  assert.throws(() => grok.parseResponsesOutput({ output: [] }), /Parse error/);
+  assert.throws(() => grok.parseResponsesOutput({ output: [{ content: [{ type: "image" }] }] }), /Parse error/);
+});
+
+test("G12: validateFiles enforces exactly-one-of and types", () => {
+  assert.equal(grok.validateFiles(undefined), null);
+  assert.equal(grok.validateFiles([{ path: "a" }]), null);
+  assert.equal(grok.validateFiles([{ file_id: "f" }]), null);
+  assert.ok(grok.validateFiles("nope"));
+  assert.ok(grok.validateFiles([{ path: "a", file_id: "b" }]));
+  assert.ok(grok.validateFiles([{}]));
+  assert.ok(grok.validateFiles([{ path: "" }]));
+  assert.ok(grok.validateFiles([{ path: "a", filename: "" }]));
+});
+
+test("G13: runGrok posts to /responses via injected fetch (success, http error, missing key)", async () => {
+  let calledUrl = null;
+  const okFetch = async (url) => {
+    calledUrl = url;
+    return { ok: true, status: 200, text: async () => JSON.stringify({ output: [{ content: [{ type: "output_text", text: "ok" }] }] }) };
+  };
+  const out = await grok.runGrok({ turns: [{ role: "user", text: "x", fileRefs: [] }], apiKey: "k", apiBase: "https://api.x.ai/v1", fetchImpl: okFetch });
+  assert.equal(out.text, "ok");
+  assert.match(calledUrl, /\/responses$/);
 
   const errFetch = async () => ({ ok: false, status: 500, text: async () => "boom" });
-  await assert.rejects(
-    runGrok({ messages: [], apiKey: "k", fetchImpl: errFetch }),
-    (e) => e.status === 500
-  );
+  await assert.rejects(grok.runGrok({ turns: [], apiKey: "k", fetchImpl: errFetch }), (e) => e.status === 500);
 
-  await assert.rejects(
-    runGrok({ messages: [], apiKey: "", fetchImpl: okFetch }),
-    (e) => e.code === "missing-auth"
-  );
+  await assert.rejects(grok.runGrok({ turns: [], apiKey: "", fetchImpl: okFetch }), (e) => e.code === "missing-auth");
 });
 
-// --- Process-lifecycle + observability tests (F2 / F3) ---
-
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-// Accumulate the child's stderr so we can assert on the F3 log lines and the
-// F2 fatal-guard messages.
-function collectStderr(child) {
-  const ref = { text: "" };
-  child.stderr.on("data", (d) => (ref.text += d.toString()));
-  return ref;
-}
-
-// Resolve with the child's exit code (or signal) once it terminates.
-function waitExit(child) {
-  return new Promise((resolve) => {
-    child.on("exit", (code, signal) => resolve({ code, signal }));
-  });
-}
-
-test("G10: F3 emits one stderr correlation line per call; stdout stays JSON-RPC", async () => {
-  const { server, base } = await startMockXai((req, res, body) => {
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ choices: [{ message: { content: "ok" } }] }));
-  });
-  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
-  const rpc = rpcClient(child);
-  const err = collectStderr(child);
-  let stdout = "";
-  child.stdout.on("data", (d) => (stdout += d.toString()));
+test("G14: uploadFile sends multipart with purpose, expires_after, and prefixed filename", async () => {
+  const tmp = path.join(os.tmpdir(), `grok-unit-${Date.now()}.md`);
+  fs.writeFileSync(tmp, "hello");
+  let captured = null;
+  const fetchImpl = async (url, opts) => {
+    captured = { url, opts };
+    return { ok: true, status: 200, text: async () => JSON.stringify({ id: "file_x", filename: "n" }) };
+  };
   try {
-    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
-    await rpc.request({
-      jsonrpc: "2.0", id: 2, method: "tools/call",
-      params: { name: "grok", arguments: { prompt: "hi" } },
-    });
-    await sleep(20); // let the finally-block stderr write flush
-    assert.match(err.text, /^\[grok\] 2 grok -> ok in \d+ms$/m, "one ok correlation line for id 2");
-    assert.equal(stdout.includes("[grok]"), false, "stdout never carries the log prefix");
+    const res = await grok.uploadFile({ filePath: tmp, apiKey: "k", apiBase: "https://api.x.ai/v1", cwd: os.tmpdir(), fetchImpl });
+    assert.equal(res.id, "file_x");
+    assert.match(captured.url, /\/files$/);
+    const form = captured.opts.body;
+    assert.equal(form.get("purpose"), "assistants");
+    assert.equal(form.get("expires_after"), String(grok.FILE_TTL_SECONDS));
+    const filePart = form.get("file");
+    assert.ok(filePart.name.startsWith(grok.FILE_PREFIX), `filename ${filePart.name} should carry the prefix`);
+    assert.ok(filePart.name.endsWith(path.basename(tmp)));
+    // No manual Content-Type (fetch sets the multipart boundary).
+    assert.equal(captured.opts.headers["Content-Type"], undefined);
   } finally {
-    child.stdin.end();
-    server.close();
+    fs.rmSync(tmp, { force: true });
   }
 });
 
-test("G11: F2 uncaughtException is logged with a stack and exits non-zero", async () => {
-  // GROK_TEST_THROW_ASYNC schedules a real async throw ~30ms after start. After
-  // an uncaught throw the process state is undefined, so the bridge logs and
-  // exits 1 (the host then restarts it); it does NOT try to keep serving.
-  const child = startGrokBridge({ XAI_API_KEY: "test", GROK_TEST_THROW_ASYNC: "1" });
-  const err = collectStderr(child);
-  const { code } = await waitExit(child);
-  assert.equal(code, 1, "uncaught throw is fatal -> exit 1");
-  assert.match(err.text, /fatal-guard uncaughtException:.*async boom/s);
-});
-
-test("G12: F2 stdin 'error' (broken pipe) exits 1", async () => {
-  const child = startGrokBridge({ XAI_API_KEY: "test", GROK_TEST_EMIT_STDIN_ERROR: "1" });
-  const err = collectStderr(child);
-  const { code } = await waitExit(child);
-  assert.equal(code, 1, "broken input pipe is terminal");
-  assert.match(err.text, /stdin error \(input pipe broken\)/);
-});
-
-test("G13: F2 clean EOF drains an in-flight call, then exits 0", async () => {
-  // Mock holds the response so EOF lands while the call is in flight.
-  const { server, base } = await startMockXai((req, res) => {
-    setTimeout(() => {
-      try {
-        // Connection: close so the bridge's HTTP socket dies after the response
-        // and does not linger in the keep-alive pool, letting the process exit
-        // promptly once stdin has ended.
-        res.writeHead(200, { "content-type": "application/json", "connection": "close" });
-        res.end(JSON.stringify({ choices: [{ message: { content: "slow-ok" } }] }));
-      } catch (_) {}
-    }, 200);
-  });
-  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
-  const rpc = rpcClient(child);
-  const exited = waitExit(child);
+test("G15: uploadFile rejects an oversize file with file-too-large", async () => {
+  const tmp = path.join(os.tmpdir(), `grok-big-${Date.now()}.bin`);
+  // Sparse 49 MB file: ftruncate sets size without writing 49 MB of data.
+  const fd = fs.openSync(tmp, "w");
+  fs.ftruncateSync(fd, 49 * 1024 * 1024);
+  fs.closeSync(fd);
   try {
-    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
-    const callPromise = rpc.request({
-      jsonrpc: "2.0", id: 2, method: "tools/call",
-      params: { name: "grok", arguments: { prompt: "slow" } },
-    });
-    await sleep(50);          // call is now in flight (mock not resolved yet)
-    child.stdin.end();        // clean EOF arrives mid-call
-    const r = await callPromise;
-    assert.equal(r.result.content[0].text, "slow-ok", "in-flight response still delivered");
-    const { code } = await exited;
-    assert.equal(code, 0, "exits 0 after draining the in-flight call");
+    await assert.rejects(
+      grok.uploadFile({ filePath: tmp, apiKey: "k", cwd: os.tmpdir(), fetchImpl: async () => { throw new Error("should not reach fetch"); } }),
+      (e) => e.code === "file-too-large"
+    );
   } finally {
-    server.close();
+    fs.rmSync(tmp, { force: true });
   }
 });
 
-test("G14: a final line with no trailing newline is flushed on EOF", async () => {
-  const child = startGrokBridge({ XAI_API_KEY: "test" });
-  const exited = waitExit(child);
-  let resolve;
-  const got = new Promise((r) => (resolve = r));
-  let out = "";
-  child.stdout.on("data", (d) => {
-    out += d.toString();
-    for (const line of out.split("\n")) {
-      if (!line.trim()) continue;
-      try { const m = JSON.parse(line); if (m.id === 1) resolve(m); } catch (_) {}
+test("G19: uploadFile refuses a path outside cwd (no exfiltration, fetch never called)", async () => {
+  const tmp = path.join(os.tmpdir(), `grok-out-${Date.now()}.txt`);
+  fs.writeFileSync(tmp, "secret");
+  try {
+    await assert.rejects(
+      grok.uploadFile({ filePath: tmp, apiKey: "k", cwd: __dirname, fetchImpl: async () => { throw new Error("should not reach fetch"); } }),
+      (e) => e.code === "file-read"
+    );
+  } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+});
+
+// --- files-admin (cleanup) unit tests ---
+
+const admin = require("../server/grok/files-admin.js");
+
+test("G16: parseOlderThan understands s/m/h/d and plain seconds", () => {
+  assert.equal(admin.parseOlderThan("30m"), 1800);
+  assert.equal(admin.parseOlderThan("24h"), 86400);
+  assert.equal(admin.parseOlderThan("7d"), 604800);
+  assert.equal(admin.parseOlderThan("90"), 90);
+  assert.equal(admin.parseOlderThan("0h"), 0);
+  assert.throws(() => admin.parseOlderThan("soon"));
+});
+
+test("G17: selectPrunable keeps only prefixed files older than the cutoff", () => {
+  const now = 1_000_000; // epoch seconds
+  const files = [
+    { id: "a", filename: "claude-delegator-1-old.txt", created_at: now - 1000 },   // prefixed + old -> prune
+    { id: "b", filename: "claude-delegator-2-new.txt", created_at: now - 10 },     // prefixed + new -> keep
+    { id: "c", filename: "user-doc.pdf", created_at: now - 100000 },               // not prefixed -> keep
+  ];
+  const out = admin.selectPrunable(files, { cutoffEpochSec: now - 100 });
+  assert.deepEqual(out.map((f) => f.id), ["a"]);
+  // Safety floor: even prefix "" can never select the non-bridge file "c".
+  const all = admin.selectPrunable(files, { prefix: "", cutoffEpochSec: now });
+  assert.deepEqual(all.map((f) => f.id), ["a", "b"]);
+});
+
+test("G18: prune lists, filters, and deletes only prunable ids when not a dry run", async () => {
+  const nowMs = 2_000_000_000_000;
+  const nowSec = Math.floor(nowMs / 1000);
+  const deleted = [];
+  const fetchImpl = async (url, opts) => {
+    if (opts.method === "GET") {
+      return { ok: true, status: 200, text: async () => JSON.stringify({
+        data: [
+          { id: "old", filename: "claude-delegator-x.txt", created_at: nowSec - 100000 },
+          { id: "fresh", filename: "claude-delegator-y.txt", created_at: nowSec - 1 },
+          { id: "theirs", filename: "report.pdf", created_at: 1 },
+        ],
+        pagination_token: null,
+      }) };
     }
-  });
-  // Write a complete request WITHOUT a trailing newline, then EOF. The bridge
-  // must flush the buffered tail line before draining.
-  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }));
-  child.stdin.end();
-  const msg = await got;
-  assert.ok(msg.result, "EOF-flushed initialize is still answered");
-  const { code } = await exited;
-  assert.equal(code, 0, "exits 0 cleanly after the flush");
+    if (opts.method === "DELETE") {
+      deleted.push(decodeURIComponent(url.split("/files/")[1]));
+      return { ok: true, status: 200, text: async () => JSON.stringify({ deleted: true }) };
+    }
+    return { ok: false, status: 405, text: async () => "no" };
+  };
+  const res = await admin.prune({ olderThanSec: 3600, apiKey: "k", apiBase: "https://api.x.ai/v1", fetchImpl, dryRun: false, now: nowMs });
+  assert.deepEqual(res.candidates.map((f) => f.id), ["old"]);
+  assert.deepEqual(deleted, ["old"]);
+
+  // Dry run deletes nothing.
+  deleted.length = 0;
+  const dry = await admin.prune({ olderThanSec: 3600, apiKey: "k", apiBase: "https://api.x.ai/v1", fetchImpl, dryRun: true, now: nowMs });
+  assert.deepEqual(dry.candidates.map((f) => f.id), ["old"]);
+  assert.deepEqual(dry.deleted, []);
+  assert.deepEqual(deleted, []);
 });

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -233,3 +233,122 @@ test("G9: runGrok uses injected fetch (success, http error, missing key)", async
     (e) => e.code === "missing-auth"
   );
 });
+
+// --- Process-lifecycle + observability tests (F2 / F3) ---
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Accumulate the child's stderr so we can assert on the F3 log lines and the
+// F2 fatal-guard messages.
+function collectStderr(child) {
+  const ref = { text: "" };
+  child.stderr.on("data", (d) => (ref.text += d.toString()));
+  return ref;
+}
+
+// Resolve with the child's exit code (or signal) once it terminates.
+function waitExit(child) {
+  return new Promise((resolve) => {
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+test("G10: F3 emits one stderr correlation line per call; stdout stays JSON-RPC", async () => {
+  const { server, base } = await startMockXai((req, res, body) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ choices: [{ message: { content: "ok" } }] }));
+  });
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  const err = collectStderr(child);
+  let stdout = "";
+  child.stdout.on("data", (d) => (stdout += d.toString()));
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "hi" } },
+    });
+    await sleep(20); // let the finally-block stderr write flush
+    assert.match(err.text, /^\[grok\] 2 grok -> ok in \d+ms$/m, "one ok correlation line for id 2");
+    assert.equal(stdout.includes("[grok]"), false, "stdout never carries the log prefix");
+  } finally {
+    child.stdin.end();
+    server.close();
+  }
+});
+
+test("G11: F2 uncaughtException is logged with a stack and exits non-zero", async () => {
+  // GROK_TEST_THROW_ASYNC schedules a real async throw ~30ms after start. After
+  // an uncaught throw the process state is undefined, so the bridge logs and
+  // exits 1 (the host then restarts it); it does NOT try to keep serving.
+  const child = startGrokBridge({ XAI_API_KEY: "test", GROK_TEST_THROW_ASYNC: "1" });
+  const err = collectStderr(child);
+  const { code } = await waitExit(child);
+  assert.equal(code, 1, "uncaught throw is fatal -> exit 1");
+  assert.match(err.text, /fatal-guard uncaughtException:.*async boom/s);
+});
+
+test("G12: F2 stdin 'error' (broken pipe) exits 1", async () => {
+  const child = startGrokBridge({ XAI_API_KEY: "test", GROK_TEST_EMIT_STDIN_ERROR: "1" });
+  const err = collectStderr(child);
+  const { code } = await waitExit(child);
+  assert.equal(code, 1, "broken input pipe is terminal");
+  assert.match(err.text, /stdin error \(input pipe broken\)/);
+});
+
+test("G13: F2 clean EOF drains an in-flight call, then exits 0", async () => {
+  // Mock holds the response so EOF lands while the call is in flight.
+  const { server, base } = await startMockXai((req, res) => {
+    setTimeout(() => {
+      try {
+        // Connection: close so the bridge's HTTP socket dies after the response
+        // and does not linger in the keep-alive pool, letting the process exit
+        // promptly once stdin has ended.
+        res.writeHead(200, { "content-type": "application/json", "connection": "close" });
+        res.end(JSON.stringify({ choices: [{ message: { content: "slow-ok" } }] }));
+      } catch (_) {}
+    }, 200);
+  });
+  const child = startGrokBridge({ XAI_API_KEY: "test", XAI_API_BASE: base });
+  const rpc = rpcClient(child);
+  const exited = waitExit(child);
+  try {
+    await rpc.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const callPromise = rpc.request({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "grok", arguments: { prompt: "slow" } },
+    });
+    await sleep(50);          // call is now in flight (mock not resolved yet)
+    child.stdin.end();        // clean EOF arrives mid-call
+    const r = await callPromise;
+    assert.equal(r.result.content[0].text, "slow-ok", "in-flight response still delivered");
+    const { code } = await exited;
+    assert.equal(code, 0, "exits 0 after draining the in-flight call");
+  } finally {
+    server.close();
+  }
+});
+
+test("G14: a final line with no trailing newline is flushed on EOF", async () => {
+  const child = startGrokBridge({ XAI_API_KEY: "test" });
+  const exited = waitExit(child);
+  let resolve;
+  const got = new Promise((r) => (resolve = r));
+  let out = "";
+  child.stdout.on("data", (d) => {
+    out += d.toString();
+    for (const line of out.split("\n")) {
+      if (!line.trim()) continue;
+      try { const m = JSON.parse(line); if (m.id === 1) resolve(m); } catch (_) {}
+    }
+  });
+  // Write a complete request WITHOUT a trailing newline, then EOF. The bridge
+  // must flush the buffered tail line before draining.
+  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }));
+  child.stdin.end();
+  const msg = await got;
+  assert.ok(msg.result, "EOF-flushed initialize is still answered");
+  const { code } = await exited;
+  assert.equal(code, 0, "exits 0 cleanly after the flush");
+});

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -396,9 +396,9 @@ test("G19: uploadFile refuses a path outside cwd (no exfiltration, fetch never c
   }
 });
 
-test("G20: resolveReasoningEffort defaults to xhigh and honors overrides", () => {
+test("G20: resolveReasoningEffort defaults to high and honors overrides", () => {
   delete process.env.GROK_REASONING_EFFORT;
-  assert.equal(grok.resolveReasoningEffort(undefined), "xhigh");
+  assert.equal(grok.resolveReasoningEffort(undefined), "high");
   assert.equal(grok.resolveReasoningEffort("low"), "low");
   assert.equal(grok.resolveReasoningEffort("  high "), "high");
   assert.equal(grok.resolveReasoningEffort("none"), null);
@@ -413,7 +413,7 @@ test("G20: resolveReasoningEffort defaults to xhigh and honors overrides", () =>
   }
 });
 
-test("G21: reasoning_effort is sent (default xhigh), overridable, and omittable", async () => {
+test("G21: reasoning_effort is sent (default high), overridable, and omittable", async () => {
   delete process.env.GROK_REASONING_EFFORT; // ensure the child inherits no override
   const bodies = [];
   const { server, base } = await startMock((req, res, body) => {
@@ -430,7 +430,7 @@ test("G21: reasoning_effort is sent (default xhigh), overridable, and omittable"
     await rpc.request({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "grok", arguments: { prompt: "a" } } });
     await rpc.request({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "grok", arguments: { prompt: "b", reasoning_effort: "low" } } });
     await rpc.request({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "grok", arguments: { prompt: "c", reasoning_effort: "none" } } });
-    assert.equal(bodies[0].reasoning_effort, "xhigh");
+    assert.equal(bodies[0].reasoning_effort, "high");
     assert.equal(bodies[1].reasoning_effort, "low");
     assert.equal("reasoning_effort" in bodies[2], false);
   } finally {


### PR DESCRIPTION
## Summary

Adds **Grok (xAI)** as a third delegation provider alongside Codex (GPT) and Gemini, then extends it with **file support** and a **storage cleanup** path. Bundled as a zero-dependency Node MCP bridge - no new runtime dependencies.

## What's included

**Provider (commits `7f222ee`, `9fa4c7f`)**
- `server/grok/index.js` - stdio JSON-RPC MCP bridge over the xAI HTTP API. Tools `grok` + `grok-reply` (in-memory `threadId` sessions), structured `errorKind` classification, env-overridable `GROK_DEFAULT_MODEL` (default `grok-4.3`) / `XAI_API_BASE`.
- `/ask-grok` command (advisory second opinion).
- `/ask-both` renamed to `/ask-all` - fans out to GPT + Gemini + Grok in parallel with a 3-way verdict comparison and per-provider failure isolation.
- `/consensus` extended to a 4-way convergence loop (GPT + Gemini + Grok + Claude).
- Chosen as an HTTP-API bridge (not a CLI wrapper) because the Grok CLI has no MCP server mode; both GPT and Gemini independently recommended this in a `/ask-both` consult.

**File support (commit `96c61c9`)**
- Migrated the bridge from `/v1/chat/completions` to **`/v1/responses`** (file attachments only work there).
- `grok` / `grok-reply` gain a `files` param: `[{path}]` (bridge uploads via the xAI Files API using zero-dep `FormData`), `[{file_id}]`, or `[{file_url}]`.
- Uploads are tagged `claude-delegator-<ts>-*` and carry `expires_after` (default **7 days**, `GROK_FILE_TTL_SECONDS`, clamped 1h..30d) so they self-delete.
- `server/grok/files-admin.js` + `/grok-files` - list/prune cleanup. Prune is dry-run by default and prefix-floored so it can only ever touch bridge-owned files.
- `/ask-all` and `/consensus` wire files per provider: Grok uploads via `files`; GPT/Gemini read the named path from `cwd`.

## Design notes

- The bridge owns conversation state and replays the server's own `output` items verbatim for multi-turn (avoids guessing the beta Responses input shape).
- Advisory-only: Grok cannot edit files (HTTP API), which is why file-editing delegation still routes to GPT/Gemini.
- Plugin + marketplace bumped to `1.8.0`; `grok`/`xai`/`files` keywords added.

## Cross-review

The file-support diff was reviewed by GPT + Gemini + Grok as Code Reviewer. All CRITICAL/HIGH/MEDIUM findings were fixed, including:
- **Path traversal**: `uploadFile` now enforces a containment check under `cwd`, blocking absolute/`../` paths from exfiltrating arbitrary local files to xAI (regression test added).
- `expires_after` appended before the file part; uploaded file id validated; pagination terminates on a short page; prune tolerates per-file delete failures.

## Testing

- `test/grok.test.js` - 19 Grok tests via a localhost mock of `/v1/responses` and the Files API, plus injected-fetch unit tests. No real network or API key required.
- `npm test` (`node --test test/*.test.js`): **46/46 pass** (Grok + existing Gemini bridge tests).
- Bridge handshake verified: `initialize` reports `serverInfo.version 1.8.0`.

## Test plan (maintainer)

- [ ] `npm test` green locally.
- [ ] With a real `XAI_API_KEY`: run `/claude-delegator:setup`, restart, then `/ask-grok` on a question and on a local file; confirm `/ask-all` returns a 3-way comparison.
- [ ] `node server/grok/files-admin.js list` shows the upload; `prune --older-than 0h --yes` deletes it.