### PR TITLE
fix(uninstall): remove deliberation MCP server on uninstall

### DIFF
--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -25,6 +25,7 @@ claude mcp remove --scope user codex
 claude mcp remove --scope user gemini
 claude mcp remove --scope user grok
 claude mcp remove --scope user openrouter
+claude mcp remove --scope user deliberation
 ```
 
 ## Remove Installed Rules


### PR DESCRIPTION
Mirror of the deliberation registration added to setup.md (PR #52). uninstall.md removed codex/gemini/grok/openrouter but not the deliberation server, leaving it orphaned in ~/.claude.json after uninstall.

Adds claude mcp remove --scope user deliberation to the remove block and updates the confirmation prompt to list Deliberation.

Do NOT merge yet - under test.