### PR TITLE
ci: rename default branch main -> master in workflows and docs

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -2,7 +2,7 @@ name: Automated Release
 
 # PR-based release flow (part A of two).
 #
-# Why a PR instead of a direct push: `main` has a ruleset requiring the
+# Why a PR instead of a direct push: `master` has a ruleset requiring the
 # "validate" status check. A direct push of the release commit is rejected, and
 # github-actions[bot] cannot be a ruleset bypass actor on a user-owned repo. So
 # the version bump goes through a PR whose required check actually runs.
@@ -15,12 +15,12 @@ name: Automated Release
 #   2. Repo Settings -> "Allow auto-merge" enabled (for `gh pr merge --auto`).
 #
 # This workflow (A) opens/refreshes the release PR. tag-release.yml (B) tags +
-# publishes after the PR merges to main.
+# publishes after the PR merges to master.
 
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 permissions:
@@ -38,7 +38,7 @@ jobs:
     # Loop guard: do not re-release the merged release commit.
     if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     steps:
-      - name: Checkout main
+      - name: Checkout master
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
       # The changelog action commits on the CURRENT branch then runs
       # `git push origin release/next`, so a local `release/next` ref must be
       # checked out; its internal `git pull --ff-only` also needs an upstream.
-      # Create release/next from main HEAD, publish it, and track it.
+      # Create release/next from master HEAD, publish it, and track it.
       - name: Prepare release branch
         run: |
           git push origin --delete release/next 2>/dev/null || true
@@ -99,7 +99,7 @@ jobs:
             gh pr edit "$PR" --title "chore(release): ${TAG}"
           else
             PR="$(gh pr create \
-              --base main \
+              --base master \
               --head release/next \
               --title "chore(release): ${TAG}" \
               --body "Automated release ${TAG}. Squash-merging publishes the tag and GitHub Release (tag-release.yml)." \

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,14 +1,14 @@
 name: Tag and Publish Release
 
 # Part B of the PR-based release flow (see automated-release.yml).
-# Runs after the `chore(release): vX.Y.Z` PR squash-merges to main. It tags the
-# merged main commit and publishes the GitHub Release. It never commits, so it
+# Runs after the `chore(release): vX.Y.Z` PR squash-merges to master. It tags the
+# merged master commit and publishes the GitHub Release. It never commits, so it
 # cannot start a release loop.
 
 on:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: write

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: Validate
 
-# Required status check for the PR-based release flow. The `main` ruleset
+# Required status check for the PR-based release flow. The `master` ruleset
 # requires the "validate" check, which is why automated-release.yml routes the
 # version bump through a PR (a direct push would bypass this gate). Keep the job
 # name "validate" in sync with the branch ruleset's required-check name.
@@ -8,7 +8,7 @@ name: Validate
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Every expert can operate in **advisory** (`sandbox: read-only`) or **implementat
 
 ## Commit Conventions & Releases
 
-Releases are automated from Conventional Commits on `main`. Do not hand-edit version numbers.
+Releases are automated from Conventional Commits on `master`. Do not hand-edit version numbers.
 
 | Commit prefix | Version bump |
 |---------------|--------------|
@@ -100,7 +100,7 @@ Releases are automated from Conventional Commits on `main`. Do not hand-edit ver
 | `fix:` | Patch |
 | Other (`chore`, `docs`, `refactor`, ...) | Patch |
 
-`version.json` is the single source of truth. On merge to `main`, `automated-release.yml`
+`version.json` is the single source of truth. On merge to `master`, `automated-release.yml`
 bumps it, regenerates `CHANGELOG.md`, and runs `.github/release/pre-commit.js` to sync the
 version in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and
 `package.json`. After the release PR merges, `tag-release.yml` tags `vX.Y.Z`, publishes the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Examples:
 Releases are automated from [Conventional Commits](https://www.conventionalcommits.org/).
 You never bump versions by hand.
 
-1. Merge a PR to `main`.
+1. Merge a PR to `master`.
 2. The release workflow reads the commits since the last release and computes the next
    version (`feat:` -> minor, `fix:` -> patch, `feat!:` / `BREAKING CHANGE:` -> major).
 3. It opens a `chore(release): vX.Y.Z` PR that updates `version.json`, `CHANGELOG.md`, and


### PR DESCRIPTION
Prep for the main->master default-branch rename. Updates release/validate workflow triggers, --base target, and doc references (CLAUDE.md, CONTRIBUTING.md). Node idioms (require.main, function main) and README left untouched.