### PR TITLE
ci(validate): install deps before typecheck

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Typecheck
         run: npm run typecheck


### PR DESCRIPTION
Adds an npm ci step (and npm cache) before Typecheck in the validate workflow.

Root cause: PR #50 added a Typecheck step that runs tsc, but tsc is a devDependency and the workflow never installed dependencies, so the step failed and the bridge tests + version-sync gate were skipped. This restores a green validate on dev (and on master once dev merges up).

The job name (validate), the version-sync gate, and all existing steps are unchanged.

Local reproduction of the CI steps: npm ci -> exit 0, npm run typecheck -> exit 0, node --test -> 207 pass / 0 fail, version-sync -> OK.