### PR TITLE
fix: correct stale "five experts" wording to reflect 7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Claude Code plugin that provides GPT (via Codex CLI), Gemini 3 (via the Antigravity CLI `agy`), and Grok (via the xAI HTTP API) as specialized expert subagents. Five domain experts that can advise OR implement: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, and Security Analyst. (Grok is advisory-only - it cannot edit files, but can read attached files via the xAI Files API.)
+A Claude Code plugin that provides GPT (via Codex CLI), Gemini 3 (via the Antigravity CLI `agy`), and Grok (via the xAI HTTP API) as specialized expert subagents. Seven domain experts that can advise OR implement: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, and Debugger. (Grok is advisory-only - it cannot edit files, but can read attached files via the xAI Files API.)
 
 ## Development Commands
 
@@ -69,7 +69,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 
-## Five GPT Experts
+## Seven GPT Experts
 
 | Expert | Prompt | Specialty | Triggers |
 |--------|--------|-----------|----------|
@@ -78,6 +78,8 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | **Scope Analyst** | `prompts/scope-analyst.md` | Requirements analysis | "clarify the scope", vague requirements |
 | **Code Reviewer** | `prompts/code-reviewer.md` | Code quality, bugs | "review this code", "find issues" |
 | **Security Analyst** | `prompts/security-analyst.md` | Vulnerabilities | "is this secure", "harden this" |
+| **Researcher** | `prompts/researcher.md` | External libraries, docs, best practices | "how do I use X", "find examples of Y" |
+| **Debugger** | `prompts/debugger.md` | Root-cause analysis, minimal fixes | "why does this crash", "debug this failing test" |
 
 Every expert can operate in **advisory** (`sandbox: read-only`) or **implementation** (`sandbox: workspace-write`) mode based on the task.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -7,7 +7,7 @@ timeout: 60000
 
 # Setup
 
-Configure GPT (via Codex) or Gemini as specialized expert subagents via native MCP. Five domain experts that can advise OR implement.
+Configure GPT (via Codex) or Gemini as specialized expert subagents via native MCP. Seven domain experts that can advise OR implement.
 
 ## Step 1: Check CLI Dependencies
 
@@ -259,7 +259,7 @@ Next steps:
    - Gemini: Run `agy` once and complete sign-in (or set the model in ~/.gemini/settings.json)
    - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai) in your shell profile, then restart Claude Code
 
-Five experts available:
+Seven experts available:
 
 ┌──────────────────┬─────────────────────────────────────────────┐
 │ Architect        │ "How should I structure this service?"      │


### PR DESCRIPTION
## Summary

- `CLAUDE.md` and the `/setup` slash command still advertised **five** domain experts in the prose even though the Researcher (added earlier) and the Debugger (#22) brought the total to seven.
- The setup ASCII table at `commands/setup.md:285-291` already listed all seven, so this only realigns the prose count and adds the two missing rows to the CLAUDE.md table.
- Commit type `fix:` so the automated release picks up the change and cuts v1.13.1 (the prior `docs:` commit in #24 didn't generate a non-empty changelog under the default conventional-changelog preset).

## Test plan

- [x] `rg -n "Five |five " CLAUDE.md commands/setup.md` -> 0 hits
- [x] CLAUDE.md "Seven GPT Experts" table lists 7 rows matching `prompts/*.md`
- [ ] After merge: `Automated Release` workflow opens a v1.13.1 PR; once merged, `Tag and Publish Release` publishes the GitHub release