### PR TITLE
fix(setup): quote ${CLAUDE_PLUGIN_ROOT} so MCP bridges resolve current plugin version per spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ Common defaults:
 
 For the full environment-variable reference and manual MCP setup, see [TECHNICAL.md](TECHNICAL.md#environment-variables).
 
+## Updating the plugin
+
+After editing plugin code or upgrading the plugin version:
+
+1. `/mcp`
+2. `gemini` → `Reconnect`
+3. `grok` → `Reconnect`
+
+No `claude` restart needed. Session context is preserved.
+
+Do NOT use `/reload-plugins` - it only applies a manifest diff and ignores source edits.
+
 ## Requirements
 
 You need at least one provider:

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -68,7 +68,7 @@ claude mcp add --transport stdio --scope user codex -- codex -m gpt-5.3-codex mc
 ```bash
 # Idempotent: safe to rerun setup
 claude mcp remove gemini >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js
+claude mcp add --transport stdio --scope user gemini -- node '${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js'
 ```
 
 ### Grok (xAI)
@@ -77,7 +77,7 @@ claude mcp add --transport stdio --scope user gemini -- node ${CLAUDE_PLUGIN_ROO
 # written to ~/.claude.json. The bridge inherits XAI_API_KEY from the environment
 # that launches Claude Code, so export it in your shell profile to persist it.
 claude mcp remove grok >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user grok -- node ${CLAUDE_PLUGIN_ROOT}/server/grok/index.js
+claude mcp add --transport stdio --scope user grok -- node '${CLAUDE_PLUGIN_ROOT}/server/grok/index.js'
 if [ -z "$XAI_API_KEY" ]; then
   echo "Note: XAI_API_KEY not set in this environment; Grok calls return missing-auth until you export it (add it to your shell profile) and restart Claude Code."
 fi
@@ -261,6 +261,7 @@ Next steps:
    - Codex: Run `codex login`
    - Gemini: Run `agy` once and complete sign-in (or set the model in ~/.gemini/settings.json)
    - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai) in your shell profile, then restart Claude Code
+3. After editing plugin code or upgrading the plugin version: run `/mcp` in your Claude Code session and press `Reconnect` on `gemini` and `grok` to load the new code without restarting Claude Code. See README → "Updating the plugin".
 
 Seven experts available:
 


### PR DESCRIPTION
## Summary

- **Bug:** `setup.md` runs `claude mcp add ... -- node ${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js` unquoted, so the shell expands `${CLAUDE_PLUGIN_ROOT}` at setup time and the absolute versioned cache path (e.g. `.../claude-delegator/1.15.0/server/gemini/index.js`) gets baked into `~/.claude.json`. After a `claude plugin upgrade`, the stored command still points at the old version dir, so the bridge keeps launching old code until the user re-runs `/claude-delegator:setup`.
- **Fix:** single-quote the path so the literal `${CLAUDE_PLUGIN_ROOT}` lands in the MCP config. Claude Code substitutes path placeholders per-element at spawn time (confirmed by the `claude` v2.1.153 binary string `"Path placeholders like ${CLAUDE_PLUGIN_ROOT} are substituted per-element as plain strings, so paths with quotes, $, or backticks never reach a shell parser."`). The bridge then always launches from the current plugin version with no re-setup required.
- **Docs:** add an "Updating the plugin" section to `README.md` documenting the in-session `/mcp` -> Reconnect workflow for picking up source edits or version upgrades without restarting Claude Code, and explain why `/reload-plugins` is the wrong tool (its handler only applies a manifest config diff and ignores source edits).
- **Setup pointer:** Step 6 final instructions now mentions the Reconnect workflow.

## Why `/mcp` Reconnect specifically

Disassembly of `claude` v2.1.153 shows two relevant request subtypes:

- `reload_plugins` -> calls `applyPluginMcpDiff`, which only handles servers added or removed from the plugin manifest. A source-code edit does not change the configured command, so the diff sees nothing and the stale stdio child keeps running.
- `mcp_reconnect` -> tears down a single named server's client and respawns it with the current config. Exposed in the `/mcp` interactive UI as the per-server "Reconnect" action. Per-session, per-server, preserves session state.

After the placeholder fix, `/mcp` -> Reconnect is sufficient for both editing the bridge source in dev mode AND picking up a plugin version upgrade.

## One-time migration (not in this PR, just an FYI for existing users)

Anyone whose `claude mcp get gemini` currently shows a versioned absolute path needs to re-run `/claude-delegator:setup` once to swap the baked path for the literal placeholder. Future upgrades are then self-healing.

## Test plan

- [ ] Re-run `/claude-delegator:setup` on this branch and confirm `claude mcp get gemini` Args is the literal `${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js` (not an absolute versioned path). Same for `grok`.
- [ ] Start `claude`, run `/ask-grok hello` - bridge connects and responds (proves runtime substitution works).
- [ ] Add a `console.error('edit-test')` near the top of `server/grok/index.js`, then `/mcp` -> grok -> Reconnect. Verify the new child runs the edited code (e.g. via bridge stderr or the `Gemini Bridge: HEALTHY` style smoke test).
- [ ] Simulate an upgrade (e.g. `claude plugin upgrade` to a future version, or manually rename the cache dir to a new version number) and confirm `/mcp` -> Reconnect picks up the new path without re-running setup.
- [ ] Confirm session context (conversation, todos) survives the Reconnect.
- [ ] Confirm a second concurrent `claude` session is unaffected by Reconnect in the first.