### PR TITLE
fix(grok): expand DEFAULT_EXCLUDE, merge caller exclude with excludeReset escape hatch

### DIFF
--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -207,8 +207,25 @@ mcp__grok__grok({
 The bridge bundles a zero-dep glob walker (`server/grok/glob.js`) so you do not have
 to enumerate every file by hand:
 
-- `include` (default `["**/*"]`), `exclude` (defaults skip `.git`, `node_modules`,
-  `dist`, `build`, `.venv`, `**/*.lock`, `**/.next`, `**/.svelte-kit`).
+- `include` (default `["**/*"]`).
+- `exclude` is **appended** to the bridge's safe defaults (it does NOT replace
+  them). Defaults cover: VCS (`.git`); JS/Node (`node_modules`, `dist`, `build`,
+  `out`, `.next`, `.svelte-kit`, `.nuxt`, `.turbo`, `.cache`, `.parcel-cache`,
+  `.pnpm-store`); Yarn Berry (`.yarn/cache`, `.yarn/unplugged`); lockfiles
+  (`**/*.lock`); Python (`.venv`, `venv`, `__pycache__`, `.tox`, `.pytest_cache`,
+  `.mypy_cache`, `.ruff_cache`, `.ipynb_checkpoints`, `.eggs`, `htmlcov`);
+  coverage (`coverage`, `.nyc_output`); Rust/Java/Gradle (`target`, `.gradle`);
+  Go/PHP (`vendor`); Terraform (`.terraform`, `.terragrunt-cache`); plus
+  security: `**/*.tfstate*`, granular `.env` variants (keeps `.env.example`
+  readable), `.ssh/**`, SSH keypairs (`id_rsa`, `id_ed25519`, `id_ecdsa`,
+  `id_dsa` and `.pub`), and `**/*.pem`/`**/*.key`.
+- To replace defaults entirely instead of appending, set `excludeReset: true`
+  on the same `{dir}` entry. `excludeReset` is validated as a strict boolean by
+  `validateFiles`; non-boolean values are rejected. Use only when reviewing
+  files defaults would block (e.g., Terraform state in a security audit, or
+  legitimate `.pem` public certs). Tradeoff is explicit: the bridge prefers a
+  false positive (blocking a legitimate `.pem`) over a false negative
+  (leaking a private key).
 - `maxFiles` (default 50), `maxBytes` (default 128 MB). Exceeding either throws a
   hard error with counts - no silent truncation.
 - Walker is symlink-safe: dirs are pruned **before** descent; symlinks to dirs are

--- a/commands/ask-grok.md
+++ b/commands/ask-grok.md
@@ -47,10 +47,14 @@ User question or topic: $ARGUMENTS
    **Files:** attach the local files Grok should read by default in `files`. Each entry
    is EXACTLY ONE of `{ path }` (local file; delivery controlled by `mode` — default
    uploads to the xAI Files API), `{ file_id }` (already uploaded), `{ file_url }`
-   (public URL), or `{ dir, include?, exclude?, maxFiles?, maxBytes? }`
-   (recursive directory expansion via the bundled glob
-   walker; defaults skip `.git`, `node_modules`, `dist`, `build`, `.venv`, lock files,
-   framework build dirs; hard caps `maxFiles=50` / `maxBytes=128MB`). Path/dir entries
+   (public URL), or `{ dir, include?, exclude?, excludeReset?, maxFiles?, maxBytes? }`
+   (recursive directory expansion via the bundled glob walker; caller `exclude`
+   is APPENDED to safe defaults that skip VCS, `node_modules`, `dist`/`build`/`out`,
+   modern Node build dirs, Yarn Berry caches, lockfiles, Python venv/cache dirs,
+   coverage, `target`/`vendor`, `.terraform`/`.terragrunt-cache`, plus security
+   patterns (`*.tfstate*`, `.env*`, `.ssh/**`, SSH keypairs, `*.pem`/`*.key`).
+   Set `excludeReset: true` to replace defaults entirely. Hard caps
+   `maxFiles=50` / `maxBytes=128MB`). Path/dir entries
    also accept `mode: "auto" | "inline" | "upload"` (default `"upload"`): **`"inline"`
    embeds the file as `input_text` so Grok reads it line-by-line** (use this for source
    code review — `input_file` references are searchable, not always fully read);

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -59,9 +59,45 @@ const globMod = require("./glob.js");
 
 const DEFAULT_INCLUDE = ["**/*"];
 const DEFAULT_EXCLUDE = [
-  ".git", ".git/**", "node_modules", "node_modules/**",
-  "dist/**", "build/**", ".venv/**", "**/*.lock",
-  "**/.next/**", "**/.svelte-kit/**",
+  // VCS (bare = any-depth via (?:^|/) anchor in glob.js compile())
+  ".git",
+  // JS / Node ecosystems
+  "node_modules",
+  "**/dist/**", "**/build/**", "**/out/**",
+  "**/.next/**", "**/.svelte-kit/**", "**/.nuxt/**",
+  "**/.turbo/**", "**/.cache/**", "**/.parcel-cache/**",
+  "**/.pnpm-store/**",
+  // Yarn Berry caches (can run into thousands of files)
+  "**/.yarn/cache/**", "**/.yarn/unplugged/**", "**/.yarn/install-state.gz",
+  // Lockfiles
+  "**/*.lock",
+  // Python
+  "**/.venv/**", "**/venv/**",
+  "**/__pycache__/**",
+  "**/.tox/**", "**/.pytest_cache/**", "**/.mypy_cache/**", "**/.ruff_cache/**",
+  "**/.ipynb_checkpoints/**",
+  "**/.eggs/**", "**/htmlcov/**",
+  // Coverage
+  "**/coverage/**", "**/.nyc_output/**",
+  // Rust / Java / Gradle
+  "**/target/**", "**/.gradle/**",
+  // Go / PHP
+  "**/vendor/**",
+  // Terraform
+  "**/.terraform/**", "**/.terragrunt-cache/**",
+  // Security: Terraform state holds plaintext credentials and resource ARNs
+  "**/*.tfstate*", "**/.terraform.tfstate.lock.info",
+  // Security: dotenv (granular - keeps .env.example/.env.sample/.env.template readable)
+  "**/.env", "**/.env.local",
+  "**/.env.development", "**/.env.development.local", "**/.env.dev", "**/.env.dev.local",
+  "**/.env.production", "**/.env.production.local", "**/.env.prod", "**/.env.prod.local",
+  "**/.env.test", "**/.env.test.local",
+  "**/.env.staging", "**/.env.staging.local", "**/.env.stage", "**/.env.stage.local",
+  // Security: SSH config + private keys
+  "**/.ssh/**",
+  "**/id_rsa", "**/id_rsa.pub", "**/id_ed25519", "**/id_ed25519.pub",
+  "**/id_ecdsa", "**/id_ecdsa.pub", "**/id_dsa", "**/id_dsa.pub",
+  "**/*.pem", "**/*.key",
 ];
 const DEFAULT_MAX_FILES = 50;
 const DEFAULT_MAX_BYTES = 128 * 1024 * 1024;
@@ -450,7 +486,11 @@ async function resolveFiles(files, opts) {
       : [require("node:fs").realpathSync(opts.cwd || process.cwd())];
     const resolved = resolvePathUnderRoots(entry.dir.replace(/\\/g, "/"), rootList, "dir");
     const include = entry.include || DEFAULT_INCLUDE;
-    const exclude = entry.exclude || DEFAULT_EXCLUDE;
+    // Caller exclude is APPENDED to bridge defaults. Pass excludeReset: true to
+    // replace defaults entirely (e.g., security review of tfstate / private keys).
+    const exclude = entry.excludeReset === true
+      ? (entry.exclude || [])
+      : [...DEFAULT_EXCLUDE, ...(entry.exclude || [])];
     const maxFiles = entry.maxFiles || DEFAULT_MAX_FILES;
     const maxBytes = entry.maxBytes || DEFAULT_MAX_BYTES;
 
@@ -740,7 +780,8 @@ const FILES_SCHEMA = {
       file_url: { type: "string", description: "Public URL to a file" },
       dir: { type: "string", description: "Local directory to expand recursively (resolved against roots[] or cwd)" },
       include: { type: "array", items: { type: "string" }, description: "POSIX glob patterns to include during dir expansion. Defaults to ['**/*']." },
-      exclude: { type: "array", items: { type: "string" }, description: "POSIX glob patterns to exclude during dir expansion. Defaults skip .git, node_modules, dist, build, .venv, **/*.lock, **/.next, **/.svelte-kit." },
+      exclude: { type: "array", items: { type: "string" }, description: "Additional POSIX glob patterns APPENDED to the bridge's safe defaults (.git, node_modules, .terraform, target, vendor, __pycache__, .yarn caches, *.tfstate, .env*, SSH keys, *.pem, *.key, framework build/cache dirs). To replace defaults entirely instead of appending, set excludeReset: true on the same dir entry." },
+      excludeReset: { type: "boolean", description: "If true, caller's exclude REPLACES bridge defaults. If omitted or false (default), caller's exclude is APPENDED to defaults. Use only when reviewing files defaults would block (e.g., Terraform state in a security audit, or *.pem certificates)." },
       maxFiles: { type: "number", description: "Hard cap on files per dir expansion. Default 50." },
       maxBytes: { type: "number", description: "Hard cap on bytes per dir expansion. Default 134217728 (128 MB)." },
       filename: { type: "string", description: "Override stored filename for a path upload" },
@@ -775,6 +816,9 @@ function validateFiles(files) {
       if (typeof entry.mode !== "string") return "'files' entry mode must be a string when provided";
       if (!["auto", "inline", "upload"].includes(entry.mode)) return `'files' entry mode "${entry.mode}" must be one of: auto, inline, upload`;
       if (entry.file_id !== undefined || entry.file_url !== undefined) return "'files' entry mode applies only to path/dir entries (not file_id/file_url)";
+    }
+    if (entry.excludeReset !== undefined && typeof entry.excludeReset !== "boolean") {
+      return "'excludeReset' must be a boolean";
     }
     if (entry.dir !== undefined) {
       for (const list of [entry.include, entry.exclude]) {

--- a/test/grok-dir.test.js
+++ b/test/grok-dir.test.js
@@ -103,3 +103,76 @@ test("dir expansion picks first root that has the directory", async () => {
 
   assert.equal(refs.length, 1, "first root wins -> only from-a.tf");
 });
+
+test("default exclude blocks .terraform at walked root", async () => {
+  const root = tmpTree({
+    "main.tf": "root-content",
+    ".terraform/modules/foo/main.tf": "vendored-content",
+  });
+  const cacheFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "grok-cache-")), "cache.json");
+  const fakeFetch = async (url) => {
+    if (String(url).endsWith("/files")) return { ok: true, text: async () => JSON.stringify({ id: "f1" }) };
+    return { ok: true, text: async () => "{}" };
+  };
+  const { refs } = await idx.resolveFiles(
+    [{ dir: ".", include: ["main.tf"] }],
+    { apiKey: "xai-T", apiBase: "https://api.x.ai/v1", ttl: 3600,
+      roots: [root], cwd: root, cacheFile, fetchImpl: fakeFetch, cid: "test" },
+  );
+  assert.equal(refs.length, 1);
+  assert.equal(path.basename(refs[0].sourcePath), "main.tf");
+  assert.ok(!refs[0].sourcePath.includes(".terraform"), "must not match vendored copy");
+});
+
+test("caller exclude is appended to defaults", async () => {
+  const root = tmpTree({
+    "main.tf": "root-content",
+    "node_modules/pkg/main.tf": "pkg-content",
+    "custom/main.tf": "custom-content",
+  });
+  const cacheFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "grok-cache-")), "cache.json");
+  const fakeFetch = async (url) => {
+    if (String(url).endsWith("/files")) return { ok: true, text: async () => JSON.stringify({ id: "f1" }) };
+    return { ok: true, text: async () => "{}" };
+  };
+  const { refs } = await idx.resolveFiles(
+    [{ dir: ".", include: ["**/main.tf"], exclude: ["**/custom/**"] }],
+    { apiKey: "xai-T", apiBase: "https://api.x.ai/v1", ttl: 3600,
+      roots: [root], cwd: root, cacheFile, fetchImpl: fakeFetch, cid: "test" },
+  );
+  assert.equal(refs.length, 1);
+  assert.equal(path.basename(refs[0].sourcePath), "main.tf");
+  assert.ok(!refs[0].sourcePath.includes("node_modules"), "default exclude still applies");
+  assert.ok(!refs[0].sourcePath.includes("custom"), "caller exclude appended");
+});
+
+test("excludeReset:true disables default exclude", async () => {
+  const root = tmpTree({
+    "main.tf": "root-content",
+    "vendor/foo/main.tf": "vendored-content",
+  });
+  const cacheFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "grok-cache-")), "cache.json");
+  let uploads = 0;
+  const fakeFetch = async (url) => {
+    if (String(url).endsWith("/files")) { uploads++; return { ok: true, text: async () => JSON.stringify({ id: `f${uploads}` }) }; }
+    return { ok: true, text: async () => "{}" };
+  };
+  const { refs } = await idx.resolveFiles(
+    [{ dir: ".", include: ["**/main.tf"], excludeReset: true }],
+    { apiKey: "xai-T", apiBase: "https://api.x.ai/v1", ttl: 3600,
+      roots: [root], cwd: root, cacheFile, fetchImpl: fakeFetch, cid: "test" },
+  );
+  assert.equal(refs.length, 2);
+  const hasVendored = refs.some(r => r.sourcePath.includes(path.join("vendor", "foo")));
+  assert.ok(hasVendored, "vendored copy walked because defaults disabled");
+});
+
+test("validateFiles rejects non-boolean excludeReset on {dir}", () => {
+  const err = idx.validateFiles([{ dir: "a", excludeReset: "true" }]);
+  assert.match(err || "", /excludeReset.*boolean/i);
+});
+
+test("validateFiles rejects non-boolean excludeReset on {path}", () => {
+  const err = idx.validateFiles([{ path: "a.txt", excludeReset: 1 }]);
+  assert.match(err || "", /excludeReset.*boolean/i);
+});


### PR DESCRIPTION
## Summary

Fixes a Grok MCP `dir-expansion maxFiles=N exceeded` error reported against a Terraform repo, where `.terraform/modules/` held 30+ vendored copies of every Terraform filename and overflowed the walker's caps.

Two compounding defects, both fixed:

1. **`DEFAULT_EXCLUDE` was incomplete and inconsistent.** It covered `node_modules`, `.git`, `dist`, `build`, `.venv`, `.next`, `.svelte-kit`, `**/*.lock` — but missed `.terraform`, `target`, `vendor`, `__pycache__`, Yarn Berry caches, Python lint/test caches, coverage, dotenv, SSH keys, and `*.tfstate*`. Existing entries were also a mix of bare-literal (any-depth) and rooted (`dist/**`) patterns, so monorepo subdirectories leaked through. All directory patterns are now `**/X/**` for monorepo-safe any-depth matching.

2. **Caller `exclude` REPLACED defaults instead of appending.** A caller adding one custom exclude (e.g., `exclude: ["**/build-artifacts/**"]`) silently disabled the entire safety net — including the new tfstate / `.env` / private-key protections. Caller `exclude` is now APPENDED to defaults. A new `excludeReset: true` boolean opts out of defaults entirely, for callers who need to read otherwise-blocked dirs (e.g., reviewing tfstate or `.pem` in a security audit). `validateFiles` rejects non-boolean `excludeReset` on every entry kind so truthy strings cannot silently disable protection.

Plan went through a 4-round `/consensus` loop with GPT (Codex), Gemini, and Grok before implementation; convergence trace lives in `/Users/Bob/.claude/plans/this-was-grok-mcp-happy-karp.md` locally.

### What's in DEFAULT_EXCLUDE now

VCS / JS-Node (incl. `out`, `.nuxt`, `.turbo`, `.cache`, `.parcel-cache`, `.pnpm-store`) / Yarn Berry (`.yarn/cache`, `.yarn/unplugged`) / Python (`__pycache__`, `.tox`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.ipynb_checkpoints`, `.eggs`, `htmlcov`) / Coverage / Rust-Java (`target`, `.gradle`) / Go-PHP (`vendor`) / Terraform (`.terraform`, `.terragrunt-cache`) / **Security**: `*.tfstate*`, granular `.env*` (keeps `.env.example` readable), `.ssh/**`, SSH keypairs, `**/*.pem`, `**/*.key`.

### Public-API contract change

`exclude` was previously REPLACE; it is now APPEND. No tests or docs encoded REPLACE as a documented contract (audited with `rg` across `TECHNICAL.md`, `commands/`, `rules/`, `prompts/`, `.claude-plugin/`, and `test/` per the plan's Pre-flight audit), so this ships as `fix:`. If a downstream caller needs the old REPLACE behavior, set `excludeReset: true`.

## Test plan

- [x] `node --test test/grok-dir.test.js test/grok-glob.test.js` — 24 tests pass (5 new: default-blocks-`.terraform`, caller-exclude-appended, `excludeReset:true`-disables, plus 2 `validateFiles` boolean rejections)
- [x] `node --test` (full suite) — 120 tests, 0 fail
- [ ] **Manual retry** (post-merge + plugin reload): re-issue the failing Grok MCP call against a Terraform repo with `maxFiles: 10`. Expect 2 explicit `path:` entries + 3 walked (`main.tf` / `variables.tf` / `pyproject.toml`) = 5 files attached, no error.
- [ ] **Negative path**: `excludeReset: true` against a tree containing `node_modules/` — walker enters (escape hatch works).
- [ ] **Negative path**: `excludeReset: "true"` (string) on a `{path}` entry — `validateFiles` returns the boolean-required error.