### PR TITLE
docs: restructure README as front door + add TECHNICAL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,50 @@
 # Claude Delegator
 
-GPT (Codex), Gemini, and Grok (xAI) expert subagents for Claude Code. Five specialists that can analyze AND implement: architecture, plan review, scope, code review, security. Use any of the three providers, single-shot or multi-turn, advisory or implementation (Grok is advisory-only).
+GPT (Codex), Gemini, and Grok (xAI) expert subagents for Claude Code. Five specialists that can analyze and implement: architecture, plan review, scope, code review, and security. Use any of the three providers, single-shot or multi-turn, advisory or implementation (Grok is advisory-only).
 
 [![License](https://img.shields.io/github/license/antonbabenko/claude-delegator?v=2)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/antonbabenko/claude-delegator?v=2)](https://github.com/antonbabenko/claude-delegator/stargazers)
 
 ![Claude Delegator in action](claude-delegator.png)
 
-> Maintained fork of [`jarrodwatts/claude-delegator`](https://github.com/jarrodwatts/claude-delegator)
-> (upstream currently inactive). Original work and MIT copyright by Jarrod
-> Watts; this fork adds: a third provider (Grok via a bundled xAI bridge, with
-> file attachments + storage cleanup), Gemini bridge timeout / trust-recovery /
-> JSON-parsing robustness, `GEMINI_DEFAULT_MODEL` / `GROK_DEFAULT_MODEL` env
-> overrides, and the bundled delegation commands below (the former `ask-both` is
-> now `ask-all`, covering all three providers). Not an official continuation of
-> the upstream project.
+## What is Claude Delegator?
+
+Claude gains a team of GPT, Gemini, and Grok specialists over MCP: GPT through the Codex CLI's native MCP server, Gemini through a bundled MCP bridge, and Grok through a bundled bridge over the xAI HTTP API. Each expert has a distinct specialty and can advise or implement (Grok is advisory-only).
+
+You can use any subset of the three providers. The plugin detects which are configured and routes accordingly.
+
+| What you get | Why it matters |
+|--------------|----------------|
+| 5 domain experts | The right specialist for each problem type |
+| GPT, Gemini, or Grok | Use your preferred provider(s) |
+| Dual mode | Experts analyze (read-only) or implement (write) |
+| Auto-routing | Claude detects when to delegate from your request |
+| Synthesized responses | Claude interprets expert output, never raw passthrough |
 
 ## Install
 
-Inside a Claude Code instance, run the following commands:
+Inside a Claude Code instance, run:
 
-**Step 1: Add the marketplace**
+**1. Add the marketplace**
 ```
 /plugin marketplace add antonbabenko/claude-delegator
 ```
 
-**Step 2: Install the plugin**
+**2. Install the plugin**
 ```
 /plugin install claude-delegator
 ```
 
-**Step 3: Run setup**
+**3. Run setup**
 ```
 /claude-delegator:setup
 ```
 
-Done! Claude now routes complex tasks to your GPT (Codex), Gemini, and/or Grok experts automatically.
+Claude now routes complex tasks to your GPT, Gemini, and Grok experts.
 
-> **Note**: Requires at least one provider - [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google/gemini-cli), or Grok (no CLI to install; just set `XAI_API_KEY`). Setup guides you through installation.
+> Requires at least one provider: [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google/gemini-cli), or Grok (no CLI to install; just set `XAI_API_KEY`). Setup walks you through it.
+
+You can also install from the [agent-plugins marketplace](https://github.com/antonbabenko/agent-plugins): run `/plugin marketplace add antonbabenko/agent-plugins`, then `/plugin install claude-delegator@antonbabenko`.
 
 ## Commands
 
@@ -54,43 +61,11 @@ Bundled with the plugin (available once installed):
 | `/claude-delegator:consensus` | Iterate GPT + Gemini + Grok + Claude to consensus |
 | `/claude-delegator:grok-files` | List or prune Grok-uploaded files (storage cleanup) |
 
-`/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`,
-`/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/` (opt-in; never
-overwrites an existing same-named command). `/uninstall` removes an alias
-only if it is byte-identical to the bundled copy, so an unrelated same-named
-command you authored is left untouched.
+`/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/`. This is opt-in and never overwrites an existing same-named command; `/uninstall` removes an alias only if it is byte-identical to the bundled copy.
 
----
+## The Experts
 
-## What is Claude Delegator?
-
-Claude gains a team of GPT, Gemini, and Grok specialists via MCP: GPT through the Codex CLI's native MCP server, Gemini through the bundled Gemini MCP bridge, and Grok through a bundled bridge over the xAI HTTP API. Each expert has a distinct specialty and can advise OR implement (Grok is advisory-only).
-
-**Note:** You can use any subset of the three providers (GPT, Gemini, Grok). The plugin auto-detects which are configured and routes accordingly.
-
-### Features
-
-- **Three providers, one interface** - GPT via the Codex CLI, Gemini and Grok via bundled zero-dependency Node bridges (Grok over the xAI HTTP API, advisory-only). Mix them or run just one.
-- **Five domain experts** - Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst. Each has a dedicated system prompt in `prompts/`.
-- **Advisory or implementation** - every expert runs read-only for analysis or `workspace-write` to apply fixes. Mode is auto-selected from your request.
-- **Auto-routing** - Claude reads your message, picks the expert, and delegates. No manual selection needed; explicit "ask GPT/Gemini to..." also works.
-- **Multi-turn chaining** - the initial call returns a `threadId`; follow-up `*-reply` calls preserve full context for iterative implementation and retries.
-- **Synthesized output** - Claude interprets and applies judgment to expert results; raw provider text is never passed through verbatim.
-- **Gemini bridge resilience** - soft-timeout drain that recovers disk-flushed answers (`recovered: true`), structured trust-failure errors the orchestration retries with `skip-trust` (or sets preflight), and hardened JSON parsing. `GEMINI_DEFAULT_MODEL` env overrides the model.
-- **Grok bridge** - bundled zero-dependency Node bridge over the xAI **Responses API** (`/v1/responses`). Advisory-only (it cannot edit files) but it **can read attached files** - pass `files:[{path|file_id|file_url}]` and the bridge uploads to the xAI Files API and references them. Uploads are tagged `claude-delegator-*` and carry `expires_after` (default 7 days, `GROK_FILE_TTL_SECONDS`); prune early with `/grok-files`. Needs `XAI_API_KEY`; `GROK_DEFAULT_MODEL` (default `grok-4.3`) and `XAI_API_BASE` also override model/endpoint.
-- **Bundled delegation commands** - `ask-gpt`, `ask-gemini`, `ask-grok`, `ask-all` (parallel + synthesized), and `consensus` (GPT + Gemini + Grok + Claude iterate to agreement) ship with the plugin.
-
-| What You Get | Why It Matters |
-|--------------|----------------|
-| **5 domain experts** | Right specialist for each problem type |
-| **GPT, Gemini, or Grok** | Use your preferred model provider(s) |
-| **Dual mode** | Experts can analyze (read-only) or implement (write) |
-| **Auto-routing** | Claude detects when to delegate based on your request |
-| **Synthesized responses** | Claude interprets expert output, never raw passthrough |
-
-### The Experts
-
-| Expert | What They Do | Example Triggers |
+| Expert | What they do | Example triggers |
 |--------|--------------|------------------|
 | **Architect** | System design, tradeoffs, complex debugging | "How should I structure this?" / "What are the tradeoffs?" |
 | **Plan Reviewer** | Validate plans before you start | "Review this migration plan" / "Is this approach sound?" |
@@ -98,212 +73,101 @@ Claude gains a team of GPT, Gemini, and Grok specialists via MCP: GPT through th
 | **Code Reviewer** | Find bugs, improve quality | "Review this PR" / "What's wrong with this?" |
 | **Security Analyst** | Vulnerabilities, threat modeling | "Is this secure?" / "Harden this endpoint" |
 
-### When Experts Help Most
+### When experts help most
 
 - **Architecture decisions** - "Should I use Redis or in-memory caching?"
-- **Stuck debugging** - After 2+ failed attempts, get a fresh perspective
-- **Pre-implementation** - Validate your plan before writing code
+- **Stuck debugging** - after two or more failed attempts, get a fresh perspective
+- **Pre-implementation** - validate a plan before writing code
 - **Security concerns** - "Is this auth flow safe?"
-- **Code quality** - Get a second opinion on your implementation
+- **Code quality** - a second opinion on your implementation
 
-### When NOT to Use Experts
+### When not to use experts
 
 - Simple file operations (Claude handles these directly)
 - First attempt at any fix (try yourself first)
 - Trivial questions (no need to delegate)
 
----
+## How to Use
+
+Describe your task. Claude detects when an expert helps and delegates automatically:
+
+```
+You: "Is this authentication flow secure?"
+Claude: routes to the Security Analyst, then synthesizes the findings.
+```
+
+You can also ask explicitly: "Ask GPT to review this architecture", "Ask Gemini to...", or "Ask Grok to...". Each expert runs read-only for analysis or with write access to apply fixes, and Claude picks the mode from your request (Grok is advisory-only).
+
+The bundled commands give you direct control: `/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all` (all three in parallel, synthesized), and `/consensus` (the providers and Claude iterate to agreement).
 
 ## How It Works
 
 ```
 You: "Is this authentication flow secure?"
-                    ↓
-Claude: [Detects security question → selects Security Analyst]
-                    ↓
-        ┌───────────────────────────────┐
-        │  mcp__codex__codex /          │
-        │  mcp__gemini__gemini /        │
-        │  mcp__grok__grok              │
-        │  → Security Analyst prompt    │
-        │  → Expert analyzes your code  │
-        └───────────────────────────────┘
-                    ↓
-Claude: "Based on the analysis, I found 3 issues..."
-        [Synthesizes response, applies judgment]
+                |
+                v
+Claude: detects a security question, selects the Security Analyst
+                |
+                v
+   +-------------------------------------+
+   |  mcp__codex__codex /                |
+   |  mcp__gemini__gemini /              |
+   |  mcp__grok__grok                    |
+   |    -> Security Analyst prompt       |
+   |    -> expert analyzes your code     |
+   +-------------------------------------+
+                |
+                v
+Claude: "I found 3 issues..." (synthesizes, applies judgment)
 ```
 
-**Key details:**
-- Each expert has a specialized system prompt (in `prompts/`)
-- Claude reads your request → picks the right expert → delegates via MCP (GPT, Gemini, or Grok)
-- Responses are synthesized, not passed through raw
-- Implementation retries up to 3 attempts total (1 initial + 2 `*-reply` retries), then escalates to you
-- Multi-turn conversations preserve context via `threadId` for chained tasks
+- Each expert has a specialized system prompt (in `prompts/`).
+- Claude reads your request, picks the expert, and delegates over MCP.
+- Responses are synthesized, not passed through raw.
+- Multi-turn conversations preserve context via `threadId` for chained work, and implementation retries before escalating to you.
 
-### Multi-Turn Conversations
-
-For chained implementation steps, the expert preserves context across turns:
-
-```
-Turn 1: mcp__*__* → returns threadId
-Turn 2: mcp__*__*-reply(threadId) → expert remembers turn 1
-Turn 3: mcp__*__*-reply(threadId) → expert remembers turns 1-2
-```
-
-Use single-shot (`codex`, `gemini`, or `grok`) for advisory tasks. Use multi-turn for implementation chains and retries. (Grok is advisory-only.)
-
----
+For the bridge internals, retry behavior, and recovery paths, see [TECHNICAL.md](TECHNICAL.md).
 
 ## Configuration
 
-### Operating Modes
+Every expert supports two modes, chosen automatically from your request:
 
-Every expert supports two modes based on the task:
-
-| Mode | Sandbox | Use When |
+| Mode | Sandbox | Use when |
 |------|---------|----------|
-| **Advisory** | `read-only` | Analysis, recommendations, reviews |
-| **Implementation** | `workspace-write` | Making changes, fixing issues |
+| Advisory | `read-only` | Analysis, recommendations, reviews |
+| Implementation | `workspace-write` | Making changes, fixing issues |
 
-Claude automatically selects the mode based on your request.
+Common defaults:
 
-### Configuration Defaults
+- Codex (GPT) reads `~/.codex/config.toml` for its sandbox and approval defaults.
+- Gemini defaults to `gemini-2.5-flash`; override with `GEMINI_DEFAULT_MODEL`.
+- Grok defaults to `grok-4.3` and needs `XAI_API_KEY`; override with `GROK_DEFAULT_MODEL`.
 
-**Codex (GPT):** set global defaults in `~/.codex/config.toml` instead of passing parameters on every call:
-
-```toml
-sandbox_mode = "workspace-write"
-approval_policy = "on-failure"
-```
-
-Per-call parameters override these defaults. See [Codex CLI docs](https://github.com/openai/codex) for all config options.
-
-**Gemini:** the bridge defaults to `gemini-2.5-flash` (it does not read the Gemini CLI's `~/.gemini/settings.json`). Override per call with the `model` parameter, or globally with the `GEMINI_DEFAULT_MODEL` environment variable - set this if you want a different default model.
-
-**Grok:** the bridge defaults to `grok-4.3`. Override per call with the `model` parameter, or globally with `GROK_DEFAULT_MODEL`. The endpoint defaults to `https://api.x.ai/v1`; override with `XAI_API_BASE`. Grok needs `XAI_API_KEY` in the bridge's environment and is advisory-only (it can read attached files, but cannot edit them).
-
-**Reasoning effort** is controllable: the bridge sends a `reasoning_effort` on every `/v1/responses` call, defaulting to **`high`**. Override per call with the `reasoning_effort` parameter, or globally with the `GROK_REASONING_EFFORT` env var (for example `low`, `medium`, `high`); set it to `none` (or `off`) to omit the field entirely and let the model use its own default. Valid values depend on the chosen model - an unsupported value surfaces the xAI API error verbatim. Uploaded files auto-expire after `GROK_FILE_TTL_SECONDS` (default `604800` = 7 days, clamped 1h..30d); prune early with `/grok-files`.
-
-### Manual MCP Setup
-
-If `/setup` doesn't work, register the MCP server(s) manually:
-
-```bash
-# For Codex (GPT)
-# Idempotent: safe to rerun
-claude mcp remove codex >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user codex -- codex -m gpt-5.3-codex mcp-server
-
-# For Gemini
-# Idempotent: safe to rerun
-claude mcp remove gemini >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
-
-# For Grok (xAI) - API-based, advisory-only. Needs XAI_API_KEY.
-# Idempotent: safe to rerun. --env persists the key in ~/.claude.json (plaintext);
-# omit it if you prefer to export XAI_API_KEY in Claude Code's launch environment.
-claude mcp remove grok >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user grok --env XAI_API_KEY="$XAI_API_KEY" -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
-```
-
-Verify with:
-
-```bash
-claude mcp list
-printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' | node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
-printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' | node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
-```
-
-### Customizing Expert Prompts
-
-Expert prompts live in `prompts/`. Each follows the same structure:
-- Role definition and context
-- Advisory vs Implementation modes
-- Response format guidelines
-- When to invoke / when NOT to invoke
-
-Edit these to customize expert behavior for your workflow.
-
----
+For the full environment-variable reference and manual MCP setup, see [TECHNICAL.md](TECHNICAL.md#environment-variables).
 
 ## Requirements
 
-You need at least one of the following providers configured:
+You need at least one provider:
 
-- **Codex CLI** (for GPT): `npm install -g @openai/codex`
-- **Gemini CLI** (for Gemini): `npm install -g @google/gemini-cli`
-- **Grok (xAI)**: no CLI to install - the bridge ships with the plugin (needs Node 18+). Just set `XAI_API_KEY` (get a key at https://console.x.ai). Advisory-only.
-
-**Authentication**:
-- Codex: run `codex login`
-- Gemini: run `gemini` once and complete the sign-in flow (or set `GOOGLE_API_KEY`)
-- Grok: `export XAI_API_KEY=xai-...`
-
----
+- **Codex CLI** (GPT): `npm install -g @openai/codex`, then `codex login`
+- **Gemini CLI**: `npm install -g @google/gemini-cli`, then run `gemini` once (or set `GOOGLE_API_KEY`)
+- **Grok (xAI)**: no CLI to install; the bridge ships with the plugin (needs Node 18+). Set `XAI_API_KEY` (get a key at https://console.x.ai). Advisory-only.
 
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
 | MCP server not found | Restart Claude Code after setup |
-| Provider not authenticated | Codex: run `codex login`. Gemini: run `gemini` once to complete sign-in (or set `GOOGLE_API_KEY`). Grok: export `XAI_API_KEY` (else calls return `errorKind: missing-auth`) |
+| Provider not authenticated | Codex: `codex login`. Gemini: run `gemini` once (or set `GOOGLE_API_KEY`). Grok: export `XAI_API_KEY` (else calls return `errorKind: missing-auth`) |
 | Tool not appearing | Run `claude mcp list` and verify registration |
-| Expert not triggered | Try explicit: "Ask GPT to review...", "Ask Gemini to review...", or "Ask Grok to review..." |
-| Gemini blocked by trust check | The bridge returns `errorKind: "trust"` with `hint: "skip-trust"`. The orchestrator auto-retries the call once with `skip-trust: true` and prints a notice. To opt in up front, pass `"skip-trust": true` on the call. |
+| Expert not triggered | Ask explicitly: "Ask GPT to review...", "Ask Gemini to review...", or "Ask Grok to review..." |
+| Gemini blocked by trust check | The orchestrator retries once with `skip-trust` and prints a notice. See [TECHNICAL.md](TECHNICAL.md#gemini-trust-recovery) |
 
-### Untrusted directories
+Deeper failure modes (untrusted directories, soft-timeout recovery) are documented in [TECHNICAL.md](TECHNICAL.md#gemini-trust-recovery).
 
-The Gemini CLI refuses to run from a directory it has not been told to trust (entries live in `~/.gemini/trustedFolders.json`). When that happens the bridge surfaces a structured signal:
+## Contributing
 
-```json
-{
-  "content": [{ "type": "text", "text": "Error: <message>" }],
-  "isError": true,
-  "errorKind": "trust",
-  "retryable": true,
-  "hint": "skip-trust"
-}
-```
-
-`content` (the MCP text payload) is always present; `hint` is included only
-when set. Other failures use the same envelope with a different `errorKind`
-(e.g. `timeout`).
-
-The orchestration rules (`rules/orchestration.md` -> "Trust Failure Recovery") instruct Claude to retry the same call once with `"skip-trust": true`, preserving `threadId` for `gemini-reply`. A second consecutive trust failure (when `skip-trust: true` was already set) escalates to the user instead of looping.
-
-Callers that already know they want to bypass the trust check can pass `"skip-trust": true` from the start.
-
-### Timeouts and recovery
-
-`timeout` is a **soft** deadline (default 300000ms; Gemini 3 deep prompts run
-200-260s). The Gemini CLI ignores SIGTERM and persists its full answer to disk at
-`~/.gemini/tmp/<slug>/chats/session-*.jsonl` regardless. When the soft timeout
-fires the bridge does not fail immediately: it drains - keeps Gemini alive and
-polls that jsonl for a record newer than the call's start - for up to
-`recovery-grace` ms (default 120000, range 0..600000). If the answer appears it is
-returned as a normal success with a top-level `"recovered": true` flag and a
-stderr log line; `content` is unmodified so response parsers keep working. If the
-grace budget is exhausted with no answer, the call fails with the usual
-`errorKind: "timeout"` (still `retryable`).
-
-- `"recovery-grace": 0` disables the drain (immediate legacy timeout).
-- `GEMINI_DISABLE_TIMEOUT_RECOVERY=1` (env) forces full legacy behavior.
-- The call resolves within `timeout + recovery-grace`. The Gemini child
-  process is then killed `SIGTERM`, with a `SIGKILL` ~1s later; that kill is
-  async cleanup and does not delay the response.
-
-Manual recovery (any session, even without this plugin): find the project slug
-under `~/.gemini/tmp/` (its `.project_root` file holds the absolute cwd), then in
-that slug's `chats/` open the newest `session-*.jsonl`; the last record with
-`"type":"gemini"` has the full answer in `.content`.
-
-Known limitation: heavy parallel calls from the same cwd (e.g. `ask-all`,
-`consensus`) can race on "newest session file". A spawn-start timestamp guard
-(2000ms skew tolerance) makes mis-attribution unlikely but not impossible.
-
----
-
-## Development
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, commit conventions, and the automated release process. To work on the plugin locally:
 
 ```bash
 git clone https://github.com/antonbabenko/claude-delegator
@@ -313,21 +177,15 @@ cd claude-delegator
 claude --plugin-dir /path/to/claude-delegator
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+## Credits
 
----
+Claude Delegator started as a fork of [jarrodwatts/claude-delegator](https://github.com/jarrodwatts/claude-delegator) - credit to Jarrod Watts for the original solution and inspiration. Original work and MIT copyright are retained. This fork adds Grok support, Gemini bridge reliability (timeout and trust recovery), provider configuration overrides, and the bundled delegation commands. It is not an official continuation of the upstream project.
 
-## Acknowledgments
-
-Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu).
-
----
+Expert prompts are adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu).
 
 ## License
 
 MIT - see [LICENSE](LICENSE)
-
----
 
 ## Star History
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -1,0 +1,203 @@
+# Technical Reference
+
+Advanced and internal details for Claude Delegator. For install and everyday use,
+see the [README](README.md). This document covers the provider bridges, the full
+environment-variable reference, manual MCP setup, multi-turn and retry behavior,
+and the Gemini recovery paths.
+
+## Contents
+
+- [Architecture](#architecture)
+- [Provider bridges](#provider-bridges)
+- [Environment variables](#environment-variables)
+- [Manual MCP setup](#manual-mcp-setup)
+- [Multi-turn and retry](#multi-turn-and-retry)
+- [Gemini trust recovery](#gemini-trust-recovery)
+- [Gemini timeout recovery](#gemini-timeout-recovery)
+- [Grok files and cleanup](#grok-files-and-cleanup)
+- [Customizing expert prompts](#customizing-expert-prompts)
+- [Known limitations](#known-limitations)
+
+## Architecture
+
+Claude acts as the orchestrator. It reads your request, picks an expert, and
+delegates to a provider over MCP. Each provider reaches Claude Code differently:
+
+- **Codex (GPT)** - the Codex CLI ships a native MCP server (`codex mcp-server`).
+- **Gemini** - a bundled zero-dependency Node bridge (`server/gemini/index.js`)
+  wraps the Gemini CLI.
+- **Grok (xAI)** - a bundled zero-dependency Node bridge (`server/grok/index.js`)
+  talks to the xAI Responses API (`/v1/responses`) over HTTP. Advisory-only: it
+  cannot edit files, but it can read attached files.
+
+Responses are synthesized by Claude, never passed through verbatim.
+
+## Provider bridges
+
+### Gemini bridge
+
+The bridge wraps the Gemini CLI and adds three reliability behaviors:
+
+- **Soft-timeout drain** - on timeout it keeps Gemini alive and recovers the
+  disk-flushed answer instead of failing. See
+  [Gemini timeout recovery](#gemini-timeout-recovery).
+- **Trust-failure signal** - when the CLI refuses an untrusted directory, the
+  bridge returns a structured `errorKind: "trust"` envelope the orchestrator
+  retries with `skip-trust`. See [Gemini trust recovery](#gemini-trust-recovery).
+- **Hardened JSON parsing** - tolerant of the CLI's mixed stdout.
+
+The bridge default model is `gemini-2.5-flash` (it does not read the Gemini CLI's
+`~/.gemini/settings.json`). Override per call with the `model` parameter or globally
+with `GEMINI_DEFAULT_MODEL`.
+
+### Grok bridge
+
+A bundled zero-dependency Node bridge over the xAI Responses API
+(`/v1/responses`). It is advisory-only (it cannot edit files) but it can read
+attached files: pass `files: [{ path | file_id | file_url }]` and the bridge
+uploads to the xAI Files API and references them. Uploads are tagged
+`claude-delegator-*` and carry an `expires_after` (default 7 days); prune early
+with `/grok-files`. See [Grok files and cleanup](#grok-files-and-cleanup).
+
+The bridge default model is `grok-4.3`. It needs `XAI_API_KEY` in its environment;
+a missing key surfaces `errorKind: "missing-auth"`.
+
+## Environment variables
+
+This is the single source of truth for the bridge environment variables.
+
+| Variable | Provider | Default | Purpose |
+|----------|----------|---------|---------|
+| `GEMINI_DEFAULT_MODEL` | Gemini | `gemini-2.5-flash` | Default model when the call sets none |
+| `GEMINI_DISABLE_TIMEOUT_RECOVERY` | Gemini | unset | `1` forces legacy timeout (no drain) |
+| `XAI_API_KEY` | Grok | unset (required) | xAI API key; missing key returns `missing-auth` |
+| `GROK_DEFAULT_MODEL` | Grok | `grok-4.3` | Default model when the call sets none |
+| `XAI_API_BASE` | Grok | `https://api.x.ai/v1` | API endpoint override |
+| `GROK_REASONING_EFFORT` | Grok | `high` | `low`/`medium`/`high`; `none` or `off` omits the field |
+| `GROK_FILE_TTL_SECONDS` | Grok | `604800` (7 days) | Upload lifetime, clamped 1h..30d |
+
+Codex reads its own config from `~/.codex/config.toml` (see
+[Configuration in the README](README.md#configuration)).
+
+## Manual MCP setup
+
+If `/setup` does not work, register the MCP servers manually. Each command is
+idempotent (safe to rerun):
+
+```bash
+# Codex (GPT)
+claude mcp remove codex >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user codex -- codex -m gpt-5.3-codex mcp-server
+
+# Gemini
+claude mcp remove gemini >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
+
+# Grok (xAI) - API-based, advisory-only. Needs XAI_API_KEY.
+# --env persists the key in ~/.claude.json (plaintext); omit it if you prefer to
+# export XAI_API_KEY in Claude Code's launch environment instead.
+claude mcp remove grok >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user grok --env XAI_API_KEY="$XAI_API_KEY" -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+```
+
+Verify:
+
+```bash
+claude mcp list
+printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' | node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
+printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' | node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+```
+
+## Multi-turn and retry
+
+For chained implementation steps, an expert preserves context across turns:
+
+```
+Turn 1: mcp__*__*       -> returns threadId
+Turn 2: mcp__*__*-reply(threadId) -> expert remembers turn 1
+Turn 3: mcp__*__*-reply(threadId) -> expert remembers turns 1-2
+```
+
+Use single-shot (`codex`, `gemini`, `grok`) for advisory tasks. Use multi-turn for
+implementation chains and retries. Grok is advisory-only.
+
+Implementation retries up to 3 attempts total (1 initial + 2 `*-reply` retries),
+then escalates to you. Retries reuse the `threadId` so the expert remembers the
+earlier attempts.
+
+## Gemini trust recovery
+
+The Gemini CLI refuses to run from a directory it has not been told to trust
+(entries live in `~/.gemini/trustedFolders.json`). When that happens the bridge
+returns a structured signal:
+
+```json
+{
+  "content": [{ "type": "text", "text": "Error: <message>" }],
+  "isError": true,
+  "errorKind": "trust",
+  "retryable": true,
+  "hint": "skip-trust"
+}
+```
+
+`content` (the MCP text payload) is always present; `hint` is included only when
+set. Other failures use the same envelope with a different `errorKind` (for
+example `timeout`).
+
+The orchestration rules (`rules/orchestration.md`, "Trust Failure Recovery")
+instruct Claude to retry the same call once with `"skip-trust": true`, preserving
+`threadId` for `gemini-reply`. A second consecutive trust failure (when
+`skip-trust: true` was already set) escalates to you instead of looping. Callers
+that already know they want to bypass the check can pass `"skip-trust": true` from
+the start.
+
+## Gemini timeout recovery
+
+`timeout` is a soft deadline (default 300000ms; Gemini 3 deep prompts run
+200-260s). The Gemini CLI ignores SIGTERM and persists its full answer to disk at
+`~/.gemini/tmp/<slug>/chats/session-*.jsonl` regardless. When the soft timeout
+fires, the bridge does not fail immediately: it drains - keeps Gemini alive and
+polls that jsonl for a record newer than the call's start - for up to
+`recovery-grace` ms (default 120000, range 0..600000). If the answer appears it is
+returned as a normal success with a top-level `"recovered": true` flag and a stderr
+log line; `content` is unmodified so response parsers keep working. If the grace
+budget is exhausted with no answer, the call fails with `errorKind: "timeout"`
+(still `retryable`).
+
+- `"recovery-grace": 0` disables the drain (immediate legacy timeout).
+- `GEMINI_DISABLE_TIMEOUT_RECOVERY=1` (env) forces full legacy behavior.
+- The call resolves within `timeout + recovery-grace`. The Gemini child process is
+  then killed `SIGTERM`, with a `SIGKILL` about 1s later; that kill is async
+  cleanup and does not delay the response.
+
+Manual recovery (any session, even without this plugin): find the project slug under
+`~/.gemini/tmp/` (its `.project_root` file holds the absolute cwd), then in that
+slug's `chats/` open the newest `session-*.jsonl`; the last record with
+`"type":"gemini"` has the full answer in `.content`.
+
+## Grok files and cleanup
+
+Grok can read attached files. Pass `files: [{ path | file_id | file_url }]`:
+
+- `path` - a local file the bridge uploads to the xAI Files API, then references.
+- `file_id` - an already-uploaded xAI file id.
+- `file_url` - a public URL.
+
+Uploads are tagged `claude-delegator-*` and carry an `expires_after` set by
+`GROK_FILE_TTL_SECONDS` (default `604800` = 7 days, clamped 1h..30d). List or prune
+bridge-owned uploads early with `/grok-files`. A path outside the working directory
+is refused (no exfiltration); an oversize file returns `file-too-large`.
+
+## Customizing expert prompts
+
+Expert prompts live in `prompts/`. Each follows the same structure: role definition
+and context, advisory vs implementation modes, response-format guidance, and when
+to invoke or not invoke. Edit these to change expert behavior for your workflow.
+
+## Known limitations
+
+- Heavy parallel calls from the same cwd (for example `/ask-all`, `/consensus`) can
+  race on "newest session file" during Gemini timeout recovery. A spawn-start
+  timestamp guard (2000ms skew tolerance) makes mis-attribution unlikely but not
+  impossible.

--- a/config/mcp-servers.example.json
+++ b/config/mcp-servers.example.json
@@ -9,6 +9,12 @@
       "type": "stdio",
       "command": "node",
       "args": ["${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js"]
+    },
+    "grok": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/grok/index.js"],
+      "env": { "XAI_API_KEY": "${XAI_API_KEY}" }
     }
   }
 }

--- a/config/providers.json
+++ b/config/providers.json
@@ -34,7 +34,7 @@
       "name": "Grok (xAI)",
       "description": "xAI Grok models via bundled MCP bridge over the xAI HTTP API - advisory expert subagents",
       "cli": null,
-      "api": "https://api.x.ai/v1/chat/completions",
+      "api": "https://api.x.ai/v1/responses",
       "auth": "export XAI_API_KEY=xai-...",
       "mcp": {
         "type": "stdio",


### PR DESCRIPTION
## What

Restructure the README into a user-facing front door and move the deep internals into a new top-level `TECHNICAL.md`.

### README (front door)
What is Claude Delegator -> Install -> Commands -> The Experts (+ when to use) -> How to Use -> How It Works (diagram + high-level) -> Configuration (modes + safe defaults) -> Requirements -> Troubleshooting (table) -> Contributing -> Credits -> License -> Star History.

### TECHNICAL.md (new, repo root)
Architecture, provider bridges, the full environment-variable reference (single source of truth), manual MCP setup, multi-turn & retry, Gemini trust recovery, Gemini timeout recovery, Grok files/TTL, customizing prompts, known limitations. Linked from the README's How It Works / Configuration / Troubleshooting.

### Credits
Removed the top fork blockquote. Added a bottom `Credits` section crediting Jarrod Watts for the original solution and inspiration (this project started as a fork of `jarrodwatts/claude-delegator`), alongside the existing oh-my-opencode credit. MIT copyright retained.

### Also
- Fix `config/providers.json` `grok.api` endpoint: `/v1/chat/completions` -> `/v1/responses` (matches the bridge, which uses the xAI Responses API).
- Add the `grok` server to `config/mcp-servers.example.json` (was only codex + gemini).
- Humanizer pass: README + TECHNICAL are pure ASCII (no em/en dashes, curly quotes, ellipsis) with no AI-vocabulary tells; How-It-Works diagram redrawn in ASCII.

## Verification
- All edited JSON parse; no version fields touched.
- README -> TECHNICAL anchors resolve (`#environment-variables`, `#gemini-trust-recovery`).
- 48/48 bridge tests pass.

## Notes
Approach gathered via `/ask-all` (GPT + Gemini + Grok). Independent of the release-automation PR (#7); touches disjoint files, so no conflict.
