### PR TITLE
feat(consensus): arbiter-mediated bias hardening for /consensus + ask-* disclaimer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Jarrod Watts
+Copyright (c) 2026 Anton Babenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Bundled with the plugin (available once installed):
 | `/claude-delegator:ask-gemini` | One-shot Gemini second opinion |
 | `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only; can read attached files) |
 | `/claude-delegator:ask-all` | GPT + Gemini + Grok in parallel, synthesized |
-| `/claude-delegator:consensus` | Iterate GPT + Gemini + Grok + Claude to consensus |
+| `/claude-delegator:consensus` | Arbiter-mediated GPT + Gemini + Grok + Claude convergence loop |
 | `/claude-delegator:grok-files` | List or prune Grok-uploaded files (storage cleanup) |
 
-`/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/`. This is opt-in and never overwrites an existing same-named command; `/uninstall` removes an alias only if it is byte-identical to the bundled copy.
+`/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/`. This is opt-in. Existing same-named commands are kept by default; setup asks before overwriting any of them. `/uninstall` removes an alias only if it is byte-identical to the bundled copy.
 
 ## The Experts
 
@@ -98,7 +98,7 @@ Claude: routes to the Security Analyst, then synthesizes the findings.
 
 You can also ask explicitly: "Ask GPT to review this architecture", "Ask Gemini to...", or "Ask Grok to...". Each expert runs read-only for analysis or with write access to apply fixes, and Claude picks the mode from your request (Grok is advisory-only).
 
-The bundled commands give you direct control: `/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all` (all three in parallel, synthesized), and `/consensus` (the providers and Claude iterate to agreement).
+The bundled commands give you direct control: `/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all` (all three in parallel, synthesized), and `/consensus` (arbiter-mediated: the providers vote, Claude commits a blind verdict and adjudicates to agreement).
 
 ## How It Works
 
@@ -127,6 +127,17 @@ Claude: "I found 3 issues..." (synthesizes, applies judgment)
 - Multi-turn conversations preserve context via `threadId` for chained work, and implementation retries before escalating to you.
 
 For the bridge internals, retry behavior, and recovery paths, see [TECHNICAL.md](TECHNICAL.md).
+
+## Bias hardening (consensus + ask-*)
+
+`/consensus` has a built-in conflict of interest: Claude writes the review prompt, casts a vote, decides which objections are real, and runs the loop. Left alone, an orchestrator like that can quietly rubber-stamp its own plan. Four guards stop that:
+
+- **Blind verdict.** Claude posts its own verdict (APPROVE / REQUEST CHANGES / REJECT) in a message sent *before* the one that calls the models. The pre-commitment is right there in the transcript, so Claude cannot reshape its opinion after seeing the panel.
+- **Arbiter-mediated, not majority vote.** The external models vote; Claude adjudicates and rewrites the plan between rounds. The command says so plainly instead of dressing it up as a democratic tally.
+- **No self-approval.** A round converges only when every responding external approves and at least one external actually answered. Claude's own approval never carries a round by itself. A provider that errors (an unconfigured Grok returning `missing-auth`, for example) drops out of the count instead of jamming the loop.
+- **No silent dismissal.** Every critical issue that gets dismissed or deferred ships with a one-line reason in the final report, including the times Claude walks back one of its own blind objections.
+
+The single and parallel commands carry a lighter version of the same rule. `/ask-gpt`, `/ask-gemini`, `/ask-grok`, and `/ask-all` each state that the external model only advises: Claude reads the output, applies its own judgment, and owns the synthesized answer. When the models agree, that is input, not a verdict.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Delegator
 
-GPT (Codex), Gemini, and Grok (xAI) expert subagents for Claude Code. Five specialists that can analyze and implement: architecture, plan review, scope, code review, and security. Use any of the three providers, single-shot or multi-turn, advisory or implementation (Grok is advisory-only).
+GPT (Codex), Gemini, and Grok (xAI) expert subagents for Claude Code. Five specialists that can analyze and implement: architecture, plan review, scope, code review, and security. Use any of the three providers, single-shot or multi-turn, advisory or implementation.
 
 [![License](https://img.shields.io/github/license/antonbabenko/claude-delegator?v=2)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/antonbabenko/claude-delegator?v=2)](https://github.com/antonbabenko/claude-delegator/stargazers)
@@ -9,7 +9,7 @@ GPT (Codex), Gemini, and Grok (xAI) expert subagents for Claude Code. Five speci
 
 ## What is Claude Delegator?
 
-Claude gains a team of GPT, Gemini, and Grok specialists over MCP: GPT through the Codex CLI's native MCP server, Gemini through a bundled MCP bridge, and Grok through a bundled bridge over the xAI HTTP API. Each expert has a distinct specialty and can advise or implement (Grok is advisory-only).
+Claude gains a team of GPT, Gemini, and Grok specialists over MCP: GPT through the Codex CLI's native MCP server, Gemini through a bundled MCP bridge, and Grok through a bundled bridge over the xAI HTTP API. Each expert has a distinct specialty and can advise or implement.
 
 You can use any subset of the three providers. The plugin detects which are configured and routes accordingly.
 
@@ -25,14 +25,14 @@ You can use any subset of the three providers. The plugin detects which are conf
 
 Inside a Claude Code instance, run:
 
-**1. Add the marketplace**
+**1. Add the marketplace - [antonbabenko/agent-plugins](https://github.com/antonbabenko/agent-plugins)**
 ```
-/plugin marketplace add antonbabenko/claude-delegator
+/plugin marketplace add antonbabenko/agent-plugins
 ```
 
 **2. Install the plugin**
 ```
-/plugin install claude-delegator
+/plugin install claude-delegator@antonbabenko
 ```
 
 **3. Run setup**
@@ -42,9 +42,7 @@ Inside a Claude Code instance, run:
 
 Claude now routes complex tasks to your GPT, Gemini, and Grok experts.
 
-> Requires at least one provider: [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google/gemini-cli), or Grok (no CLI to install; just set `XAI_API_KEY`). Setup walks you through it.
-
-You can also install from the [agent-plugins marketplace](https://github.com/antonbabenko/agent-plugins): run `/plugin marketplace add antonbabenko/agent-plugins`, then `/plugin install claude-delegator@antonbabenko`.
+The canonical marketplace is [`antonbabenko/agent-plugins`](https://github.com/antonbabenko/agent-plugins) (above), which also bundles the other plugins.
 
 ## Commands
 
@@ -53,12 +51,12 @@ Bundled with the plugin (available once installed):
 | Command | Purpose |
 |---------|---------|
 | `/claude-delegator:setup` | Configure Codex/Gemini/Grok MCP servers + orchestration rules |
-| `/claude-delegator:uninstall` | Remove MCP config, rules, and aliases |
+| `/claude-delegator:consensus` | 🔥🔥🔥 Arbiter-mediated GPT + Gemini + Grok + Claude convergence loop |
+| `/claude-delegator:ask-all` | 🔥 GPT + Gemini + Grok in parallel, synthesized |
 | `/claude-delegator:ask-gpt` | One-shot GPT (Codex) second opinion |
 | `/claude-delegator:ask-gemini` | One-shot Gemini second opinion |
-| `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only; can read attached files) |
-| `/claude-delegator:ask-all` | GPT + Gemini + Grok in parallel, synthesized |
-| `/claude-delegator:consensus` | Arbiter-mediated GPT + Gemini + Grok + Claude convergence loop |
+| `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only) |
+| `/claude-delegator:uninstall` | Remove MCP config, rules, and aliases |
 | `/claude-delegator:grok-files` | List or prune Grok-uploaded files (storage cleanup) |
 
 `/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/`. This is opt-in. Existing same-named commands are kept by default; setup asks before overwriting any of them. `/uninstall` removes an alias only if it is byte-identical to the bundled copy.
@@ -96,7 +94,7 @@ You: "Is this authentication flow secure?"
 Claude: routes to the Security Analyst, then synthesizes the findings.
 ```
 
-You can also ask explicitly: "Ask GPT to review this architecture", "Ask Gemini to...", or "Ask Grok to...". Each expert runs read-only for analysis or with write access to apply fixes, and Claude picks the mode from your request (Grok is advisory-only).
+You can also ask explicitly: "Ask GPT to review this architecture", "Ask Gemini to...", or "Ask Grok to...". Each expert runs read-only for analysis or with write access to apply fixes, and Claude picks the mode from your request.
 
 The bundled commands give you direct control: `/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all` (all three in parallel, synthesized), and `/consensus` (arbiter-mediated: the providers vote, Claude commits a blind verdict and adjudicates to agreement).
 
@@ -160,16 +158,16 @@ For the full environment-variable reference and manual MCP setup, see [TECHNICAL
 
 You need at least one provider:
 
-- **Codex CLI** (GPT): `npm install -g @openai/codex`, then `codex login`
-- **Gemini CLI**: `npm install -g @google/gemini-cli`, then run `gemini` once (or set `GOOGLE_API_KEY`)
-- **Grok (xAI)**: no CLI to install; the bridge ships with the plugin (needs Node 18+). Set `XAI_API_KEY` (get a key at https://console.x.ai). Advisory-only.
+- **Codex CLI** (GPT): `npm install -g @openai/codex`, then `codex login`.
+- **Antigravity CLI**: [Getting Started with Antigravity CLI](https://antigravity.google/docs/cli-getting-started) and [Migrating from Gemini CLI](https://antigravity.google/docs/gcli-migration), then run `agy` and login.
+- **Grok (xAI)**: no CLI to install; the bridge ships with the plugin (needs Node 18+). Set `XAI_API_KEY` (get a key at https://console.x.ai).
 
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
 | MCP server not found | Restart Claude Code after setup |
-| Provider not authenticated | Codex: `codex login`. Gemini: run `gemini` once (or set `GOOGLE_API_KEY`). Grok: export `XAI_API_KEY` (else calls return `errorKind: missing-auth`) |
+| Provider not authenticated | Codex: `codex login`. Gemini: run `agy` once (or set `GOOGLE_API_KEY`). Grok: export `XAI_API_KEY` (else calls return `errorKind: missing-auth`) |
 | Tool not appearing | Run `claude mcp list` and verify registration |
 | Expert not triggered | Ask explicitly: "Ask GPT to review...", "Ask Gemini to review...", or "Ask Grok to review..." |
 | Gemini blocked by trust check | The orchestrator retries once with `skip-trust` and prints a notice. See [TECHNICAL.md](TECHNICAL.md#gemini-trust-recovery) |

--- a/commands/ask-all.md
+++ b/commands/ask-all.md
@@ -111,6 +111,8 @@ User question or topic: $ARGUMENTS
 - **Disagreement is signal** — when the models diverge, treat it as a flag to dig deeper, not a tie to break by majority. Often more than one is partly wrong.
 - **Never paste raw output** — always synthesize.
 
+- **Final judgment is the orchestrator's** - the three models advise in parallel. Claude compares them, applies its own judgment, and is accountable for the synthesized recommendation. Agreement among models is input, not an automatic verdict.
+
 <!-- DO NOT DELETE: required fallback if plugin cache missing. See C1 in implementation plan. -->
 
 ## Inlined fallback - Architect

--- a/commands/ask-gemini.md
+++ b/commands/ask-gemini.md
@@ -67,6 +67,8 @@ User question or topic: $ARGUMENTS
 - **No contamination** — do not include prior GPT opinions in the Gemini prompt. Each expert reasons independently.
 - **Print status line** immediately before the MCP dispatch: `Gemini working (typical 30-60s)...`
 
+- **Final judgment is the orchestrator's** - the external model only advises. Claude reads its output, applies its own judgment, and is accountable for the synthesized answer shown to you. The model's raw verdict is not the final word.
+
 <!-- DO NOT DELETE: required fallback if plugin cache missing. See C1 in implementation plan. -->
 
 ## Inlined fallback - Architect

--- a/commands/ask-gpt.md
+++ b/commands/ask-gpt.md
@@ -56,6 +56,8 @@ User question or topic: $ARGUMENTS
 - **No contamination** — do not include prior Gemini opinions in the GPT prompt. Each expert reasons independently.
 - **Print status line** immediately before the MCP dispatch: `Codex working (typical 30-60s)...`
 
+- **Final judgment is the orchestrator's** - the external model only advises. Claude reads its output, applies its own judgment, and is accountable for the synthesized answer shown to you. The model's raw verdict is not the final word.
+
 <!-- DO NOT DELETE: required fallback if plugin cache missing. See C1 in implementation plan. -->
 
 ## Inlined fallback - Architect

--- a/commands/ask-grok.md
+++ b/commands/ask-grok.md
@@ -64,6 +64,8 @@ User question or topic: $ARGUMENTS
 - **Auth required** — Grok needs `XAI_API_KEY`. If the call returns `errorKind: "missing-auth"`, tell the user to `export XAI_API_KEY=xai-...` (or rerun `/claude-delegator:setup`) and restart Claude Code.
 - **Print status line** immediately before the MCP dispatch: `Grok working (typical 30-60s)...`
 
+- **Final judgment is the orchestrator's** - the external model only advises. Claude reads its output, applies its own judgment, and is accountable for the synthesized answer shown to you. The model's raw verdict is not the final word.
+
 <!-- DO NOT DELETE: required fallback if plugin cache missing. See C1 in implementation plan. -->
 
 ## Inlined fallback - Architect

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -51,7 +51,7 @@ Plan, design, spec, or proposal to refine: $ARGUMENTS
 4. Initialize state:
    - `plan` = original `$ARGUMENTS`
    - `round` = 0
-   - `history` = empty list of `{round, plan_diff_summary, gpt_verdict, gemini_verdict, grok_verdict, claude_decision}`
+   - `history` = empty list of `{round, plan_diff_summary, claude_blind_verdict, gpt_verdict, gemini_verdict, grok_verdict, claude_decision, dismissals}`
 5. Print:
    ```
    /consensus: starting consensus loop (max 5 rounds, expert=[Expert])
@@ -61,9 +61,9 @@ Plan, design, spec, or proposal to refine: $ARGUMENTS
 
 For each round R:
 
-1. **Print round header** before dispatching, so the user knows progress:
+1. **Print round header** before anything else this round:
    ```
-   --- Round R/5 --- Codex + Gemini + Grok working in parallel (typical 30-60s)...
+   --- Round R/5 ---
    ```
 
 2. **Build identical review prompt** (7-section format per `~/.claude/rules/delegator/delegation-format.md`). Include:
@@ -78,7 +78,14 @@ For each round R:
      **Recommendations** (nice-to-have; empty list = none): [bullets]
      **One-line bottom line**: [single sentence]
      ```
-3. **Parallel dispatch** - all three calls in ONE message with three tool blocks. Identical prompt body, identical expert prompt:
+
+3. **Claude's BLIND verdict - EMIT BEFORE DISPATCHING**: in a message of its OWN, BEFORE the message that calls any MCP tool, Claude writes its own verdict in the strict OUTPUT FORMAT above using ONLY the review prompt from step 2 (it has not seen any reviewer output yet), and stores it verbatim in `history[R].claude_blind_verdict`. Print:
+   ```
+   Claude blind (R{R}): APPROVE | REQUEST CHANGES | REJECT (N critical)
+   ```
+   This is the orchestrator's PEER vote. Emitting it in an earlier message than the dispatch makes the pre-commitment visible in the transcript. Claude must NOT edit the blind verdict after seeing reviewers; it appears verbatim in the final report. (Claude's *adjudication* in step 6 is a separate, arbiter-role decision, recorded distinctly.)
+
+4. **Parallel dispatch** - in the NEXT message, all three calls in ONE message with three tool blocks. Identical prompt body, identical expert prompt:
    ```
    mcp__codex__codex({
      prompt: "[identical 7-section prompt for round R]",
@@ -106,35 +113,38 @@ For each round R:
    Grok via `files:[{path}]` each round; GPT and Gemini read the named paths from their
    trusted `cwd`.
 
-4. **Stream short status as each return arrives**. Do not wait until all are back to print anything. Examples:
+5. **Stream short status as each return arrives**. Do not wait until all are back to print anything. Mark a provider that returned an MCP error or `result.isError` as ERRORED. Examples:
    ```
    GPT (R{R}): APPROVE
    Gemini (R{R}): REQUEST CHANGES (3 critical)
-   Grok (R{R}): APPROVE
+   Grok (R{R}): ERRORED (provider error: missing-auth)
    ```
 
-5. **Parse verdicts and form Claude's own opinion**:
-   - Extract `Verdict`, `Critical issues`, `Recommendations` from each of the three reviewers.
-   - For each critical issue: Claude marks it as `accept` (real problem, fix), `dismiss` (false positive - record why), or `defer` (legitimate but out of scope for this plan).
-   - Claude's own `verdict` is APPROVE if and only if there are zero accepted critical issues across all three reviewers, AND Claude has no critical issues of its own.
+6. **Adjudicate (arbiter role) - reconcile issues against the blind verdict**:
+   - From each RESPONDING reviewer, extract `Verdict`, `Critical issues`, `Recommendations`. An ERRORED provider is excluded (see Convergence check); it contributes no verdict and no issues.
+   - For each critical issue - whether raised by a reviewer OR by Claude's own blind verdict - record a decision WITH a one-line reason: `accept` (real problem, fix), `dismiss` (false positive - reason REQUIRED), or `defer` (out of scope - reason REQUIRED). Append every `dismiss`/`defer` to `history[R].dismissals`. **This includes Claude walking back one of its own blind critical issues** - that is a `dismiss` and needs a recorded reason too.
+   - **Repeated-issue default**: if two or more sources (reviewers, or a reviewer plus Claude's blind verdict) raise substantially the same critical issue, `accept` it by default; only `dismiss` with a concrete factual reason ("out of scope" alone is not enough).
+   - Claude's adjudicated verdict is APPROVE if and only if zero accepted critical issues remain anywhere (reviewers or Claude's blind verdict).
 
-6. **Convergence check** - STOP the loop when ALL FOUR are APPROVE:
-   - GPT verdict == APPROVE AND
-   - Gemini verdict == APPROVE AND
-   - Grok verdict == APPROVE AND
-   - Claude verdict == APPROVE (no accepted critical issues anywhere)
+7. **Convergence check** - the loop CONVERGES only when ALL of these hold:
+   - At least one external reviewer RESPONDED this round (not all errored), AND
+   - Every RESPONDING external returned APPROVE (ERRORED providers are excluded from the bar - not counted as APPROVE or as REQUEST CHANGES), AND
+   - No responding reviewer returned REJECT, AND
+   - Zero accepted critical issues remain (from any reviewer or from Claude's blind verdict), AND
+   - Claude's adjudicated verdict == APPROVE.
+   A round in which ALL externals errored has no responding external and therefore CANNOT converge. If any responding reviewer returned REJECT, the result may NOT be labelled "consensus" even at round 5.
 
-7. **If not converged**:
-   - Compile the union of `accept`-ed critical issues from all three reviewers plus any Claude found.
+8. **If not converged**:
+   - Compile the union of `accept`-ed critical issues from all responding reviewers plus any Claude found.
    - Revise the plan to address them. Be explicit about what changed and what was deliberately not changed.
-   - Record this round in `history` with: GPT verdict, Gemini verdict, Grok verdict, Claude's per-issue decisions, the diff summary applied to the plan.
+   - Record this round in `history` with: Claude blind verdict, GPT/Gemini/Grok verdicts (or ERRORED), Claude's per-issue decisions + reasons, the diff summary applied to the plan.
    - Print the revised plan ONLY if it has changed materially (don't spam on small wording tweaks).
    - Continue to round R+1.
-   - **Backoff after multi error**: if MORE THAN ONE provider returned a provider-error in round R (not a regular REQUEST CHANGES verdict, but an MCP error or `result.isError`), wait 1-2 seconds before dispatching round R+1 to let transient API hiccups clear.
+   - **Backoff after multi error**: if MORE THAN ONE provider errored in round R, wait 1-2 seconds before dispatching round R+1 to let transient API hiccups clear.
 
-8. **If round R == 5 and still not converged**:
+9. **If round R == 5 and still not converged**:
    - Emit the final state with residual disagreements clearly labeled. Do not pretend convergence.
-   - Note which side (GPT, Gemini, Grok, or Claude) holds out on which issues.
+   - Note which side (Claude blind, GPT, Gemini, or Grok) holds out on which issues.
 
 ### Final output
 

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -151,15 +151,20 @@ For each round R:
 ```
 ## /consensus result
 
+**Mode**: arbiter-mediated consensus (external models vote; Claude adjudicates + synthesizes)
 **Outcome**: CONVERGED in N rounds | UNRESOLVED after 5 rounds
 **Final plan**:
 [full converged plan, or last revision]
 
-**Round history**:
-| Round | GPT | Gemini | Grok | Claude | Changes applied |
-| 1     | RC  | RC     | RC   | RC     | added rollback step, clarified ownership |
-| 2     | RC  | APPR   | APPR | APPR   | tightened error handling on step 3 |
-| 3     | APPR | APPR  | APPR | APPR   | - (no change; consensus reached) |
+**Round history** (CB = Claude blind verdict; reviewer cols use APPR/RC/REJ or ERR; Adj = Claude adjudicated):
+| Round | CB   | GPT  | Gemini | Grok | Adj  | Changes applied |
+| 1     | RC   | RC   | RC     | RC   | RC   | added rollback step, clarified ownership |
+| 2     | RC   | RC   | APPR   | ERR  | RC   | tightened error handling on step 3 |
+| 3     | APPR | APPR | APPR   | ERR  | APPR | - (Grok unconfigured; converged on responding externals) |
+
+**Dismissed / deferred issues** (every dismiss/defer, with reason - no silent dismissal; includes Claude walking back its own blind issues):
+- [R{n}] {source} raised "{issue}" -> dismissed: {one-line reason}
+- [R{n}] {source} raised "{issue}" -> deferred (out of scope): {one-line reason}
 
 **Residual disagreements** (if any):
 - GPT (held out on R5): [issue + reason Claude dismissed it]
@@ -170,8 +175,10 @@ For each round R:
 - **Always dispatch in parallel** - all three MCP calls in the same message. Sequential triples wall time.
 - **Single-shot per round** - fresh thread each call. Do NOT use `*-reply` with stored threadId. Cross-round state lives in the prompt body, not in provider memory. Avoids contamination if one provider went off track.
 - **Trusted `cwd` for Gemini** - run the Pre-flight cwd trust check from Setup step 3. NEVER switch folders; use skip-trust when supported, abort otherwise.
-- **Provider failure does not kill the loop** - if a provider errors (timeout, trust failure, Grok `missing-auth`, transient API error), treat its verdict as `REQUEST CHANGES` with a note `"provider error: <truncated msg>"`. Continue the round. The loop can still converge if the surviving reviewers agree with Claude.
+- **Provider failure does not kill the loop** - if a provider errors (timeout, trust failure, Grok `missing-auth`, transient API error), mark it ERRORED with a note `"provider error: <truncated msg>"` and EXCLUDE it from the convergence bar for that round (it counts as neither APPROVE nor REQUEST CHANGES). The loop still converges when every responding external and Claude APPROVE and at least one external responded. If ALL externals errored in a round, there is no responding external, so that round cannot converge.
 - **Pin Gemini model** - always `model: "auto-gemini-3"`. Grok uses its bridge default (`GROK_DEFAULT_MODEL` or `grok-4.3`); no in-command pin.
+- **Claude cannot self-approve into consensus** - convergence requires every responding external to APPROVE and at least one external to respond; Claude's APPROVE alone never converges. Claude's blind verdict is a peer vote; its adjudication is a separate, accountable role.
+- **No silent dismissal** - every `dismiss`/`defer` of a critical issue (from a reviewer OR from Claude's own blind verdict) carries a one-line reason that appears in the final report. Repeated cross-source issues are accepted by default.
 - **Hard cap at 5 rounds** - even if one reviewer is being stubborn, terminate. Diverging too many rounds usually means the plan has an unresolved ambiguity, not that the reviewer is wrong.
 - **Report as you go** - print a status line after each round dispatch and after each return. Long silences look like a hang.
 - **Synthesize, never paste raw** - reviewers' raw output never appears verbatim in the final report.
@@ -179,7 +186,7 @@ For each round R:
 ## Heuristics for Claude's per-issue decisions
 
 - **accept**: reviewer found a real gap or risk that the plan does not cover. Update the plan.
-- **dismiss**: reviewer flagged something that the plan already addresses, or that is genuinely out of scope, or that is theoretical (e.g., "what if the disk fails mid-write" on a non-critical caching plan). Record the dismissal reason in `history` so the next round's prompt explains why it was not changed.
+- **dismiss**: a source (reviewer or Claude's own blind verdict) flagged something that the plan already addresses, or that is genuinely out of scope, or that is theoretical (e.g., "what if the disk fails mid-write" on a non-critical caching plan). Record the dismissal reason in `history` AND surface it in the final report's "Dismissed / deferred issues" section - never dismiss silently.
 - **defer**: reviewer is right but the issue is for a future phase. Add to plan's `Out of scope` section explicitly so the next round doesn't re-flag it.
 
 When Claude dismisses or defers an issue, the next round's prompt should include:

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -1,13 +1,13 @@
 ---
 name: consensus
-description: Iteratively converge GPT + Gemini + Grok + Claude on a plan/design until all four agree. Max 5 rounds. Best for plan refinement.
+description: Arbiter-mediated consensus - GPT + Gemini + Grok review while Claude commits a blind verdict, adjudicates, and synthesizes. Converges only with cross-model agreement. Max 5 rounds.
 allowed-tools: mcp__codex__codex, mcp__gemini__gemini, mcp__grok__grok, Read, Bash
 timeout: 900000
 ---
 
-# Consensus (GPT + Gemini + Grok + Claude convergence loop)
+# Consensus (arbiter-mediated GPT + Gemini + Grok + Claude convergence loop)
 
-Iterate up to 5 rounds. Each round refines the plan based on GPT + Gemini + Grok feedback. Stop when all four (Claude, GPT, Gemini, Grok) approve the current revision, or when 5 rounds are exhausted.
+Iterate up to 5 rounds. Each round refines the plan based on GPT + Gemini + Grok feedback. This is **arbiter-mediated consensus, not pure democracy**: the external models vote independently, but Claude (the orchestrator) authors the review prompt, adjudicates which critical issues are real, and rewrites the plan between rounds. To keep that power accountable, Claude commits a **blind verdict** before reading the reviewers (Round loop below), cannot reach consensus on its own vote alone (Convergence check below), and must show a reason for every dismissed issue. Stop when the convergence rule is met or when 5 rounds are exhausted.
 
 ## Input
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -72,29 +72,29 @@ claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROO
 
 ### Grok (xAI)
 ```bash
-# Idempotent: safe to rerun setup. The key is passed via --env so the bridge
-# inherits it. WARNING: --env persists XAI_API_KEY in plaintext in ~/.claude.json.
-# To avoid that, drop --env and instead export XAI_API_KEY in the environment that
-# launches Claude Code.
+# Idempotent: safe to rerun setup. Registered WITHOUT --env so the key is NOT
+# written to ~/.claude.json. The bridge inherits XAI_API_KEY from the environment
+# that launches Claude Code, so export it in your shell profile to persist it.
 claude mcp remove grok >/dev/null 2>&1 || true
-if [ -n "$XAI_API_KEY" ]; then
-  claude mcp add --transport stdio --scope user grok --env XAI_API_KEY="$XAI_API_KEY" -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
-else
-  echo "XAI_API_KEY not set; registering grok without it (calls return missing-auth until you export it and re-run setup)."
-  claude mcp add --transport stdio --scope user grok -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+claude mcp add --transport stdio --scope user grok -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+if [ -z "$XAI_API_KEY" ]; then
+  echo "Note: XAI_API_KEY not set in this environment; Grok calls return missing-auth until you export it (add it to your shell profile) and restart Claude Code."
 fi
 ```
+
+Want the key persisted in config instead of an exported env var? Add `--env XAI_API_KEY="$XAI_API_KEY"` before `-- node ...` on the command above. That writes the key in plaintext into `~/.claude.json`, so only do it if you accept storing a secret on disk.
 
 This registers the MCP servers at user scope (available across all projects).
 
 **Grok file TTL (optional):** files Grok uploads default to a 7-day `expires_after` so they
-self-delete. To change it, also pass `--env GROK_FILE_TTL_SECONDS=<seconds>` (1h..30d, i.e.
-3600..2592000) on the `grok` registration, or export it in Claude Code's launch environment.
-Prune bridge-owned files early any time with `/grok-files prune --older-than <age>`.
+self-delete. To change it, export `GROK_FILE_TTL_SECONDS=<seconds>` (1h..30d, i.e. 3600..2592000)
+in Claude Code's launch environment, or add `--env GROK_FILE_TTL_SECONDS=<seconds>` on the `grok`
+registration. Prune bridge-owned files early any time with `/grok-files prune --older-than <age>`.
 
-**Grok reasoning effort (optional):** defaults to `high`. Override globally with
-`--env GROK_REASONING_EFFORT=<low|medium|high|none>` on the `grok` registration (or export it),
-or per call with the `reasoning_effort` parameter; `none` omits the field so the model uses its default.
+**Grok reasoning effort (optional):** defaults to `high`. Override by exporting
+`GROK_REASONING_EFFORT=<low|medium|high|none>` in Claude Code's launch environment, or add
+`--env GROK_REASONING_EFFORT=<low|medium|high|none>` on the `grok` registration, or set it per
+call with the `reasoning_effort` parameter; `none` omits the field so the model uses its default.
 
 **Note:** To customise Codex behaviour, add CLI flags before `mcp-server`.
 - For Codex: `-p nosandbox`
@@ -117,19 +117,35 @@ Offer the short, unnamespaced aliases (`/ask-gpt` etc.) by copying them into
 Use AskUserQuestion: "Also install short command names (/ask-gpt etc.) into
 ~/.claude/commands?" Options: "Yes (recommended)" / "No, keep namespaced only".
 
-**If yes**, run (idempotent; never overwrites a pre-existing file - skips it
-with a notice so an unrelated command of the same name is left untouched):
+**If yes**, run (installs only the missing aliases; pre-existing files are skipped
+and collected so you can decide about them next):
 ```bash
 mkdir -p ~/.claude/commands
+collisions=""
 for c in ask-gpt ask-gemini ask-grok ask-all consensus grok-files; do
   dest=~/.claude/commands/$c.md
   if [ -e "$dest" ]; then
     echo "skip $c: ~/.claude/commands/$c.md already exists (left untouched)"
+    collisions="$collisions $c"
   else
     cp "${CLAUDE_PLUGIN_ROOT}/commands/$c.md" "$dest" && echo "installed /$c"
   fi
 done
+echo "COLLISIONS:$collisions"
 ```
+
+If `COLLISIONS` is empty, you are done. If it lists names, ask before touching
+those files. Use AskUserQuestion: "These alias file(s) already exist:[list].
+Overwrite them with the bundled versions?" Options (default first = keep):
+"No, keep existing (recommended)" / "Yes, overwrite".
+
+**Only if the user picks "Yes, overwrite"**, force-copy just the collided names:
+```bash
+for c in <collided names>; do
+  cp -f "${CLAUDE_PLUGIN_ROOT}/commands/$c.md" ~/.claude/commands/$c.md && echo "overwrote /$c"
+done
+```
+Keeping the existing files is the default; overwrite only on explicit opt-in.
 
 **If no**, skip - the namespaced commands still work.
 
@@ -154,7 +170,8 @@ fi
 # Check 3: Gemini MCP server
 GEMINI_CONFIG=$(claude mcp get gemini 2>/dev/null)
 if echo "$GEMINI_CONFIG" | grep -q "server/gemini/index.js"; then
-  echo "Gemini: OK"
+  GEMINI_MODEL="${GEMINI_DEFAULT_MODEL:-gemini-2.5-flash}"
+  echo "Gemini: OK (model: $GEMINI_MODEL)"
 else
   echo "Gemini: NOT CONFIGURED"
 fi
@@ -172,6 +189,8 @@ fi
 # Check 4b: Grok MCP server + bridge health
 GROK_CONFIG=$(claude mcp get grok 2>/dev/null)
 if echo "$GROK_CONFIG" | grep -q "server/grok/index.js"; then
+  GROK_MODEL="${GROK_DEFAULT_MODEL:-grok-4.3}"
+  echo "Grok: OK (model: $GROK_MODEL)"
   GROK_HEALTH=$(printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' \
     | node "${CLAUDE_PLUGIN_ROOT}/server/grok/index.js" 2>/dev/null \
     | grep -q '"id":"health"' && echo "Grok Bridge: HEALTHY" || echo "Grok Bridge: UNHEALTHY")
@@ -197,10 +216,10 @@ claude-delegator Status
 ───────────────────────────────────────────────────
 Codex CLI:     [version from check 1]
 Gemini CLI:    [version from check 1]
-Codex MCP:     [status from check 2]
-Gemini MCP:    [status from check 3]
+Codex MCP:     [status + model from check 2]
+Gemini MCP:    [status + model from check 3]
 Gemini Bridge: [status from check 4]
-Grok MCP:      [status from check 4b]
+Grok MCP:      [status + model from check 4b]
 Rules:         ✓ [N] files in ~/.claude/rules/delegator/
 Codex Auth:    [status from check 6]
 Grok Auth:     [XAI_API_KEY status from check 4b]
@@ -219,7 +238,7 @@ Next steps:
 2. Authenticate providers as needed:
    - Codex: Run `codex login`
    - Gemini: Run `gemini` once and complete the sign-in flow (or set `GOOGLE_API_KEY`)
-   - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai), then re-run setup
+   - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai) in your shell profile, then restart Claude Code
 
 Five experts available:
 


### PR DESCRIPTION
## Summary

Hardens the `/consensus` slash command against orchestrator (Claude) judge-and-player bias, and adds a one-line accountability note to the single/parallel ask commands. Markdown instruction files only - no code, no `.js` changes.

- **Hard blind verdict** - Claude emits its own verdict in its own message *before* the message that dispatches GPT/Gemini/Grok, so the pre-commitment is visible in the transcript (not honor-system).
- **Symmetric reasoned dismissals** - every `dismiss`/`defer` carries a one-line reason surfaced in the report, including Claude walking back one of its *own* blind critical issues.
- **Responding-external convergence** - converge only when every *responding* external APPROVES, at least one responded, no REJECT, zero accepted critical issues, and Claude APPROVES. Errored/unconfigured providers are excluded from the bar rather than blocking forever. This also reconciles a pre-existing contradiction between the stability rule ("surviving reviewers can converge") and the old convergence check ("all three must APPROVE") - an unconfigured Grok (`missing-auth`) no longer deadlocks the loop.
- **Honest framing** - relabelled "arbiter-mediated consensus, not pure democracy"; final report gains a Mode line, a Claude-blind (CB) column, and a Dismissed/deferred section.
- **ask-* disclaimer** - `ask-gpt`/`ask-gemini`/`ask-grok`/`ask-all` note that the orchestrator makes the final, accountable judgment; the model advises.

Design was reviewed via the plugin's own `/ask-all` (GPT + Gemini + Grok) and a `/grill-me` pass, which caught that the original rec-2 would have *weakened* an existing guarantee - corrected here.

## Test Plan

- [x] `npm test` green (48 pass / 0 fail) - confirms no runtime behaviour changed (instruction files only)
- [x] Structural greps: blind-verdict / quorum / dismissal wording present; old "treat its verdict as REQUEST CHANGES" wording removed
- [x] Per-task spec + quality review and a final holistic review (step numbering, convergence wording consistent across round loop + stability rules + final output)
- [x] Live `/consensus` dry-run on a throwaway plan: confirm the `Claude blind (R1)` line precedes the dispatch message; report shows Mode + CB column; with an unconfigured provider it converges on responding externals instead of deadlocking