### PR TITLE
fix(setup): register deliberation MCP server

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -127,6 +127,19 @@ if [ "$OR_ON" = "1" ]; then
 fi
 ```
 
+### Deliberation (unified fan-out server)
+
+The deliberation server powers `/ask-all` and `/consensus`. It selects and
+dispatches the active delegate set (enabled built-ins plus eligible OpenRouter
+aliases) in one server call, so a disabled alias can never be dispatched from a
+stale client-side selection. Register it unconditionally - it fans out to
+whatever providers are enabled.
+
+```bash
+claude mcp remove deliberation >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user deliberation -- node '${CLAUDE_PLUGIN_ROOT}/server/mcp/index.js'
+```
+
 **Codex model (optional):** by default Codex inherits its model, sandbox, and
 approval policy from `~/.codex/config.toml` (the `model` key) - change it there
 and every provider that reads that file follows. To pin a model on the MCP server


### PR DESCRIPTION
setup.md registered codex/gemini/grok/openrouter but never the new deliberation server, so after PR #50 merged, /ask-all and /consensus had no mcp__deliberation__ tools to call. The .claude-plugin/mcp.json entry added in PR #50 is not a registration mechanism the plugin uses (the working servers are user-scope via setup.md, not plugin-scope).

This adds the deliberation registration block to setup.md, mirroring the openrouter block. Registered locally and verified: claude mcp get deliberation -> Connected, 13 tools (ask-all, consensus, ask-gpt|gemini|grok|openrouter, 7 experts).

Note: existing installs need to re-run /setup (or claude mcp add) and restart the session to pick up the new tools.