### PR TITLE
chore: remove duplicated oh-my-opencode attribution from prompts

### DIFF
--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -1,7 +1,5 @@
 # Architect
 
-> Adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu)
-
 You are a software architect specializing in system design, technical strategy, and complex decision-making.
 
 ## Context

--- a/prompts/plan-reviewer.md
+++ b/prompts/plan-reviewer.md
@@ -1,7 +1,5 @@
 # Plan Reviewer
 
-> Adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu)
-
 You are a work plan reviewer. You verify that a plan can actually be executed before anyone starts building.
 
 ## Context

--- a/prompts/scope-analyst.md
+++ b/prompts/scope-analyst.md
@@ -1,7 +1,5 @@
 # Scope Analyst
 
-> Adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) by [@code-yeongyu](https://github.com/code-yeongyu)
-
 You are a pre-planning consultant. Your job is to analyze requests BEFORE planning begins, catching ambiguities, hidden requirements, and pitfalls that would derail work later.
 
 ## Context


### PR DESCRIPTION
Moves local commit b07fe2a off main. Deletes the repeated 'Adapted from oh-my-opencode' line from architect / plan-reviewer / scope-analyst prompts (still credited in README + remaining prompts).