### PR TITLE
feat(plugin)!: rebrand claude-delegator -> deliberation + namespace bridge MCPs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "deliberation",
       "source": "./",
-      "description": "Deliberation for Claude Code - GPT, Gemini, Grok, and OpenRouter expert subagents. Seven specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger.",
+      "description": "GPT (Codex CLI), Gemini, Grok (xAI), and OpenRouter (400+ models) expert subagents for Claude Code and any MCP host. Seven experts (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) that advise or implement across delegation, code review, and architecture.",
       "version": "1.18.0",
       "author": {
         "name": "Anton Babenko",
@@ -27,10 +27,12 @@
         "google",
         "grok",
         "xai",
-        "files",
+        "openrouter",
         "experts",
         "subagents",
-        "orchestration"
+        "orchestration",
+        "code-review",
+        "architecture"
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,21 +1,21 @@
 {
-  "name": "antonbabenko-claude-delegator",
+  "name": "antonbabenko-deliberation",
   "owner": {
     "name": "Anton Babenko",
     "url": "https://github.com/antonbabenko"
   },
   "plugins": [
     {
-      "name": "claude-delegator",
+      "name": "deliberation",
       "source": "./",
-      "description": "GPT (Codex CLI), Gemini (bundled MCP bridge), and Grok (xAI HTTP bridge) expert subagents for Claude Code. Seven specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger.",
+      "description": "Deliberation for Claude Code - GPT, Gemini, Grok, and OpenRouter expert subagents. Seven specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger.",
       "version": "1.18.0",
       "author": {
         "name": "Anton Babenko",
         "url": "https://github.com/antonbabenko"
       },
-      "homepage": "https://github.com/antonbabenko/claude-delegator",
-      "repository": "https://github.com/antonbabenko/claude-delegator",
+      "homepage": "https://github.com/antonbabenko/deliberation",
+      "repository": "https://github.com/antonbabenko/deliberation",
       "license": "MIT",
       "keywords": [
         "delegation",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "deliberation",
       "source": "./",
-      "description": "GPT (Codex CLI), Gemini, Grok (xAI), and OpenRouter (400+ models) expert subagents for Claude Code and any MCP host. Seven experts (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) that advise or implement across delegation, code review, and architecture.",
+      "description": "Use when you want a delegated second opinion or implementation from GPT (Codex), Gemini, Grok (xAI), or OpenRouter (config-driven, 400+ models) - seven expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) and bundled ask-gpt/ask-gemini/ask-grok/ask-openrouter/ask-all/consensus commands, advisory (read-only) or implementation (write; Grok and OpenRouter are advisory-only).",
       "version": "1.18.0",
       "author": {
         "name": "Anton Babenko",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deliberation",
-  "description": "Deliberation for Claude Code - GPT, Gemini, Grok, and OpenRouter expert subagents. Seven specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger.",
+  "description": "GPT (Codex CLI), Gemini, Grok (xAI), and OpenRouter (400+ models) expert subagents for Claude Code and any MCP host. Seven experts (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) that advise or implement across delegation, code review, and architecture.",
   "version": "1.18.0",
   "author": {
     "name": "Anton Babenko",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "name": "claude-delegator",
-  "description": "GPT (Codex CLI), Gemini (bundled MCP bridge), and Grok (xAI HTTP bridge) expert subagents for Claude Code. Seven specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger.",
+  "name": "deliberation",
+  "description": "Deliberation for Claude Code - GPT, Gemini, Grok, and OpenRouter expert subagents. Seven specialized experts: Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger.",
   "version": "1.18.0",
   "author": {
     "name": "Anton Babenko",
     "url": "https://github.com/antonbabenko"
   },
-  "homepage": "https://github.com/antonbabenko/claude-delegator",
-  "repository": "https://github.com/antonbabenko/claude-delegator",
+  "homepage": "https://github.com/antonbabenko/deliberation",
+  "repository": "https://github.com/antonbabenko/deliberation",
   "license": "MIT",
   "keywords": ["delegation", "mcp", "codex", "gpt", "openai", "gemini", "antigravity", "agy", "google", "grok", "xai", "files", "experts", "subagents", "orchestration"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deliberation",
-  "description": "GPT (Codex CLI), Gemini, Grok (xAI), and OpenRouter (400+ models) expert subagents for Claude Code and any MCP host. Seven experts (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) that advise or implement across delegation, code review, and architecture.",
+  "description": "Use when you want a delegated second opinion or implementation from GPT (Codex), Gemini, Grok (xAI), or OpenRouter (config-driven, 400+ models) - seven expert subagents (Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security Analyst, Researcher, Debugger) and bundled ask-gpt/ask-gemini/ask-grok/ask-openrouter/ask-all/consensus commands, advisory (read-only) or implementation (write; Grok and OpenRouter are advisory-only).",
   "version": "1.18.0",
   "author": {
     "name": "Anton Babenko",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,13 @@ A Claude Code plugin that provides GPT (via Codex CLI), Gemini 3 (via the Antigr
 
 ```bash
 # Test plugin locally (loads from working directory)
-claude --plugin-dir /path/to/claude-delegator
+claude --plugin-dir /path/to/deliberation
 
 # Run setup to test installation flow
-/claude-delegator:setup
+/deliberation:setup
 
 # Run uninstall to test removal flow
-/claude-delegator:uninstall
+/deliberation:uninstall
 ```
 
 No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok, and OpenRouter use bundled zero-dependency Node bridges (`server/gemini/index.js`, `server/grok/index.js`, `server/openrouter/index.js`). The Gemini bridge wraps the Antigravity CLI (`agy`) in print mode. The OpenRouter bridge calls any OpenAI-compatible `/chat/completions` endpoint.
@@ -25,7 +25,7 @@ No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok,
 
 ### Orchestration Flow
 
-Claude acts as orchestrator—delegates to specialized experts based on task type. Supports both **single-shot** (independent calls) and **multi-turn** (context preserved via `threadId`).
+Claude acts as orchestrator - delegates to specialized experts based on task type. Supports both **single-shot** (independent calls) and **multi-turn** (context preserved via `threadId`).
 
 ```
 User Request → Claude Code → [Match trigger → Select expert & provider]
@@ -44,7 +44,7 @@ User Request → Claude Code → [Match trigger → Select expert & provider]
 1. **Match trigger** - Check `rules/triggers.md` for semantic patterns
 2. **Read expert prompt** - Load from `prompts/[expert].md`
 3. **Build 7-section prompt** - Use format from `rules/delegation-format.md`
-4. **Call provider tool** - `mcp__codex__codex`, `mcp__gemini__gemini`, `mcp__grok__grok`, or `mcp__openrouter__openrouter`
+4. **Call provider tool** - `mcp__codex__codex`, `mcp__gemini__gemini`, `mcp__grok__grok`, or `mcp__deliberation__openrouter`
 5. **Synthesize response** - Never show raw output; interpret and verify
 
 ### The 7-Section Delegation Format
@@ -62,11 +62,11 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 
 | Component | Purpose | Notes |
 |-----------|---------|-------|
-| `rules/*.md` | When/how to delegate | Installed to `~/.claude/rules/delegator/` |
+| `rules/*.md` | When/how to delegate | Installed to `~/.claude/rules/deliberation/` |
 | `prompts/*.md` | Expert personalities | Injected via `developer-instructions` |
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
-| `~/.claude/claude-delegator/config.json` | OpenRouter model config | Live SSOT; stat-gated hot-reload |
+| `~/.claude/deliberation/config.json` | OpenRouter model config | Live SSOT (legacy `~/.claude/claude-delegator/` read as fallback); stat-gated hot-reload |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 
@@ -82,15 +82,15 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | **Researcher** | `prompts/researcher.md` | External libraries, docs, best practices | "how do I use X", "find examples of Y" |
 | **Debugger** | `prompts/debugger.md` | Root-cause analysis, minimal fixes | "why does this crash", "debug this failing test" |
 
-Every expert can operate in **advisory** (`sandbox: read-only`) or **implementation** (`sandbox: workspace-write`) mode based on the task. OpenRouter models are always advisory - per-model expert eligibility is controlled by the `experts` field in `~/.claude/claude-delegator/config.json`.
+Every expert can operate in **advisory** (`sandbox: read-only`) or **implementation** (`sandbox: workspace-write`) mode based on the task. OpenRouter models are always advisory - per-model expert eligibility is controlled by the `experts` field in `~/.claude/deliberation/config.json`.
 
 ## Grok file access
 
-Grok reads attached files via `files[]` and resolves them under `roots[]` (top-level array of absolute directories) or `cwd`. `path` and `dir` entries take an optional `mode: "auto" | "inline" | "upload"` — inline embeds the file as `input_text` so Grok reads it line-by-line (best for source code); upload routes through the xAI Files API and is SHA-256 dedup-cached locally. `file_id` / `file_url` entries pass through unchanged and do not accept `mode`. Directory expansion via `{dir}` entries. See **[TECHNICAL.md: Grok files and cleanup](TECHNICAL.md#grok-files-and-cleanup)** for parameters, the inline-vs-upload tradeoff, cross-repo usage, cache layout, and the `gc` cleanup subcommand.
+Grok reads attached files via `files[]` and resolves them under `roots[]` (top-level array of absolute directories) or `cwd`. `path` and `dir` entries take an optional `mode: "auto" | "inline" | "upload"` - inline embeds the file as `input_text` so Grok reads it line-by-line (best for source code); upload routes through the xAI Files API and is SHA-256 dedup-cached locally. `file_id` / `file_url` entries pass through unchanged and do not accept `mode`. Directory expansion via `{dir}` entries. See **[TECHNICAL.md: Grok files and cleanup](TECHNICAL.md#grok-files-and-cleanup)** for parameters, the inline-vs-upload tradeoff, cross-repo usage, cache layout, and the `gc` cleanup subcommand.
 
 ## Key Design Decisions
 
-1. **Native & Bridge MCP** - Codex has a native `mcp-server` command. Gemini requires a bundled bridge (`server/gemini/index.js`) that wraps the Antigravity CLI (`agy`) in print mode. Grok has no MCP or CLI server mode, so a bundled bridge (`server/grok/index.js`) wraps the xAI **Responses API** (`/v1/responses`) directly - advisory-only (no file editing), but it can READ attached files (`files:[{path|file_id|file_url|dir}]`, optional `roots[]`, per-entry `mode` for upload-vs-inline delivery); uploaded files are SHA-256 dedup-cached locally, auto-expire (7-day default, `GROK_FILE_TTL_SECONDS`), and are managed with `/grok-files` (`server/grok/files-admin.js`: `list`/`prune`/`gc`). Details in [TECHNICAL.md § Grok files and cleanup](TECHNICAL.md#grok-files-and-cleanup). OpenRouter uses a bundled bridge (`server/openrouter/index.js`) that calls any OpenAI-compatible `POST {apiBase}/chat/completions` endpoint - advisory-only, text-inline file attachment only (`{path}`/`{dir}`; no upload path), config-driven via `~/.claude/claude-delegator/config.json`. Details in [TECHNICAL.md § OpenRouter bridge](TECHNICAL.md#openrouter-bridge).
+1. **Native & Bridge MCP** - Codex has a native `mcp-server` command. Gemini requires a bundled bridge (`server/gemini/index.js`) that wraps the Antigravity CLI (`agy`) in print mode. Grok has no MCP or CLI server mode, so a bundled bridge (`server/grok/index.js`) wraps the xAI **Responses API** (`/v1/responses`) directly - advisory-only (no file editing), but it can READ attached files (`files:[{path|file_id|file_url|dir}]`, optional `roots[]`, per-entry `mode` for upload-vs-inline delivery); uploaded files are SHA-256 dedup-cached locally, auto-expire (7-day default, `GROK_FILE_TTL_SECONDS`), and are managed with `/grok-files` (`server/grok/files-admin.js`: `list`/`prune`/`gc`). Details in [TECHNICAL.md § Grok files and cleanup](TECHNICAL.md#grok-files-and-cleanup). OpenRouter uses a bundled bridge (`server/openrouter/index.js`) that calls any OpenAI-compatible `POST {apiBase}/chat/completions` endpoint - advisory-only, text-inline file attachment only (`{path}`/`{dir}`; no upload path), config-driven via `~/.claude/deliberation/config.json`. Details in [TECHNICAL.md § OpenRouter bridge](TECHNICAL.md#openrouter-bridge).
 2. **Single-shot + multi-turn** - Single-shot for advisory (full context per call), multi-turn via `threadId` for chained implementation and retries
 3. **Dual mode** - Any expert can advise or implement based on task
 4. **Synthesize, don't passthrough** - Claude interprets expert output, applies judgment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ User Request → Claude Code → [Match trigger → Select expert & provider]
 1. **Match trigger** - Check `rules/triggers.md` for semantic patterns
 2. **Read expert prompt** - Load from `prompts/[expert].md`
 3. **Build 7-section prompt** - Use format from `rules/delegation-format.md`
-4. **Call provider tool** - `mcp__codex__codex`, `mcp__gemini__gemini`, `mcp__grok__grok`, or `mcp__deliberation__openrouter`
+4. **Call provider tool** - `mcp__deliberation-codex__codex`, `mcp__deliberation-gemini__gemini`, `mcp__deliberation-grok__grok`, or `mcp__deliberation-openrouter__openrouter`
 5. **Synthesize response** - Never show raw output; interpret and verify
 
 ### The 7-Section Delegation Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | `prompts/*.md` | Expert personalities | Injected via `developer-instructions` |
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
-| `~/.claude/deliberation/config.json` | OpenRouter model config | Live SSOT (legacy `~/.claude/claude-delegator/` read as fallback); stat-gated hot-reload |
+| `~/.claude/deliberation/config.json` | OpenRouter model config | Live SSOT; stat-gated hot-reload |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to claude-delegator
+# Contributing to deliberation
 
 Contributions welcome. This document covers how to contribute effectively.
 
@@ -8,15 +8,15 @@ Contributions welcome. This document covers how to contribute effectively.
 
 ```bash
 # Clone the repo
-git clone https://github.com/antonbabenko/claude-delegator
-cd claude-delegator
+git clone https://github.com/antonbabenko/deliberation
+cd deliberation
 
 # Run `claude` and install plugin in Claude Code
 claude
-/claude-delegator:setup
+/deliberation:setup
 
 # Or test your changes locally without reinstalling
-claude --plugin-dir /path/to/claude-delegator
+claude --plugin-dir /path/to/deliberation
 ```
 
 ---
@@ -36,7 +36,7 @@ claude --plugin-dir /path/to/claude-delegator
 ## Project Structure
 
 ```
-claude-delegator/
+deliberation/
 ├── .claude-plugin/         # Plugin manifest
 │   └── plugin.json
 ├── commands/               # Slash commands (/setup, /uninstall)
@@ -53,7 +53,7 @@ claude-delegator/
 
 ### Before Submitting
 
-1. **Test your changes** - Run `/claude-delegator:setup` and verify
+1. **Test your changes** - Run `/deliberation:setup` and verify
 2. **Update docs** - If you change behavior, update relevant docs
 3. **Keep commits atomic** - One logical change per commit
 
@@ -94,7 +94,7 @@ You never bump versions by hand.
 3. It opens a `chore(release): vX.Y.Z` PR that updates `version.json`, `CHANGELOG.md`, and
    the synced manifests, then auto-merges it once the `validate` check passes.
 4. On merge, a second workflow tags `vX.Y.Z` and publishes the GitHub Release.
-5. The `antonbabenko/agent-plugins` marketplace then re-pins `claude-delegator` to the new
+5. The `antonbabenko/agent-plugins` marketplace then re-pins `deliberation` to the new
    release (immediately if its dispatch token is set, otherwise within a day via cron).
 
 `version.json` is the single source of truth. `.claude-plugin/plugin.json`,
@@ -163,7 +163,7 @@ check fails if they drift.
 After changes, verify with actual MCP calls:
 
 1. Install the plugin in Claude Code
-2. Run `/claude-delegator:setup`
+2. Run `/deliberation:setup`
 3. Verify MCP tools are available (`mcp__codex__codex`)
 4. Test MCP tool calls via oracle delegation
 5. Verify responses are properly synthesized

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ After changes, verify with actual MCP calls:
 
 1. Install the plugin in Claude Code
 2. Run `/deliberation:setup`
-3. Verify MCP tools are available (`mcp__codex__codex`)
+3. Verify MCP tools are available (`mcp__deliberation-codex__codex`)
 4. Test MCP tool calls via oracle delegation
 5. Verify responses are properly synthesized
 6. Test error cases (timeout, missing CLI)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Delegator
+# Deliberation
 
 Get a second opinion in Claude Code from GPT, Gemini, and Grok - plus 300+ more models through OpenRouter, including Qwen, Kimi, and DeepSeek. Seven domain experts (Architect, Code Reviewer, Security Analyst, and four more) review your plans, find bugs, and debate edge cases until they agree.
 
@@ -29,7 +29,7 @@ When three models argue, the real bug reveals itself. Round 1 = independent top 
 
 </details>
 
-## What is Claude Delegator?
+## What is Deliberation?
 
 Claude can ask GPT, Gemini, Grok, or any OpenAI-compatible model (via OpenRouter) for help
 through MCP. The plugin handles the wiring for each provider so you just write the prompt.
@@ -37,7 +37,7 @@ Each expert has a distinct specialty and can advise or implement.
 
 You can use any subset of the providers. The plugin detects which are configured and routes
 accordingly. OpenRouter is advisory-only and config-driven: models are declared in
-`~/.claude/claude-delegator/config.json` and hot-reload without restarting Claude Code.
+`~/.claude/deliberation/config.json` and hot-reload without restarting Claude Code.
 
 | What you get | Why it matters |
 |--------------|----------------|
@@ -58,12 +58,12 @@ Inside a Claude Code instance, run:
 
 **2. Install the plugin**
 ```
-/plugin install claude-delegator@antonbabenko
+/plugin install deliberation@antonbabenko
 ```
 
 **3. Run setup**
 ```
-/claude-delegator:setup
+/deliberation:setup
 ```
 
 Claude now routes complex tasks to your GPT, Gemini, Grok, and OpenRouter experts (Grok and OpenRouter advise; GPT and Gemini can also implement).
@@ -92,7 +92,7 @@ You need at least one provider:
 - **Codex CLI** (GPT): `npm install -g @openai/codex`, then `codex login`.
 - **Antigravity CLI**: [Getting Started with Antigravity CLI](https://antigravity.google/docs/cli-getting-started) and [Migrating from Gemini CLI](https://antigravity.google/docs/gcli-migration), then run `agy` and login.
 - **Grok (xAI)**: no CLI to install; the bridge ships with the plugin (needs Node 18+). Set `XAI_API_KEY` (get a key at https://console.x.ai).
-- **OpenRouter**: no CLI; the bridge ships with the plugin (needs Node 18+). Set `OPENROUTER_API_KEY` (get a key at https://openrouter.ai/keys), then declare models in `~/.claude/claude-delegator/config.json`. Works with any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, HuggingFace Inference) - auth is skipped automatically when the key env var is empty.
+- **OpenRouter**: no CLI; the bridge ships with the plugin (needs Node 18+). Set `OPENROUTER_API_KEY` (get a key at https://openrouter.ai/keys), then declare models in `~/.claude/deliberation/config.json`. Works with any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, HuggingFace Inference) - auth is skipped automatically when the key env var is empty.
 
 ## Commands
 
@@ -100,15 +100,15 @@ Bundled with the plugin (available once installed):
 
 | Command | Purpose |
 |---------|---------|
-| `/claude-delegator:setup` | Configure Codex/Gemini/Grok/OpenRouter MCP servers + orchestration rules |
-| `/claude-delegator:consensus` | 🔥🔥🔥 Arbiter-mediated GPT + Gemini + Grok + Claude convergence loop |
-| `/claude-delegator:ask-all` | 🔥 GPT + Gemini + Grok (+ configured OpenRouter models) in parallel, synthesized |
-| `/claude-delegator:ask-gpt` | One-shot GPT (Codex) second opinion |
-| `/claude-delegator:ask-gemini` | One-shot Gemini second opinion |
-| `/claude-delegator:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only) |
-| `/claude-delegator:ask-openrouter` | One-shot OpenRouter model second opinion (advisory-only) |
-| `/claude-delegator:uninstall` | Remove MCP config, rules, and aliases |
-| `/claude-delegator:grok-files` | List, prune, or gc Grok-uploaded files (storage + local cache cleanup) |
+| `/deliberation:setup` | Configure Codex/Gemini/Grok/OpenRouter MCP servers + orchestration rules |
+| `/deliberation:consensus` | 🔥🔥🔥 Arbiter-mediated GPT + Gemini + Grok + Claude convergence loop |
+| `/deliberation:ask-all` | 🔥 GPT + Gemini + Grok (+ configured OpenRouter models) in parallel, synthesized |
+| `/deliberation:ask-gpt` | One-shot GPT (Codex) second opinion |
+| `/deliberation:ask-gemini` | One-shot Gemini second opinion |
+| `/deliberation:ask-grok` | One-shot Grok (xAI) second opinion (advisory-only) |
+| `/deliberation:ask-openrouter` | One-shot OpenRouter model second opinion (advisory-only) |
+| `/deliberation:uninstall` | Remove MCP config, rules, and aliases |
+| `/deliberation:grok-files` | List, prune, or gc Grok-uploaded files (storage + local cache cleanup) |
 
 `/setup` can also install short aliases (`/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-all`, `/consensus`, `/grok-files`) into `~/.claude/commands/`. This is opt-in. Existing same-named commands are kept by default; setup asks before overwriting any of them. `/uninstall` removes an alias only if it is byte-identical to the bundled copy.
 
@@ -202,8 +202,9 @@ Every expert supports two modes, chosen automatically from your request:
 
 ### OpenRouter config
 
-OpenRouter models are declared in `~/.claude/claude-delegator/config.json`
-(override path with `CLAUDE_DELEGATOR_CONFIG`). The file is the live single source of
+OpenRouter models are declared in `~/.claude/deliberation/config.json`
+(override path with `DELIBERATION_CONFIG`; the legacy `CLAUDE_DELEGATOR_CONFIG` and
+`~/.claude/claude-delegator/config.json` path are still read as a fallback). The file is the live single source of
 truth: changes to the `openrouter` block hot-reload without restarting Claude Code.
 Toggling a built-in provider (codex / gemini / grok) still requires `/setup`.
 
@@ -272,7 +273,7 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, 
 
 ## Credits
 
-Claude Delegator started as a fork of [jarrodwatts/claude-delegator](https://github.com/jarrodwatts/claude-delegator) - credit to Jarrod Watts for the original solution and inspiration. Original work and MIT copyright are retained. This fork adds Grok support, Gemini bridge reliability (timeout and trust recovery), provider configuration overrides, and the bundled delegation commands. It is not an official continuation of the upstream project.
+Deliberation started as a fork of [jarrodwatts/claude-delegator](https://github.com/jarrodwatts/claude-delegator) - credit to Jarrod Watts for the original solution and inspiration. Original work and MIT copyright are retained. This fork adds Grok support, Gemini bridge reliability (timeout and trust recovery), provider configuration overrides, and the bundled delegation commands. It is not an official continuation of the upstream project.
 
 Expert prompts are adapted from [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) (snapshot `03eb9fff`, 2026-05-25) and [PAL MCP server](https://github.com/BeehiveInnovations/pal-mcp-server) (Apache-2.0, snapshot `7afc7c1`, 2026-05-25).
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ Every expert supports two modes, chosen automatically from your request:
 ### OpenRouter config
 
 OpenRouter models are declared in `~/.claude/deliberation/config.json`
-(override path with `DELIBERATION_CONFIG`; the legacy `CLAUDE_DELEGATOR_CONFIG` and
-`~/.claude/claude-delegator/config.json` path are still read as a fallback). The file is the live single source of
+(override the path with `DELIBERATION_CONFIG`). The file is the live single source of
 truth: changes to the `openrouter` block hot-reload without restarting Claude Code.
 Toggling a built-in provider (codex / gemini / grok) still requires `/setup`.
 
@@ -262,6 +261,26 @@ file-attachment caps, session model persistence, consensus cost model, and error
 see [TECHNICAL.md - OpenRouter bridge](TECHNICAL.md#openrouter-bridge).
 
 For provider defaults, environment variables, and manual MCP setup, see [TECHNICAL.md](TECHNICAL.md#environment-variables).
+
+## Upgrade from 1.x (claude-delegator -> deliberation)
+
+2.0 renames the plugin and drops 1.x compatibility. One-time steps:
+
+1. Move your config: `mv ~/.claude/claude-delegator ~/.claude/deliberation` (or set
+   `DELIBERATION_CONFIG` to a custom path; `CLAUDE_DELEGATOR_CONFIG` is no longer read).
+2. Re-run `/deliberation:setup` to register the renamed MCP servers. The old bare
+   `codex`/`gemini`/`grok`/`openrouter` registrations are not auto-removed. If you had them,
+   remove each one (the CLI takes one name per call):
+   ```
+   claude mcp remove --scope user codex
+   claude mcp remove --scope user gemini
+   claude mcp remove --scope user grok
+   claude mcp remove --scope user openrouter
+   ```
+3. Slash commands moved from `/claude-delegator:*` to `/deliberation:*` (the short aliases
+   `/ask-gpt` etc. are unchanged).
+4. Optional cleanup: `rm -rf ~/.claude/rules/delegator ~/.claude/cache/claude-delegator`.
+5. Restart Claude Code.
 
 ## Author
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -147,8 +147,8 @@ Codex has no bridge environment variables: it ships its own native MCP server an
 reads `~/.codex/config.toml` directly. The **model** comes from the `model` key in
 that file by default (the Codex analog of `GEMINI_DEFAULT_MODEL` /
 `GROK_DEFAULT_MODEL`). Override it on the server with `-c model=<id>` on the
-`claude mcp add ... codex` registration, or per call with the `model` parameter of
-`mcp__codex__codex(...)`. See [Configuration in the README](README.md#configuration).
+`claude mcp add ... deliberation-codex` registration, or per call with the `model` parameter of
+`mcp__deliberation-codex__codex(...)`. See [Configuration in the README](README.md#configuration).
 
 ## Manual MCP setup
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -44,9 +44,9 @@ Claude: detects a security question, selects the Security Analyst
                 |
                 v
    +-------------------------------------+
-   |  mcp__codex__codex /                |
-   |  mcp__gemini__gemini /              |
-   |  mcp__grok__grok                    |
+   |  mcp__deliberation-codex__codex /   |
+   |  mcp__deliberation-gemini__gemini / |
+   |  mcp__deliberation-grok__grok       |
    |    -> Security Analyst prompt       |
    |    -> expert analyzes your code     |
    +-------------------------------------+
@@ -239,7 +239,7 @@ that escape via `realpath` are also refused. An oversize file (>48 MB) returns
 ### Cross-repo example
 
 ```js
-mcp__grok__grok({
+mcp__deliberation-grok__grok({
   prompt: "Compare the auth strategy in these two services.",
   cwd: "/Users/me/work/service-a",
   roots: ["/Users/me/work/service-a", "/Users/me/work/service-b"],

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -319,7 +319,7 @@ Uploads are deduplicated by SHA-256 content hash. A reuse hit requires the SAME 
 (see cache-key below); identical bytes uploaded under a different filename or a different
 key produce separate cache rows:
 
-- Cache file: `~/.claude/cache/deliberation/grok-files.json` (legacy `~/.claude/cache/claude-delegator/grok-files.json` read as a fallback)
+- Cache file: `~/.claude/cache/deliberation/grok-files.json`
 - Cache key: `sha256(bytes)@sha256(XAI_API_KEY)[:16]@normalize(apiBase)@effectiveFilename`
   - Key rotation auto-invalidates entries (different `keyFp`).
   - Different `apiBase` (including port/protocol differences) → separate rows.
@@ -370,8 +370,8 @@ It is **advisory-only** - it cannot edit files or run shell commands.
 ### Configuration file
 
 The bridge and the fan-out commands (`/ask-all`, `/consensus`) read
-`~/.claude/claude-delegator/config.json` at call time. Override the path with
-`CLAUDE_DELEGATOR_CONFIG`. The file is stat-gated: the bridge re-reads it only when
+`~/.claude/deliberation/config.json` at call time. Override the path with
+`DELIBERATION_CONFIG`. The file is stat-gated: the bridge re-reads it only when
 the mtime changes, so edits to the `openrouter` block (models, flags, defaults) take
 effect immediately without restarting Claude Code or re-running `/setup`. Toggling a
 **built-in** provider (codex / gemini / grok) still requires `/setup` to re-register

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -1,6 +1,6 @@
 # Technical Reference
 
-Advanced and internal details for Claude Delegator. For install and everyday use,
+Advanced and internal details for Deliberation. For install and everyday use,
 see the [README](README.md). This document covers the provider bridges, the full
 environment-variable reference, manual MCP setup, multi-turn and retry behavior,
 and the Gemini recovery paths.
@@ -116,7 +116,7 @@ it can read context to advise but cannot mutate the real workspace, even under
 A bundled zero-dependency Node bridge over the xAI Responses API
 (`/v1/responses`). It is advisory-only (it cannot edit files) but it can read
 attached files: pass `files: [{ path | file_id | file_url | dir }]` and the
-bridge delivers them per the `mode` setting — uploaded to the xAI Files API
+bridge delivers them per the `mode` setting - uploaded to the xAI Files API
 (default), inlined as `input_text` (for line-by-line reading of source files),
 or expanded via the bundled glob walker for directories. Resolution is against
 the top-level `roots: string[]` (first-root-wins) or `cwd` when `roots` is
@@ -224,7 +224,7 @@ budget is exhausted, the call fails with `errorKind: "timeout"` (still
 
 Grok reads attached files via the `files[]` parameter. Each entry has EXACTLY ONE of:
 
-- `path` - a local file. Delivery is controlled by `mode` (default `"upload"` — bridge uploads to the xAI Files API; `"inline"` embeds as `input_text`; `"auto"` picks per heuristic — see "Inline vs upload delivery" below).
+- `path` - a local file. Delivery is controlled by `mode` (default `"upload"` - bridge uploads to the xAI Files API; `"inline"` embeds as `input_text`; `"auto"` picks per heuristic - see "Inline vs upload delivery" below).
 - `file_id` - an already-uploaded xAI file id (passed through, no upload).
 - `file_url` - a public URL (passed through).
 - `dir` - a local directory expanded recursively. Same `mode` rules; the walker
@@ -319,7 +319,7 @@ Uploads are deduplicated by SHA-256 content hash. A reuse hit requires the SAME 
 (see cache-key below); identical bytes uploaded under a different filename or a different
 key produce separate cache rows:
 
-- Cache file: `~/.claude/cache/claude-delegator/grok-files.json`
+- Cache file: `~/.claude/cache/deliberation/grok-files.json` (legacy `~/.claude/cache/claude-delegator/grok-files.json` read as a fallback)
 - Cache key: `sha256(bytes)@sha256(XAI_API_KEY)[:16]@normalize(apiBase)@effectiveFilename`
   - Key rotation auto-invalidates entries (different `keyFp`).
   - Different `apiBase` (including port/protocol differences) → separate rows.
@@ -338,7 +338,7 @@ key produce separate cache rows:
   known file id are surfaced unchanged.
 - `XAI_DISABLE_FILE_CACHE=1` (env) skips the cache layer entirely (debugging).
 
-Stored upload filenames are `claude-delegator-{sha256[:16]}-{basename}`. Uploads also
+Stored upload filenames are `deliberation-{sha256[:16]}-{basename}`. Uploads also
 carry `expires_after` set by `GROK_FILE_TTL_SECONDS` (default `604800` = 7 days,
 clamped 1h..30d).
 
@@ -346,7 +346,7 @@ clamped 1h..30d).
 
 The bundled `server/grok/files-admin.js` supports three subcommands:
 
-- `list` - shows total xAI file count and every `claude-delegator-*` upload.
+- `list` - shows total xAI file count and every `deliberation-*` upload.
 - `prune --older-than <30m|24h|7d|seconds> [--yes]` - dry run by default; deletes
   **remote** bridge-owned files matched by filename prefix + age. Works without the
   local cache; safe for environments where the cache was lost or never existed.
@@ -358,7 +358,7 @@ The bundled `server/grok/files-admin.js` supports three subcommands:
   files). `--force-local-prune` drops ambiguous foreign rows anyway.
 
 `prune` and `gc` are complementary: `prune` is the remote-side cleaner; `gc` keeps
-the local cache aligned with remote state. The `claude-delegator-` filename prefix
+the local cache aligned with remote state. The `deliberation-` filename prefix
 is a hard safety invariant on both paths - your own xAI files are never touched.
 
 ## OpenRouter bridge
@@ -440,7 +440,7 @@ rounds; you want the models reasoning, not improvising.
   for the requested expert; capped to `maxFanout` models (default 3).
 - **`/consensus`**: includes models where `consensus === true`; NOT subject to `maxFanout`.
   A warning is logged when more than 3 models enter a consensus round (cost).
-- **`openrouter-default`** is the reserved alias for the bare `mcp__openrouter__openrouter`
+- **`openrouter-default`** is the reserved alias for the bare `mcp__deliberation__openrouter`
   call and `/ask-openrouter` with no alias specified. It is the single-shot fallback only
   and is never included in fan-out or consensus.
 - Implementation tasks always route to Codex or Gemini, never to OpenRouter.
@@ -454,7 +454,7 @@ valid delegate and collects the bad ones into `invalidModels`. Only **top-level/
 problems hard-fail the whole config: malformed JSON, a non-object root, an unsupported
 `version`, or a non-integer/`< 1` `maxFanout`.
 
-`mcp__openrouter__openrouter-list` returns:
+`mcp__deliberation__openrouter-list` returns:
 
 ```jsonc
 {
@@ -511,7 +511,7 @@ Exceeding either cap returns a hard error with counts.
 
 ### Session model persistence
 
-A model alias is bound at the start of a session via `mcp__openrouter__openrouter`
+A model alias is bound at the start of a session via `mcp__deliberation__openrouter`
 and is preserved for the life of that `threadId`. `-reply` calls on the same thread
 always use the same model.
 
@@ -525,9 +525,9 @@ token count. There is no hard spend cap - the warning is informational only.
 
 | Tool | Purpose |
 |------|---------|
-| `mcp__openrouter__openrouter` | Start a new advisory session |
-| `mcp__openrouter__openrouter-reply` | Continue a session (multi-turn via threadId) |
-| `mcp__openrouter__openrouter-list` | List configured model aliases and their eligibility flags |
+| `mcp__deliberation__openrouter` | Start a new advisory session |
+| `mcp__deliberation__openrouter-reply` | Continue a session (multi-turn via threadId) |
+| `mcp__deliberation__openrouter-list` | List configured model aliases and their eligibility flags |
 
 ### Error kinds
 

--- a/assets/consensus-flow-simple.html
+++ b/assets/consensus-flow-simple.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>How /consensus works (simple) — claude-delegator</title>
+  <title>How /consensus works (simple) - deliberation</title>
   <style>
     html, body { margin: 0; padding: 0; }
     body {

--- a/assets/consensus-flow.html
+++ b/assets/consensus-flow.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>How /consensus works — claude-delegator</title>
+  <title>How /consensus works - deliberation</title>
   <style>
     html, body { margin: 0; padding: 0; }
     body {

--- a/assets/social-preview.html
+++ b/assets/social-preview.html
@@ -111,8 +111,8 @@
 <div class="card">
   <div class="accent"></div>
   <div class="top-block">
-    <div class="owner">antonbabenko <span class="owner-repo">/ claude-delegator</span></div>
-    <h1 class="title">Claude Delegator</h1>
+    <div class="owner">antonbabenko <span class="owner-repo">/ deliberation</span></div>
+    <h1 class="title">Deliberation</h1>
     <p class="subtitle">Second opinions in Claude Code from GPT, Gemini, and Grok - plus 300+ models via OpenRouter. Advisory or implementation, with arbiter-mediated consensus.</p>
     <p class="meta"><span>Architect</span><span class="meta-sep">·</span><span>Plan Reviewer</span><span class="meta-sep">·</span><span>Scope Analyst</span><span class="meta-sep">·</span><span>Code Reviewer</span><span class="meta-sep">·</span><span>Security Analyst</span><span class="meta-sep">·</span><span>Researcher</span><span class="meta-sep">·</span><span>Debugger</span></p>
   </div>

--- a/commands/ask-all.md
+++ b/commands/ask-all.md
@@ -22,14 +22,14 @@ User question or topic: $ARGUMENTS
      an alias the server has not approved. -->
 
 0. **Prep - identify the expert and load its prompt.** Identify the expert role first (step 1 below is *reasoning* on `$ARGUMENTS`, no tool call), then read the expert prompt:
-   - `Glob` `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md` (expert prompt; fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` if no match)
+   - `Glob` `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md` (expert prompt)
 
    Delegate selection - which built-ins are enabled, which OpenRouter aliases are eligible, the fanout cap - is resolved server-side by `mcp__deliberation__ask-all`. The command does not read `config.json`, list OpenRouter aliases, or pre-read provider model config. The exact dispatched delegates, their models, and any fanout-capped omissions come back in the tool response, so the status block (step 4) is built from that response, not from pre-read sources.
 
 1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/deliberation/triggers.md`. The server applies the **same expert role** to every delegate so verdicts are comparable. Default to Architect if unclear.
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
    3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 

--- a/commands/ask-all.md
+++ b/commands/ask-all.md
@@ -1,7 +1,7 @@
 ---
 name: ask-all
 description: Ask GPT, Gemini, Grok, and any configured OpenRouter models in parallel for independent second opinions, then synthesize and compare. Zero cross-contamination.
-allowed-tools: mcp__deliberation__ask-all, Read, Bash
+allowed-tools: mcp__deliberation__ask-all, mcp__deliberation-openrouter__openrouter-list, Read, Bash
 timeout: 300000
 ---
 
@@ -22,20 +22,20 @@ User question or topic: $ARGUMENTS
      an alias the server has not approved. -->
 
 0. **Prep - identify the expert and load its prompt.** Identify the expert role first (step 1 below is *reasoning* on `$ARGUMENTS`, no tool call), then read the expert prompt:
-   - `Glob` `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (expert prompt)
+   - `Glob` `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md` (expert prompt; fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` if no match)
 
    Delegate selection - which built-ins are enabled, which OpenRouter aliases are eligible, the fanout cap - is resolved server-side by `mcp__deliberation__ask-all`. The command does not read `config.json`, list OpenRouter aliases, or pre-read provider model config. The exact dispatched delegates, their models, and any fanout-capped omissions come back in the tool response, so the status block (step 4) is built from that response, not from pre-read sources.
 
-1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`. The server applies the **same expert role** to every delegate so verdicts are comparable. Default to Architect if unclear.
+1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/deliberation/triggers.md`. The server applies the **same expert role** to every delegate so verdicts are comparable. Default to Architect if unclear.
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
-   3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
+   3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 
    Pass the loaded prompt as the `developerInstructions` argument so the server injects the same expert prompt into every delegate.
 
-3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. **Identical prompt** sent to every delegate - the server forwards the same `prompt` to all of them, so there is no provider-specific framing. This is the `prompt` argument for the tool call. Include:
+3. **Build 7-section delegation prompt** per `~/.claude/rules/deliberation/delegation-format.md`. **Identical prompt** sent to every delegate - the server forwards the same `prompt` to all of them, so there is no provider-specific framing. This is the `prompt` argument for the tool call. Include:
    - Verbatim user question from `$ARGUMENTS`
    - Relevant code snippets / file paths from current conversation context
    - Any specific constraints user has mentioned this session

--- a/commands/ask-gemini.md
+++ b/commands/ask-gemini.md
@@ -24,7 +24,7 @@ User question or topic: $ARGUMENTS
    - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
    3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 

--- a/commands/ask-gemini.md
+++ b/commands/ask-gemini.md
@@ -1,7 +1,7 @@
 ---
 name: ask-gemini
 description: Get Gemini second opinion on a question or current work. Single-shot, advisory, no contamination. Pinned to auto-gemini-3.
-allowed-tools: mcp__gemini__gemini, Read, Bash
+allowed-tools: mcp__deliberation-gemini__gemini, Read, Bash
 timeout: 300000
 ---
 
@@ -15,7 +15,7 @@ User question or topic: $ARGUMENTS
 
 ## Workflow
 
-1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`:
+1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/deliberation/triggers.md`:
    - Architecture / design / tradeoffs → Architect
    - Plan validation → Plan Reviewer
    - Requirements / scope → Scope Analyst
@@ -24,11 +24,11 @@ User question or topic: $ARGUMENTS
    - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
-   3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
+   3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 
-3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. Include:
+3. **Build 7-section delegation prompt** per `~/.claude/rules/deliberation/delegation-format.md`. Include:
    - Verbatim user question from `$ARGUMENTS`
    - Relevant code snippets / file paths from current conversation context
    - Any specific constraints user has mentioned this session
@@ -37,7 +37,7 @@ User question or topic: $ARGUMENTS
 
 5. **Call Gemini** - single-shot, advisory, model pinned:
    ```
-   mcp__gemini__gemini({
+   mcp__deliberation-gemini__gemini({
      prompt: "[7-section delegation prompt]",
      "developer-instructions": "[contents of expert prompt file]",
      sandbox: "read-only",
@@ -59,7 +59,7 @@ User question or topic: $ARGUMENTS
 - **Advisory by default** - use `sandbox: "read-only"` unless user explicitly asks for implementation.
 - **No contamination** - do not include prior GPT opinions in the Gemini prompt. Each expert reasons independently.
 - **Print status line** immediately before the MCP dispatch: `Gemini working (typical 30-60s)...`
-- **Concurrent prep, single dispatch** - prep here is a single expert-prompt `Glob` followed by one dispatch (a fixed status line, no per-delegate config reads). Keep it that way; do not pad the preamble with extra sequential round-trips. See `rules/delegator/orchestration.md` Step 5.5.
+- **Concurrent prep, single dispatch** - prep here is a single expert-prompt `Glob` followed by one dispatch (a fixed status line, no per-delegate config reads). Keep it that way; do not pad the preamble with extra sequential round-trips. See `rules/deliberation/orchestration.md` Step 5.5.
 
 - **Final judgment is the orchestrator's** - the external model only advises. Claude reads its output, applies its own judgment, and is accountable for the synthesized answer shown to you. The model's raw verdict is not the final word.
 

--- a/commands/ask-gpt.md
+++ b/commands/ask-gpt.md
@@ -1,7 +1,7 @@
 ---
 name: ask-gpt
 description: Get GPT (Codex) second opinion on a question or current work. Single-shot, advisory, no contamination.
-allowed-tools: mcp__codex__codex, Read, Bash
+allowed-tools: mcp__deliberation-codex__codex, Read, Bash
 timeout: 180000
 ---
 
@@ -15,7 +15,7 @@ User question or topic: $ARGUMENTS
 
 ## Workflow
 
-1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`:
+1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/deliberation/triggers.md`:
    - Architecture / design / tradeoffs → Architect
    - Plan validation → Plan Reviewer
    - Requirements / scope → Scope Analyst
@@ -24,18 +24,18 @@ User question or topic: $ARGUMENTS
    - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
-   3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
+   3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 
-3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. Include:
+3. **Build 7-section delegation prompt** per `~/.claude/rules/deliberation/delegation-format.md`. Include:
    - Verbatim user question from `$ARGUMENTS`
    - Relevant code snippets / file paths from current conversation context
    - Any specific constraints user has mentioned this session
 
 4. **Call Codex** - single-shot, advisory:
    ```
-   mcp__codex__codex({
+   mcp__deliberation-codex__codex({
      prompt: "[7-section delegation prompt]",
      "developer-instructions": "[contents of expert prompt file]",
      sandbox: "read-only",
@@ -55,7 +55,7 @@ User question or topic: $ARGUMENTS
 - **Advisory by default** - use `sandbox: "read-only"` unless user explicitly asks for implementation.
 - **No contamination** - do not include prior Gemini opinions in the GPT prompt. Each expert reasons independently.
 - **Print status line** immediately before the MCP dispatch: `Codex working (typical 30-60s)...`
-- **Concurrent prep, single dispatch** - prep here is a single expert-prompt `Glob` followed by one dispatch (a fixed status line, no per-delegate config reads). Keep it that way; do not pad the preamble with extra sequential round-trips. See `rules/delegator/orchestration.md` Step 5.5.
+- **Concurrent prep, single dispatch** - prep here is a single expert-prompt `Glob` followed by one dispatch (a fixed status line, no per-delegate config reads). Keep it that way; do not pad the preamble with extra sequential round-trips. See `rules/deliberation/orchestration.md` Step 5.5.
 
 - **Final judgment is the orchestrator's** - the external model only advises. Claude reads its output, applies its own judgment, and is accountable for the synthesized answer shown to you. The model's raw verdict is not the final word.
 

--- a/commands/ask-gpt.md
+++ b/commands/ask-gpt.md
@@ -24,7 +24,7 @@ User question or topic: $ARGUMENTS
    - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
    3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 

--- a/commands/ask-grok.md
+++ b/commands/ask-grok.md
@@ -24,7 +24,7 @@ User question or topic: $ARGUMENTS
    - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
    3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 

--- a/commands/ask-grok.md
+++ b/commands/ask-grok.md
@@ -1,7 +1,7 @@
 ---
 name: ask-grok
 description: Get Grok (xAI) second opinion on a question or current work. Single-shot, advisory, no contamination.
-allowed-tools: mcp__grok__grok, Read, Bash
+allowed-tools: mcp__deliberation-grok__grok, Read, Bash
 timeout: 180000
 ---
 
@@ -15,7 +15,7 @@ User question or topic: $ARGUMENTS
 
 ## Workflow
 
-1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/delegator/triggers.md`:
+1. **Identify expert** - match `$ARGUMENTS` against trigger patterns in `~/.claude/rules/deliberation/triggers.md`:
    - Architecture / design / tradeoffs → Architect
    - Plan validation → Plan Reviewer
    - Requirements / scope → Scope Analyst
@@ -24,18 +24,18 @@ User question or topic: $ARGUMENTS
    - Default if unclear → Architect
 
 2. **Read expert prompt** via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
-   3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
+   3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 
-3. **Build 7-section delegation prompt** per `~/.claude/rules/delegator/delegation-format.md`. Include:
+3. **Build 7-section delegation prompt** per `~/.claude/rules/deliberation/delegation-format.md`. Include:
    - Verbatim user question from `$ARGUMENTS`
    - Relevant code snippets / file paths from current conversation context (attach local files Grok should read via `files` in step 4; inline small snippets directly)
    - Any specific constraints user has mentioned this session
 
 4. **Call Grok** - single-shot, advisory:
    ```
-   mcp__grok__grok({
+   mcp__deliberation-grok__grok({
      prompt: "[7-section delegation prompt]",
      "developer-instructions": "[contents of expert prompt file]",
      sandbox: "read-only",
@@ -110,9 +110,9 @@ User question or topic: $ARGUMENTS
 - **Files** - `files:[{path|file_id|file_url}]` attaches documents (PDF, code, md, csv, json, txt; <= 48 MB) to the query. Attach referenced local files by default and pass `cwd` = repo root so `path` entries resolve (a path outside `cwd` is refused). On `errorKind: "file-read"` / `"file-too-large"`, tell the user which file failed.
 - **No model pin in-command** - the bridge defaults to `GROK_DEFAULT_MODEL` (or `grok-4.3`). To change it, set `GROK_DEFAULT_MODEL` in the MCP server's environment rather than hardcoding a (drift-prone) id here.
 - **No contamination** - do not include prior GPT or Gemini opinions in the Grok prompt. Each expert reasons independently.
-- **Auth required** - Grok needs `XAI_API_KEY`. If the call returns `errorKind: "missing-auth"`, tell the user to `export XAI_API_KEY=xai-...` (or rerun `/claude-delegator:setup`) and restart Claude Code.
+- **Auth required** - Grok needs `XAI_API_KEY`. If the call returns `errorKind: "missing-auth"`, tell the user to `export XAI_API_KEY=xai-...` (or rerun `/deliberation:setup`) and restart Claude Code.
 - **Print status line** immediately before the MCP dispatch: `Grok working (typical 30-60s)...`
-- **Concurrent prep, single dispatch** - prep here is a single expert-prompt `Glob` followed by one dispatch (a fixed status line, no per-delegate config reads). Keep it that way; do not pad the preamble with extra sequential round-trips. See `rules/delegator/orchestration.md` Step 5.5.
+- **Concurrent prep, single dispatch** - prep here is a single expert-prompt `Glob` followed by one dispatch (a fixed status line, no per-delegate config reads). Keep it that way; do not pad the preamble with extra sequential round-trips. See `rules/deliberation/orchestration.md` Step 5.5.
 
 - **Final judgment is the orchestrator's** - the external model only advises. Claude reads its output, applies its own judgment, and is accountable for the synthesized answer shown to you. The model's raw verdict is not the final word.
 

--- a/commands/ask-openrouter.md
+++ b/commands/ask-openrouter.md
@@ -25,7 +25,7 @@ is used.
    alias (the bridge falls back to `openrouter-default`; if `defaultModelSet` is false in
    the list output, tell the user to pass an explicit alias and stop).
 3. Identify the expert role from the question via `~/.claude/rules/deliberation/triggers.md` (default Architect). Then load that expert's prompt:
-   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md` and pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md` and pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical compare).
    2. If no match is found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 4. Build the 7-section delegation prompt per `~/.claude/rules/deliberation/delegation-format.md`.
    If the question references local files, attach them with

--- a/commands/ask-openrouter.md
+++ b/commands/ask-openrouter.md
@@ -1,7 +1,7 @@
 ---
 name: ask-openrouter
 description: Ask a single configured OpenRouter model for a second opinion. Advisory only. Single-shot or multi-turn.
-allowed-tools: mcp__openrouter__openrouter, mcp__openrouter__openrouter-reply, mcp__openrouter__openrouter-list, Read, Bash
+allowed-tools: mcp__deliberation-openrouter__openrouter, mcp__deliberation-openrouter__openrouter-reply, mcp__deliberation-openrouter__openrouter-list, Read, Bash
 timeout: 300000
 ---
 
@@ -18,22 +18,22 @@ is used.
 
 ## Workflow
 
-1. Call `mcp__openrouter__openrouter-list`. If the tool is unavailable, tell the user
+1. Call `mcp__deliberation-openrouter__openrouter-list`. If the tool is unavailable, tell the user
    OpenRouter is not configured (add models to `~/.claude/claude-delegator/config.json`,
-   then run `/claude-delegator:setup`) and stop.
+   then run `/deliberation:setup`) and stop.
 2. Parse `$ARGUMENTS`: if the first token equals a delegate `alias`, use it; else use no
    alias (the bridge falls back to `openrouter-default`; if `defaultModelSet` is false in
    the list output, tell the user to pass an explicit alias and stop).
-3. Identify the expert role from the question via `~/.claude/rules/delegator/triggers.md` (default Architect). Then load that expert's prompt:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` and pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical compare).
-   2. If no match is found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
-4. Build the 7-section delegation prompt per `~/.claude/rules/delegator/delegation-format.md`.
+3. Identify the expert role from the question via `~/.claude/rules/deliberation/triggers.md` (default Architect). Then load that expert's prompt:
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md` and pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   2. If no match is found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
+4. Build the 7-section delegation prompt per `~/.claude/rules/deliberation/delegation-format.md`.
    If the question references local files, attach them with
    `files: [{ path: "...", mode: "auto" }]` (text-inline; `{ dir: "..." }` also supported).
 5. Print: `OpenRouter (<alias-or-default>) working (typical 30-60s)...` where `<alias-or-default>` is the selected alias, or `openrouter-default` when no alias was given.
 6. Call:
    ```
-   mcp__openrouter__openrouter({
+   mcp__deliberation-openrouter__openrouter({
      prompt: "[7-section prompt]",
      "developer-instructions": "[expert prompt]",
      alias: "[selected alias, omit to use openrouter-default]",
@@ -47,14 +47,14 @@ is used.
    `config.json`). A single bad model entry no longer breaks the whole config: this
    single-shot call still works as long as the requested alias is valid. To see which
    entries the bridge skipped (and their `suggestedAlias` repairs), run
-   `mcp__openrouter__openrouter-list` and check `invalidModels`, then either hand-edit
+   `mcp__deliberation-openrouter__openrouter-list` and check `invalidModels`, then either hand-edit
    `config.json` or run `/ask-all` or `/consensus`, which offer a Fix & proceed prompt.
 8. Synthesize the answer; never paste raw output. For a follow-up turn, reuse the returned
-   `threadId` via `mcp__openrouter__openrouter-reply`.
+   `threadId` via `mcp__deliberation-openrouter__openrouter-reply`.
 
 ## Rules
 
 - Advisory only - OpenRouter has no filesystem access; route implementation tasks to
   Codex/Gemini.
 - Single delegate per call. For parallel multi-model opinions use `/ask-all`.
-- **Serial prep is correct here** - `openrouter-list` (step 1) MUST run before the expert-prompt `Glob` (step 3): alias-stripping consumes the list, the stripped question determines the expert, and the expert determines the `Glob` target. This is a genuine data dependency, so the two reads CANNOT be merged into one parallel block (unlike `/ask-all`). Do not "optimize" them together. See `rules/delegator/orchestration.md` Step 5.5.
+- **Serial prep is correct here** - `openrouter-list` (step 1) MUST run before the expert-prompt `Glob` (step 3): alias-stripping consumes the list, the stripped question determines the expert, and the expert determines the `Glob` target. This is a genuine data dependency, so the two reads CANNOT be merged into one parallel block (unlike `/ask-all`). Do not "optimize" them together. See `rules/deliberation/orchestration.md` Step 5.5.

--- a/commands/ask-openrouter.md
+++ b/commands/ask-openrouter.md
@@ -19,7 +19,7 @@ is used.
 ## Workflow
 
 1. Call `mcp__deliberation-openrouter__openrouter-list`. If the tool is unavailable, tell the user
-   OpenRouter is not configured (add models to `~/.claude/claude-delegator/config.json`,
+   OpenRouter is not configured (add models to `~/.claude/deliberation/config.json`,
    then run `/deliberation:setup`) and stop.
 2. Parse `$ARGUMENTS`: if the first token equals a delegate `alias`, use it; else use no
    alias (the bridge falls back to `openrouter-default`; if `defaultModelSet` is false in

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -35,7 +35,7 @@ Plan, design, spec, or proposal to refine: $ARGUMENTS
    - Security / threat modeling → Security Analyst
    - Code review of a concrete diff → Code Reviewer
 2. Read expert prompt ONCE via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
    3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -35,9 +35,9 @@ Plan, design, spec, or proposal to refine: $ARGUMENTS
    - Security / threat modeling → Security Analyst
    - Code review of a concrete diff → Code Reviewer
 2. Read expert prompt ONCE via this resolution sequence:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `claude-delegator/`, parsed as semver - not lexical string compare).
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/prompts/[expert].md`. Pick the match with the highest semver version segment (the segment immediately after `deliberation/`, parsed as semver - not lexical string compare). If no match, fall back to `~/.claude/plugins/cache/*/claude-delegator/*/prompts/[expert].md` (legacy cache; same semver pick).
    2. If no match, look up the inlined fallback under the heading `## Inlined fallback - [Expert]` in this command file (see end of this file).
-   3. If neither found, abort with: `Error: claude-delegator plugin cache missing for expert "[Expert]". Run /plugin install claude-delegator or /reload-plugins.`
+   3. If neither found, abort with: `Error: deliberation plugin cache missing for expert "[Expert]". Run /plugin install deliberation or /reload-plugins.`
 
    Reuse the loaded contents across all rounds (pass it as `developerInstructions` to the consensus tool).
 3. **Set cwd**: use `process.cwd()` as the MCP `cwd` for every call; the server resolves each provider's working directory from it.
@@ -67,7 +67,7 @@ For each round R:
    --- Round R/5 ---
    ```
 
-2. **Build identical review prompt** (7-section format per `~/.claude/rules/delegator/delegation-format.md`). Include:
+2. **Build identical review prompt** (7-section format per `~/.claude/rules/deliberation/delegation-format.md`). Include:
    - **CURRENT PLAN** (full text of the latest revision)
    - **ROUND METADATA**: round R of 5; if R > 1, attach the previous round's deltas (what was changed and why)
    - **Round metadata is BOUNDED**: include the last 2 rounds verbatim; for any rounds older than that, include only a one-line summary of each (verdict + applied-change phrase). This prevents prompt-length growth across 5 rounds.

--- a/commands/grok-files.md
+++ b/commands/grok-files.md
@@ -22,10 +22,11 @@ Sub-command + flags: $ARGUMENTS
 ## Workflow
 
 1. **Resolve the admin script** via this sequence:
-   1. Glob `~/.claude/plugins/cache/*/claude-delegator/*/server/grok/files-admin.js`;
-      pick the highest-semver match.
+   1. Glob `~/.claude/plugins/cache/*/deliberation/*/server/grok/files-admin.js`;
+      pick the highest-semver match. If no match, fall back to
+      `~/.claude/plugins/cache/*/claude-delegator/*/server/grok/files-admin.js` (legacy cache).
    2. Fall back to `${CLAUDE_PLUGIN_ROOT}/server/grok/files-admin.js`.
-   3. If neither exists, abort: `Error: claude-delegator plugin cache missing. Run /plugin install claude-delegator.`
+   3. If none exists, abort: `Error: deliberation plugin cache missing. Run /plugin install deliberation.`
 
 2. **Check auth**: the script needs `XAI_API_KEY` in the environment. If it is unset, tell the
    user to `export XAI_API_KEY=xai-...` and stop (the script will error otherwise).

--- a/commands/grok-files.md
+++ b/commands/grok-files.md
@@ -8,7 +8,7 @@ timeout: 120000
 # Grok Files (storage cleanup)
 
 List, prune, or gc the xAI files uploaded by the Grok bridge. Uploads are tagged with
-the filename prefix `claude-delegator-`, so the remote-side cleanup ONLY ever targets
+the filename prefix `deliberation-`, so the remote-side cleanup ONLY ever targets
 those - your own xAI files are never touched. Uploads also carry `expires_after`
 (default 7 days) so they self-delete; this command is for pruning orphans early,
 auditing what exists, or syncing the local SHA-256 cache with remote state.
@@ -23,8 +23,7 @@ Sub-command + flags: $ARGUMENTS
 
 1. **Resolve the admin script** via this sequence:
    1. Glob `~/.claude/plugins/cache/*/deliberation/*/server/grok/files-admin.js`;
-      pick the highest-semver match. If no match, fall back to
-      `~/.claude/plugins/cache/*/claude-delegator/*/server/grok/files-admin.js` (legacy cache).
+      pick the highest-semver match.
    2. Fall back to `${CLAUDE_PLUGIN_ROOT}/server/grok/files-admin.js`.
    3. If none exists, abort: `Error: deliberation plugin cache missing. Run /plugin install deliberation.`
 
@@ -35,10 +34,10 @@ Sub-command + flags: $ARGUMENTS
    ```bash
    node "<resolved files-admin.js>" $ARGUMENTS
    ```
-   - `list` - prints total file count and every `claude-delegator-*` upload (id, created, expires, name).
+   - `list` - prints total file count and every `deliberation-*` upload (id, created, expires, name).
    - `prune --older-than <30m|24h|7d|seconds>` - **dry run** by default; prints what it WOULD delete (remote files).
    - `prune --older-than <...> --yes` - actually deletes the matched bridge-owned **remote** files.
-   - `gc` - syncs the **local** SHA-256 cache (`~/.claude/cache/claude-delegator/grok-files.json`)
+   - `gc` - syncs the **local** SHA-256 cache (`~/.claude/cache/deliberation/grok-files.json`)
      with remote state via one paginated `GET /v1/files`. Prunes local rows whose `fileId` is no
      longer on xAI. Default scope: current `XAI_API_KEY` + `XAI_API_BASE` rows only.
    - `gc --all-keys` - widens the diff to foreign rows but leaves them when remote absence is
@@ -53,7 +52,7 @@ Sub-command + flags: $ARGUMENTS
 ## Rules
 
 - **Never** pass `--prefix ""` or any prefix that would match non-bridge files; the default
-  `claude-delegator-` prefix is the safety boundary for `prune`.
+  `deliberation-` prefix is the safety boundary for `prune`.
 - Always run `prune` as a dry run first and show the user the candidate list before suggesting `--yes`.
 - `gc` is read-modify-write under the cache lock; never edit the cache file by hand while a
   Grok bridge is running.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Configure claude-delegator with Codex (GPT), Gemini, Grok, and OpenRouter MCP servers
+description: Configure deliberation with Codex (GPT), Gemini, Grok, and OpenRouter MCP servers
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 timeout: 60000
 ---
@@ -8,6 +8,10 @@ timeout: 60000
 # Setup
 
 Configure GPT (via Codex), Gemini, Grok, and OpenRouter as specialized expert subagents via MCP. Seven domain experts that can advise OR implement (Grok and OpenRouter are advisory-only).
+
+## Migration note
+
+If a legacy bare `codex`, `gemini`, `grok`, or `openrouter` MCP registration is present from an earlier install, re-run this setup. Step 2 registers the namespaced `deliberation-*` servers and removes the legacy bare registrations so nothing is left dangling.
 
 ## Step 1: Check CLI Dependencies
 
@@ -69,28 +73,34 @@ built-in is `enabled:false`, run `claude mcp remove <name>` instead of registeri
 
 ### Codex (GPT)
 ```bash
-# Idempotent: safe to rerun setup.
+# Idempotent: safe to rerun setup. Ordered migration: ADD the namespaced
+# registration first, then remove the legacy bare one (|| true) so there is no
+# window where neither exists.
 # No model flag: Codex inherits its model from ~/.codex/config.toml. To pin a
 # model on the server regardless of config.toml, append `-c model=<id>` (see the
 # Codex model note below).
+claude mcp remove deliberation-codex >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user deliberation-codex -- codex mcp-server
 claude mcp remove codex >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user codex -- codex mcp-server
 ```
 
 ### Gemini
 ```bash
-# Idempotent: safe to rerun setup
+# Idempotent: safe to rerun setup. ADD namespaced first, then remove legacy bare.
+claude mcp remove deliberation-gemini >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user deliberation-gemini -- node '${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js'
 claude mcp remove gemini >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user gemini -- node '${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js'
 ```
 
 ### Grok (xAI)
 ```bash
-# Idempotent: safe to rerun setup. Registered WITHOUT --env so the key is NOT
-# written to ~/.claude.json. The bridge inherits XAI_API_KEY from the environment
-# that launches Claude Code, so export it in your shell profile to persist it.
+# Idempotent: safe to rerun setup. ADD namespaced first, then remove legacy bare.
+# Registered WITHOUT --env so the key is NOT written to ~/.claude.json. The bridge
+# inherits XAI_API_KEY from the environment that launches Claude Code, so export it
+# in your shell profile to persist it.
+claude mcp remove deliberation-grok >/dev/null 2>&1 || true
+claude mcp add --transport stdio --scope user deliberation-grok -- node '${CLAUDE_PLUGIN_ROOT}/server/grok/index.js'
 claude mcp remove grok >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user grok -- node '${CLAUDE_PLUGIN_ROOT}/server/grok/index.js'
 if [ -z "$XAI_API_KEY" ]; then
   echo "Note: XAI_API_KEY not set in this environment; Grok calls return missing-auth until you export it (add it to your shell profile) and restart Claude Code."
 fi
@@ -102,7 +112,7 @@ This registers the MCP servers at user scope (available across all projects).
 
 **Grok file TTL (optional):** files Grok uploads default to a 7-day `expires_after` so they
 self-delete. To change it, export `GROK_FILE_TTL_SECONDS=<seconds>` (1h..30d, i.e. 3600..2592000)
-in Claude Code's launch environment, or add `--env GROK_FILE_TTL_SECONDS=<seconds>` on the `grok`
+in Claude Code's launch environment, or add `--env GROK_FILE_TTL_SECONDS=<seconds>` on the `deliberation-grok`
 registration. Manage uploads with `/grok-files`: `prune --older-than <age>` deletes remote
 bridge-owned files; `gc` reconciles the local SHA-256 cache (`~/.claude/cache/claude-delegator/grok-files.json`)
 with remote state. Set `XAI_DISABLE_FILE_CACHE=1` to bypass the cache layer (debugging). Full
@@ -110,7 +120,7 @@ reference: [TECHNICAL.md § Grok files and cleanup](../TECHNICAL.md#grok-files-a
 
 **Grok reasoning effort (optional):** defaults to `high`. Override by exporting
 `GROK_REASONING_EFFORT=<low|medium|high|none>` in Claude Code's launch environment, or add
-`--env GROK_REASONING_EFFORT=<low|medium|high|none>` on the `grok` registration, or set it per
+`--env GROK_REASONING_EFFORT=<low|medium|high|none>` on the `deliberation-grok` registration, or set it per
 call with the `reasoning_effort` parameter; `none` omits the field so the model uses its default.
 
 ### OpenRouter (optional, config-driven)
@@ -118,9 +128,14 @@ call with the `reasoning_effort` parameter; `none` omits the field so the model 
 ```bash
 CFG="${CLAUDE_DELEGATOR_CONFIG:-$HOME/.claude/claude-delegator/config.json}"
 OR_ON=$(node -e 'try{const c=require(process.argv[1]);const o=c.openrouter||{};const on=o.enabled!==false&&((Array.isArray(o.models)&&o.models.length)||o.defaultModel);process.stdout.write(on?"1":"0")}catch(e){process.stdout.write("0")}' "$CFG" 2>/dev/null || echo 0)
+# Clean up any prior registrations unconditionally (covers the disabled-OpenRouter
+# rerun case): drop the legacy bare name and the namespaced one before deciding.
 claude mcp remove openrouter >/dev/null 2>&1 || true
+claude mcp remove deliberation-openrouter >/dev/null 2>&1 || true
 if [ "$OR_ON" = "1" ]; then
-  claude mcp add --transport stdio --scope user openrouter -- node '${CLAUDE_PLUGIN_ROOT}/server/openrouter/index.js'
+  # ADD namespaced registration (the unconditional removes above already cleared
+  # both the legacy bare and any stale namespaced entry).
+  claude mcp add --transport stdio --scope user deliberation-openrouter -- node '${CLAUDE_PLUGIN_ROOT}/server/openrouter/index.js'
   KEYENV=$(node -e 'try{const c=require(process.argv[1]);process.stdout.write((c.openrouter&&c.openrouter.apiKeyEnv)||"OPENROUTER_API_KEY")}catch(e){process.stdout.write("OPENROUTER_API_KEY")}' "$CFG" 2>/dev/null || echo OPENROUTER_API_KEY)
   KEYVAL=$(printenv "$KEYENV" 2>/dev/null)
   if [ -z "$KEYVAL" ]; then echo "Note: \$$KEYENV is empty; OpenRouter calls to openrouter.ai will return auth errors until you export it."; fi
@@ -140,12 +155,18 @@ claude mcp remove deliberation >/dev/null 2>&1 || true
 claude mcp add --transport stdio --scope user deliberation -- node '${CLAUDE_PLUGIN_ROOT}/server/mcp/index.js'
 ```
 
+After registering the servers above, print this restart notice:
+
+```
+Restart Claude Code so the deliberation-* tools load; until then /ask-* may not find them.
+```
+
 **Codex model (optional):** by default Codex inherits its model, sandbox, and
 approval policy from `~/.codex/config.toml` (the `model` key) - change it there
 and every provider that reads that file follows. To pin a model on the MCP server
 regardless of config.toml, append `-c model=<id>` to the registration, e.g.
 `claude mcp add --transport stdio --scope user codex -- codex mcp-server -c model=gpt-5.5`.
-To override for a single call, pass `model:` to `mcp__codex__codex(...)`. This
+To override for a single call, pass `model:` to `mcp__deliberation-codex__codex(...)`. This
 mirrors the Gemini/Grok model-override pattern. (Codex has no bridge env var like
 `GROK_DEFAULT_MODEL` because it ships its own native MCP server and reads
 `~/.codex/config.toml` directly.)
@@ -156,17 +177,23 @@ e.g. `-p nosandbox`.
 ## Step 3: Install Orchestration Rules
 
 ```bash
-mkdir -p ~/.claude/rules/delegator && cp ${CLAUDE_PLUGIN_ROOT}/rules/*.md ~/.claude/rules/delegator/
+mkdir -p ~/.claude/rules/deliberation && cp ${CLAUDE_PLUGIN_ROOT}/rules/*.md ~/.claude/rules/deliberation/
+# Remove the legacy rules dir so it does not linger after the rename.
+rm -rf ~/.claude/rules/delegator
 ```
 
 ## Step 3b: Optional Short Command Names
 
 The delegation commands ship with the plugin and are always available
-namespaced: `/claude-delegator:ask-gpt`, `:ask-gemini`, `:ask-grok`,
+namespaced: `/deliberation:ask-gpt`, `:ask-gemini`, `:ask-grok`,
 `:ask-all`, `:consensus`.
 
 Offer the short, unnamespaced aliases (`/ask-gpt` etc.) by copying them into
 `~/.claude/commands/`.
+
+Note: the namespaced command form changed from `/claude-delegator:*` to
+`/deliberation:*`. The unnamespaced aliases below (`/ask-gpt`, `/ask-all`, and
+the rest) are unaffected by the rename and keep working.
 
 Use AskUserQuestion: "Also install short command names (/ask-gpt etc.) into
 ~/.claude/commands?" Options: "Yes (recommended)" / "No, keep namespaced only".
@@ -215,7 +242,7 @@ agy --help 2>&1 | head -1 || echo "Not installed"
 # Check 2: Codex MCP server
 # Model is no longer hardcoded on the registration; resolve it from a `-c model=`
 # server override if present, else the `model` key in ~/.codex/config.toml.
-CODEX_CONFIG=$(claude mcp get codex 2>/dev/null)
+CODEX_CONFIG=$(claude mcp get deliberation-codex 2>/dev/null)
 if echo "$CODEX_CONFIG" | grep -q "codex"; then
   MODEL=$(echo "$CODEX_CONFIG" | grep -oE 'model=[^ ]+' | head -1 | cut -d= -f2)
   if [ -z "$MODEL" ]; then
@@ -228,7 +255,7 @@ else
 fi
 
 # Check 3: Gemini MCP server
-GEMINI_CONFIG=$(claude mcp get gemini 2>/dev/null)
+GEMINI_CONFIG=$(claude mcp get deliberation-gemini 2>/dev/null)
 if echo "$GEMINI_CONFIG" | grep -q "server/gemini/index.js"; then
   GEMINI_MODEL="${GEMINI_DEFAULT_MODEL:-auto-gemini-3}"
   echo "Gemini: OK (model: $GEMINI_MODEL)"
@@ -264,7 +291,7 @@ case "$GEMINI_SETTINGS_MODEL" in
 esac
 
 # Check 4b: Grok MCP server + bridge health
-GROK_CONFIG=$(claude mcp get grok 2>/dev/null)
+GROK_CONFIG=$(claude mcp get deliberation-grok 2>/dev/null)
 if echo "$GROK_CONFIG" | grep -q "server/grok/index.js"; then
   GROK_MODEL="${GROK_DEFAULT_MODEL:-grok-4.3}"
   echo "Grok: OK (model: $GROK_MODEL)"
@@ -278,7 +305,7 @@ else
 fi
 
 # Check 5: OpenRouter MCP server + bridge health
-OR_CONFIG=$(claude mcp get openrouter 2>/dev/null)
+OR_CONFIG=$(claude mcp get deliberation-openrouter 2>/dev/null)
 if echo "$OR_CONFIG" | grep -q "server/openrouter/index.js"; then
   OR_HEALTH=$(printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' \
     | node "${CLAUDE_PLUGIN_ROOT}/server/openrouter/index.js" 2>/dev/null \
@@ -289,7 +316,7 @@ else
 fi
 
 # Check 6: Rules installed (count files)
-ls ~/.claude/rules/delegator/*.md 2>/dev/null | wc -l
+ls ~/.claude/rules/deliberation/*.md 2>/dev/null | wc -l
 
 # Check 7: Codex auth status
 codex login status 2>&1 | head -1 || echo "Codex: Run 'codex login'"
@@ -300,7 +327,7 @@ codex login status 2>&1 | head -1 || echo "Codex: Run 'codex login'"
 Display actual values from the checks above:
 
 ```
-claude-delegator Status
+deliberation Status
 ───────────────────────────────────────────────────
 Codex CLI:       [version from check 1]
 Antigravity CLI: [agy install signal from check 1]
@@ -309,7 +336,7 @@ Gemini MCP:      [status + model from check 3]
 Gemini Bridge:   [status from check 4]
 Gemini model:    [value from check 4a]
 Grok MCP:        [status + model from check 4b]
-Rules:           ✓ [N] files in ~/.claude/rules/delegator/
+Rules:           ✓ [N] files in ~/.claude/rules/deliberation/
 Codex Auth:      [status from check 7]
 Grok Auth:       [XAI_API_KEY status from check 4b]
 ───────────────────────────────────────────────────
@@ -328,7 +355,7 @@ Next steps:
    - Codex: Run `codex login`
    - Gemini: Run `agy` once and complete sign-in (or set the model in ~/.gemini/settings.json)
    - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai) in your shell profile, then restart Claude Code
-3. After editing plugin code or upgrading the plugin version: run `/mcp` in your Claude Code session and press `Reconnect` on `gemini` and `grok` to load the new code without restarting Claude Code. See README → "Updating the plugin".
+3. After editing plugin code or upgrading the plugin version: run `/mcp` in your Claude Code session and press `Reconnect` on `deliberation-gemini` and `deliberation-grok` to load the new code without restarting Claude Code. See README → "Updating the plugin".
 
 Seven experts available:
 
@@ -369,18 +396,18 @@ Explicit: "Ask GPT to...", "Ask Gemini to...", or "Ask Grok to..."
 
 ## Step 7: Ask About Starring
 
-Use AskUserQuestion to ask the user if they'd like to ⭐ star the claude-delegator repository on GitHub to support the project.
+Use AskUserQuestion to ask the user if they'd like to ⭐ star the deliberation repository on GitHub to support the project.
 
 Options: "Yes, star the repo" / "No thanks"
 
 **If yes**: Check if `gh` CLI is available and run:
 ```bash
-gh api -X PUT /user/starred/antonbabenko/claude-delegator
+gh api -X PUT /user/starred/antonbabenko/deliberation
 ```
 
 If `gh` is not available or the command fails, provide the manual link:
 ```
-https://github.com/antonbabenko/claude-delegator
+https://github.com/antonbabenko/deliberation
 ```
 
 **If no**: Thank them and complete setup without starring.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -64,7 +64,8 @@ Register your preferred provider(s) as MCP servers using Claude Code's native co
 ### Read config (single source of truth)
 
 ```bash
-CFG="${CLAUDE_DELEGATOR_CONFIG:-$HOME/.claude/claude-delegator/config.json}"
+CFG="${DELIBERATION_CONFIG:-${CLAUDE_DELEGATOR_CONFIG:-}}"
+[ -z "$CFG" ] && { if [ -f "$HOME/.claude/deliberation/config.json" ]; then CFG="$HOME/.claude/deliberation/config.json"; else CFG="$HOME/.claude/claude-delegator/config.json"; fi; }
 if [ -f "$CFG" ]; then echo "config: $CFG"; else echo "config: none (defaults: 3 built-ins on, no OpenRouter)"; fi
 ```
 
@@ -126,7 +127,8 @@ call with the `reasoning_effort` parameter; `none` omits the field so the model 
 ### OpenRouter (optional, config-driven)
 
 ```bash
-CFG="${CLAUDE_DELEGATOR_CONFIG:-$HOME/.claude/claude-delegator/config.json}"
+CFG="${DELIBERATION_CONFIG:-${CLAUDE_DELEGATOR_CONFIG:-}}"
+[ -z "$CFG" ] && { if [ -f "$HOME/.claude/deliberation/config.json" ]; then CFG="$HOME/.claude/deliberation/config.json"; else CFG="$HOME/.claude/claude-delegator/config.json"; fi; }
 OR_ON=$(node -e 'try{const c=require(process.argv[1]);const o=c.openrouter||{};const on=o.enabled!==false&&((Array.isArray(o.models)&&o.models.length)||o.defaultModel);process.stdout.write(on?"1":"0")}catch(e){process.stdout.write("0")}' "$CFG" 2>/dev/null || echo 0)
 # Clean up any prior registrations unconditionally (covers the disabled-OpenRouter
 # rerun case): drop the legacy bare name and the namespaced one before deciding.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,415 +1,188 @@
 ---
 name: setup
 description: Configure deliberation with Codex (GPT), Gemini, Grok, and OpenRouter MCP servers
-allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
+allowed-tools: Bash, Read, AskUserQuestion
 timeout: 60000
 ---
 
 # Setup
 
-Configure GPT (via Codex), Gemini, Grok, and OpenRouter as specialized expert subagents via MCP. Seven domain experts that can advise OR implement (Grok and OpenRouter are advisory-only).
+Configure GPT (via Codex), Gemini, Grok, and OpenRouter as expert subagents via MCP, install the
+orchestration rules, and (optionally) the short command aliases. Grok and OpenRouter are
+advisory-only.
 
-## Migration note
+This command runs in three phases: ONE main Bash call (checks + register + install + status), then
+isolated question turns for the optional aliases and the optional GitHub star. Do not batch a Bash
+call with an AskUserQuestion, and do not split the main block.
 
-If a legacy bare `codex`, `gemini`, `grok`, or `openrouter` MCP registration is present from an earlier install, re-run this setup. Step 2 registers the namespaced `deliberation-*` servers and removes the legacy bare registrations so nothing is left dangling.
+## Step 1: Run setup
 
-## Step 1: Check CLI Dependencies
+> Run the block below as ONE Bash call. Do NOT split it into smaller calls, and do NOT batch it
+> with any other tool call. It is idempotent - safe to re-run.
 
-### Codex (GPT)
-```bash
-which codex 2>/dev/null && codex --version 2>&1 | head -1 || echo "CODEX_MISSING"
-```
-
-### Gemini (Antigravity CLI)
-```bash
-# agy has no --version flag; presence on PATH is the install signal.
-which agy 2>/dev/null && echo "agy: installed" || echo "GEMINI_MISSING"
-```
-
-### Grok (xAI)
-```bash
-# Grok is API-based (no CLI). It needs XAI_API_KEY in the environment.
-[ -n "$XAI_API_KEY" ] && echo "Grok: XAI_API_KEY set" || echo "XAI_API_KEY_MISSING"
-```
-
-### If Missing
-
-**Codex Missing:**
-```
-Codex CLI not found.
-Install with: npm install -g @openai/codex
-Then authenticate: codex login
-```
-
-**Gemini Missing:**
-```
-Antigravity CLI (agy) not found.
-Install Antigravity from https://antigravity.google
-Then authenticate: run `agy` once and complete sign-in (or set the model in ~/.gemini/settings.json)
-```
-
-**Grok key missing (XAI_API_KEY_MISSING):**
-```
-XAI_API_KEY is not set.
-Grok is API-based - there is no CLI to install. Get a key at https://console.x.ai
-then: export XAI_API_KEY=xai-...   (add it to your shell profile to persist)
-```
-
-**STOP here if no providers are installed.**
-
-## Step 2: Configure MCP Servers
-
-Register your preferred provider(s) as MCP servers using Claude Code's native command:
-
-### Read config (single source of truth)
+It does everything non-interactive: checks CLIs, reads `config.json` once, registers the enabled
+MCP servers at user scope (namespaced `deliberation-*`, removing any legacy bare registrations),
+installs the rules, and prints a status report.
 
 ```bash
+set -u
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required (run this via /deliberation:setup)}"
+
+# --- config path: new env > legacy env > new file > legacy file ---
 CFG="${DELIBERATION_CONFIG:-${CLAUDE_DELEGATOR_CONFIG:-}}"
-[ -z "$CFG" ] && { if [ -f "$HOME/.claude/deliberation/config.json" ]; then CFG="$HOME/.claude/deliberation/config.json"; else CFG="$HOME/.claude/claude-delegator/config.json"; fi; }
-if [ -f "$CFG" ]; then echo "config: $CFG"; else echo "config: none (defaults: 3 built-ins on, no OpenRouter)"; fi
-```
-
-For each built-in, read `providers.<name>.enabled` from `$CFG` (missing = enabled). When a
-built-in is `enabled:false`, run `claude mcp remove <name>` instead of registering it.
-
-### Codex (GPT)
-```bash
-# Idempotent: safe to rerun setup. Ordered migration: ADD the namespaced
-# registration first, then remove the legacy bare one (|| true) so there is no
-# window where neither exists.
-# No model flag: Codex inherits its model from ~/.codex/config.toml. To pin a
-# model on the server regardless of config.toml, append `-c model=<id>` (see the
-# Codex model note below).
-claude mcp remove deliberation-codex >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user deliberation-codex -- codex mcp-server
-claude mcp remove codex >/dev/null 2>&1 || true
-```
-
-### Gemini
-```bash
-# Idempotent: safe to rerun setup. ADD namespaced first, then remove legacy bare.
-claude mcp remove deliberation-gemini >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user deliberation-gemini -- node '${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js'
-claude mcp remove gemini >/dev/null 2>&1 || true
-```
-
-### Grok (xAI)
-```bash
-# Idempotent: safe to rerun setup. ADD namespaced first, then remove legacy bare.
-# Registered WITHOUT --env so the key is NOT written to ~/.claude.json. The bridge
-# inherits XAI_API_KEY from the environment that launches Claude Code, so export it
-# in your shell profile to persist it.
-claude mcp remove deliberation-grok >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user deliberation-grok -- node '${CLAUDE_PLUGIN_ROOT}/server/grok/index.js'
-claude mcp remove grok >/dev/null 2>&1 || true
-if [ -z "$XAI_API_KEY" ]; then
-  echo "Note: XAI_API_KEY not set in this environment; Grok calls return missing-auth until you export it (add it to your shell profile) and restart Claude Code."
+if [ -z "$CFG" ]; then
+  if [ -f "$HOME/.claude/deliberation/config.json" ]; then CFG="$HOME/.claude/deliberation/config.json"
+  else CFG="$HOME/.claude/claude-delegator/config.json"; fi
 fi
-```
 
-Want the key persisted in config instead of an exported env var? Add `--env XAI_API_KEY="$XAI_API_KEY"` before `-- node ...` on the command above. That writes the key in plaintext into `~/.claude.json`, so only do it if you accept storing a secret on disk.
+json_eval() { node -e "$1" "$CFG" 2>/dev/null; }
+# providers.<name>.enabled: missing => enabled (returns 1); explicit false => 0.
+provider_enabled() {
+  json_eval 'try{const c=require(process.argv[1]);const p=(c.providers&&c.providers[process.argv[2]])||{};process.stdout.write(p.enabled===false?"0":"1")}catch(e){process.stdout.write("1")}' "$1"
+}
+# openrouter on iff enabled!=false AND (non-empty models[] OR defaultModel).
+openrouter_enabled() {
+  json_eval 'try{const c=require(process.argv[1]);const o=c.openrouter||{};const on=o.enabled!==false&&((Array.isArray(o.models)&&o.models.length)||o.defaultModel);process.stdout.write(on?"1":"0")}catch(e){process.stdout.write("0")}'
+}
+or_key_env() {
+  json_eval 'try{const c=require(process.argv[1]);process.stdout.write((c.openrouter&&c.openrouter.apiKeyEnv)||"OPENROUTER_API_KEY")}catch(e){process.stdout.write("OPENROUTER_API_KEY")}'
+}
 
-This registers the MCP servers at user scope (available across all projects).
+remove_mcp() { claude mcp remove "$1" >/dev/null 2>&1 || true; }
+# remove-then-add (do not assume `claude mcp add` upserts). Never aborts the rest on one failure.
+add_mcp() { name="$1"; shift; remove_mcp "$name"; claude mcp add --transport stdio --scope user "$name" -- "$@" || echo "WARN: failed to register $name"; }
 
-**Grok file TTL (optional):** files Grok uploads default to a 7-day `expires_after` so they
-self-delete. To change it, export `GROK_FILE_TTL_SECONDS=<seconds>` (1h..30d, i.e. 3600..2592000)
-in Claude Code's launch environment, or add `--env GROK_FILE_TTL_SECONDS=<seconds>` on the `deliberation-grok`
-registration. Manage uploads with `/grok-files`: `prune --older-than <age>` deletes remote
-bridge-owned files; `gc` reconciles the local SHA-256 cache (`~/.claude/cache/claude-delegator/grok-files.json`)
-with remote state. Set `XAI_DISABLE_FILE_CACHE=1` to bypass the cache layer (debugging). Full
-reference: [TECHNICAL.md § Grok files and cleanup](../TECHNICAL.md#grok-files-and-cleanup).
+# --- CLI presence (external tools; bridges ship with the plugin so are not checked) ---
+command -v codex >/dev/null 2>&1 && CODEX_STATUS="$(codex --version 2>&1 | head -1)" || CODEX_STATUS="MISSING (npm i -g @openai/codex)"
+command -v agy   >/dev/null 2>&1 && AGY_STATUS="installed" || AGY_STATUS="MISSING (https://antigravity.google)"
 
-**Grok reasoning effort (optional):** defaults to `high`. Override by exporting
-`GROK_REASONING_EFFORT=<low|medium|high|none>` in Claude Code's launch environment, or add
-`--env GROK_REASONING_EFFORT=<low|medium|high|none>` on the `deliberation-grok` registration, or set it per
-call with the `reasoning_effort` parameter; `none` omits the field so the model uses its default.
+# --- register servers (each gated on provider_enabled; missing config = all on) ---
+# Codex: inherits model from ~/.codex/config.toml. Pin with `-c model=<id>` (see notes below).
+if [ "$(provider_enabled codex)" = "1" ]; then add_mcp deliberation-codex codex mcp-server; else remove_mcp deliberation-codex; fi
+remove_mcp codex   # drop legacy bare name
 
-### OpenRouter (optional, config-driven)
+if [ "$(provider_enabled gemini)" = "1" ]; then add_mcp deliberation-gemini node "$PLUGIN_ROOT/server/gemini/index.js"; else remove_mcp deliberation-gemini; fi
+remove_mcp gemini
 
-```bash
-CFG="${DELIBERATION_CONFIG:-${CLAUDE_DELEGATOR_CONFIG:-}}"
-[ -z "$CFG" ] && { if [ -f "$HOME/.claude/deliberation/config.json" ]; then CFG="$HOME/.claude/deliberation/config.json"; else CFG="$HOME/.claude/claude-delegator/config.json"; fi; }
-OR_ON=$(node -e 'try{const c=require(process.argv[1]);const o=c.openrouter||{};const on=o.enabled!==false&&((Array.isArray(o.models)&&o.models.length)||o.defaultModel);process.stdout.write(on?"1":"0")}catch(e){process.stdout.write("0")}' "$CFG" 2>/dev/null || echo 0)
-# Clean up any prior registrations unconditionally (covers the disabled-OpenRouter
-# rerun case): drop the legacy bare name and the namespaced one before deciding.
-claude mcp remove openrouter >/dev/null 2>&1 || true
-claude mcp remove deliberation-openrouter >/dev/null 2>&1 || true
-if [ "$OR_ON" = "1" ]; then
-  # ADD namespaced registration (the unconditional removes above already cleared
-  # both the legacy bare and any stale namespaced entry).
-  claude mcp add --transport stdio --scope user deliberation-openrouter -- node '${CLAUDE_PLUGIN_ROOT}/server/openrouter/index.js'
-  KEYENV=$(node -e 'try{const c=require(process.argv[1]);process.stdout.write((c.openrouter&&c.openrouter.apiKeyEnv)||"OPENROUTER_API_KEY")}catch(e){process.stdout.write("OPENROUTER_API_KEY")}' "$CFG" 2>/dev/null || echo OPENROUTER_API_KEY)
-  KEYVAL=$(printenv "$KEYENV" 2>/dev/null)
-  if [ -z "$KEYVAL" ]; then echo "Note: \$$KEYENV is empty; OpenRouter calls to openrouter.ai will return auth errors until you export it."; fi
+if [ "$(provider_enabled grok)" = "1" ]; then add_mcp deliberation-grok node "$PLUGIN_ROOT/server/grok/index.js"; else remove_mcp deliberation-grok; fi
+remove_mcp grok
+
+remove_mcp openrouter   # drop legacy bare name
+if [ "$(openrouter_enabled)" = "1" ]; then
+  add_mcp deliberation-openrouter node "$PLUGIN_ROOT/server/openrouter/index.js"
+  KEYENV="$(or_key_env)"; [ -z "$(printenv "$KEYENV" 2>/dev/null)" ] && echo "Note: \$$KEYENV is empty; OpenRouter calls return auth errors until you export it."
+else
+  remove_mcp deliberation-openrouter
 fi
+
+# Unified fan-out server (powers /ask-all and /consensus). Always on.
+add_mcp deliberation node "$PLUGIN_ROOT/server/mcp/index.js"
+
+# --- install orchestration rules (copy only; never deletes) ---
+mkdir -p "$HOME/.claude/rules/deliberation"
+cp "$PLUGIN_ROOT"/rules/*.md "$HOME/.claude/rules/deliberation/" 2>/dev/null || true
+RULE_COUNT=$(find "$HOME/.claude/rules/deliberation" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+
+# --- status ---
+echo
+echo "deliberation setup"
+echo "--------------------------------------------------"
+echo "Codex CLI:       $CODEX_STATUS"
+echo "Antigravity CLI: $AGY_STATUS"
+echo "config:          $([ -f "$CFG" ] && echo "$CFG" || echo "none (defaults: 3 built-ins on, no OpenRouter)")"
+echo "Rules:           $RULE_COUNT files in ~/.claude/rules/deliberation/"
+echo "Grok auth:       $([ -n "${XAI_API_KEY:-}" ] && echo "XAI_API_KEY set" || echo "XAI_API_KEY not set (calls return missing-auth)")"
+echo "OpenRouter auth: $([ -n "${OPENROUTER_API_KEY:-}" ] && echo set || echo "not set")"
+echo "MCP servers registered (user scope). Run 'claude mcp list' to confirm."
+echo
+echo "Restart Claude Code so the deliberation-* tools load; until then /ask-* may not find them."
+[ -d "$HOME/.claude/rules/delegator" ] && echo "Note: legacy ~/.claude/rules/delegator/ is unused after the rename; remove it manually if you want."
 ```
 
-### Deliberation (unified fan-out server)
+After it runs, report the printed status to the user.
 
-The deliberation server powers `/ask-all` and `/consensus`. It selects and
-dispatches the active delegate set (enabled built-ins plus eligible OpenRouter
-aliases) in one server call, so a disabled alias can never be dispatched from a
-stale client-side selection. Register it unconditionally - it fans out to
-whatever providers are enabled.
+### Optional provider tuning (no extra setup calls needed)
+
+- **Codex model:** by default Codex reads its model from `~/.codex/config.toml` (`model` key). To
+  pin it on the server, append `-c model=<id>` to the `deliberation-codex` registration (re-run with
+  the flag, e.g. `claude mcp add --transport stdio --scope user deliberation-codex -- codex mcp-server -c model=gpt-5.5`),
+  or pass `model:` per call to `mcp__deliberation-codex__codex(...)`. Other Codex flags go before
+  `mcp-server` (e.g. `-p nosandbox`).
+- **Grok key in config (vs env):** the `deliberation-grok` registration omits `--env` so no secret
+  is written to `~/.claude.json`; the bridge inherits `XAI_API_KEY` from Claude Code's launch
+  environment (export it in your shell profile). To persist it in config instead, re-register with
+  `--env XAI_API_KEY="$XAI_API_KEY"` before `-- node ...` (writes the key in plaintext to
+  `~/.claude.json`).
+- **Grok file TTL / reasoning:** uploads default to a 7-day `expires_after`; override with
+  `GROK_FILE_TTL_SECONDS=<3600..2592000>`. Reasoning effort defaults to `high`; override with
+  `GROK_REASONING_EFFORT=<low|medium|high|none>` (env, `--env` on the registration, or per call).
+  Manage uploads with `/grok-files`. Full reference: [TECHNICAL.md](../TECHNICAL.md#grok-files-and-cleanup).
+
+## Step 2: Optional short command names
+
+The commands are always available namespaced (`/deliberation:ask-gpt`, `:ask-all`, `:consensus`,
+...). The short aliases (`/ask-gpt` etc.) are an opt-in copy into `~/.claude/commands/`. (The
+namespaced form changed from `/claude-delegator:*` to `/deliberation:*`; the unnamespaced aliases
+are unaffected by the rename.)
+
+Ask with `AskUserQuestion` (this turn has NO Bash call): "Also install short command names
+(/ask-gpt etc.) into ~/.claude/commands?" Options: "Yes (recommended)" / "No, keep namespaced
+only".
+
+**If yes**, run this as ONE isolated Bash call (installs only missing aliases; collects collisions):
 
 ```bash
-claude mcp remove deliberation >/dev/null 2>&1 || true
-claude mcp add --transport stdio --scope user deliberation -- node '${CLAUDE_PLUGIN_ROOT}/server/mcp/index.js'
-```
-
-After registering the servers above, print this restart notice:
-
-```
-Restart Claude Code so the deliberation-* tools load; until then /ask-* may not find them.
-```
-
-**Codex model (optional):** by default Codex inherits its model, sandbox, and
-approval policy from `~/.codex/config.toml` (the `model` key) - change it there
-and every provider that reads that file follows. To pin a model on the MCP server
-regardless of config.toml, append `-c model=<id>` to the registration, e.g.
-`claude mcp add --transport stdio --scope user codex -- codex mcp-server -c model=gpt-5.5`.
-To override for a single call, pass `model:` to `mcp__deliberation-codex__codex(...)`. This
-mirrors the Gemini/Grok model-override pattern. (Codex has no bridge env var like
-`GROK_DEFAULT_MODEL` because it ships its own native MCP server and reads
-`~/.codex/config.toml` directly.)
-
-**Note:** To customise other Codex behaviour, add CLI flags before `mcp-server`,
-e.g. `-p nosandbox`.
-
-## Step 3: Install Orchestration Rules
-
-```bash
-mkdir -p ~/.claude/rules/deliberation && cp ${CLAUDE_PLUGIN_ROOT}/rules/*.md ~/.claude/rules/deliberation/
-# Remove the legacy rules dir so it does not linger after the rename.
-rm -rf ~/.claude/rules/delegator
-```
-
-## Step 3b: Optional Short Command Names
-
-The delegation commands ship with the plugin and are always available
-namespaced: `/deliberation:ask-gpt`, `:ask-gemini`, `:ask-grok`,
-`:ask-all`, `:consensus`.
-
-Offer the short, unnamespaced aliases (`/ask-gpt` etc.) by copying them into
-`~/.claude/commands/`.
-
-Note: the namespaced command form changed from `/claude-delegator:*` to
-`/deliberation:*`. The unnamespaced aliases below (`/ask-gpt`, `/ask-all`, and
-the rest) are unaffected by the rename and keep working.
-
-Use AskUserQuestion: "Also install short command names (/ask-gpt etc.) into
-~/.claude/commands?" Options: "Yes (recommended)" / "No, keep namespaced only".
-
-**If yes**, run (installs only the missing aliases; pre-existing files are skipped
-and collected so you can decide about them next):
-```bash
-mkdir -p ~/.claude/commands
+set -u
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required}"
+mkdir -p "$HOME/.claude/commands"
 collisions=""
-for c in ask-gpt ask-gemini ask-grok ask-all consensus grok-files ask-openrouter; do
-  dest=~/.claude/commands/$c.md
-  if [ -e "$dest" ]; then
-    echo "skip $c: ~/.claude/commands/$c.md already exists (left untouched)"
-    collisions="$collisions $c"
-  else
-    cp "${CLAUDE_PLUGIN_ROOT}/commands/$c.md" "$dest" && echo "installed /$c"
-  fi
+for c in ask-gpt ask-gemini ask-grok ask-openrouter ask-all consensus grok-files; do
+  dest="$HOME/.claude/commands/$c.md"
+  if [ -e "$dest" ]; then collisions="$collisions $c"
+  else cp "$PLUGIN_ROOT/commands/$c.md" "$dest" && echo "installed /$c"; fi
 done
-echo "COLLISIONS:$collisions"
+echo "COLLISIONS:${collisions:- none}"
 ```
 
-If `COLLISIONS` is empty, you are done. If it lists names, ask before touching
-those files. Use AskUserQuestion: "These alias file(s) already exist:[list].
-Overwrite them with the bundled versions?" Options (default first = keep):
-"No, keep existing (recommended)" / "Yes, overwrite".
+If `COLLISIONS` is `none`, done. If it lists names, ask with `AskUserQuestion` (own turn, no Bash):
+"These alias file(s) already exist:[list]. Overwrite with the bundled versions?" Options (default
+first = keep): "No, keep existing (recommended)" / "Yes, overwrite".
 
-**Only if the user picks "Yes, overwrite"**, force-copy just the collided names:
+**Only if "Yes, overwrite"**, run this as ONE isolated Bash call (collided names only):
+
 ```bash
+set -u
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required}"
 for c in <collided names>; do
-  cp -f "${CLAUDE_PLUGIN_ROOT}/commands/$c.md" ~/.claude/commands/$c.md && echo "overwrote /$c"
+  cp -f "$PLUGIN_ROOT/commands/$c.md" "$HOME/.claude/commands/$c.md" && echo "overwrote /$c"
 done
 ```
-Keeping the existing files is the default; overwrite only on explicit opt-in.
 
 **If no**, skip - the namespaced commands still work.
 
-## Step 4: Verify Installation
+## Step 3: Provider auth reminders
 
-Run these checks and report results:
+Print only the reminders relevant to what the Step-1 status showed as missing:
+
+- Codex: `codex login`
+- Gemini: run `agy` once and complete sign-in (or set the model in `~/.gemini/settings.json`)
+- Grok: `export XAI_API_KEY=xai-...` (https://console.x.ai) in your shell profile, then restart
+- OpenRouter: export the key named by `apiKeyEnv` (default `OPENROUTER_API_KEY`)
+
+Seven experts are available, auto-detected from the request (or explicit: "Ask GPT to...", "Ask
+Gemini to...", "Ask Grok to..."), each able to advise (read-only) or implement (write; Grok and
+OpenRouter advisory-only): Architect, Plan Reviewer, Scope Analyst, Code Reviewer, Security
+Analyst, Researcher, Debugger.
+
+## Step 4: Ask about starring
+
+Ask with `AskUserQuestion` (own turn): would the user like to star the deliberation repo to support
+the project? Options: "Yes, star the repo" / "No thanks".
+
+**If yes**, run as ONE isolated Bash call:
 
 ```bash
-# Check 1: CLI versions
-codex --version 2>&1 | head -1 || echo "Not installed"
-agy --help 2>&1 | head -1 || echo "Not installed"
-
-# Check 2: Codex MCP server
-# Model is no longer hardcoded on the registration; resolve it from a `-c model=`
-# server override if present, else the `model` key in ~/.codex/config.toml.
-CODEX_CONFIG=$(claude mcp get deliberation-codex 2>/dev/null)
-if echo "$CODEX_CONFIG" | grep -q "codex"; then
-  MODEL=$(echo "$CODEX_CONFIG" | grep -oE 'model=[^ ]+' | head -1 | cut -d= -f2)
-  if [ -z "$MODEL" ]; then
-    MODEL=$(grep -oE '^[[:space:]]*model[[:space:]]*=[[:space:]]*"[^"]+"' ~/.codex/config.toml 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
-    MODEL="${MODEL:+$MODEL (from ~/.codex/config.toml)}"
-  fi
-  echo "Codex: OK (model: ${MODEL:-default from ~/.codex/config.toml})"
-else
-  echo "Codex: NOT CONFIGURED"
-fi
-
-# Check 3: Gemini MCP server
-GEMINI_CONFIG=$(claude mcp get deliberation-gemini 2>/dev/null)
-if echo "$GEMINI_CONFIG" | grep -q "server/gemini/index.js"; then
-  GEMINI_MODEL="${GEMINI_DEFAULT_MODEL:-auto-gemini-3}"
-  echo "Gemini: OK (model: $GEMINI_MODEL)"
-else
-  echo "Gemini: NOT CONFIGURED"
-fi
-
-# Check 4: Gemini bridge health (initialize handshake)
-if echo "$GEMINI_CONFIG" | grep -q "server/gemini/index.js"; then
-  BRIDGE_HEALTH=$(printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' \
-    | node "${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js" 2>/dev/null \
-    | grep -q '"id":"health"' && echo "Gemini Bridge: HEALTHY" || echo "Gemini Bridge: UNHEALTHY")
-  echo "$BRIDGE_HEALTH"
-else
-  echo "Gemini Bridge: SKIPPED (Gemini MCP not configured)"
-fi
-
-# Check 4a: Gemini model validation
-# agy reads the model from ~/.gemini/settings.json (model.name); the bridge cannot
-# override it per call. Warn if the configured model is not a known Gemini 3 value.
-GEMINI_SETTINGS_MODEL=$(node -e 'try{const s=require(require("os").homedir()+"/.gemini/settings.json");process.stdout.write((s.model&&s.model.name)||"")}catch(e){process.stdout.write("")}' 2>/dev/null)
-case "$GEMINI_SETTINGS_MODEL" in
-  auto-gemini-3|gemini-3-pro-preview|gemini-3-flash-preview)
-    echo "Gemini model: $GEMINI_SETTINGS_MODEL (OK)"
-    ;;
-  "")
-    echo "Gemini model: not set in ~/.gemini/settings.json (agy default: auto-gemini-3)"
-    ;;
-  *)
-    echo "Gemini model: $GEMINI_SETTINGS_MODEL (WARNING: unexpected value)"
-    echo "  The bridge cannot override the model per call. Set it via \`agy\` /model or by editing ~/.gemini/settings.json (model.name) to one of: auto-gemini-3, gemini-3-pro-preview, gemini-3-flash-preview."
-    ;;
-esac
-
-# Check 4b: Grok MCP server + bridge health
-GROK_CONFIG=$(claude mcp get deliberation-grok 2>/dev/null)
-if echo "$GROK_CONFIG" | grep -q "server/grok/index.js"; then
-  GROK_MODEL="${GROK_DEFAULT_MODEL:-grok-4.3}"
-  echo "Grok: OK (model: $GROK_MODEL)"
-  GROK_HEALTH=$(printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' \
-    | node "${CLAUDE_PLUGIN_ROOT}/server/grok/index.js" 2>/dev/null \
-    | grep -q '"id":"health"' && echo "Grok Bridge: HEALTHY" || echo "Grok Bridge: UNHEALTHY")
-  echo "$GROK_HEALTH"
-  [ -n "$XAI_API_KEY" ] && echo "Grok Auth: XAI_API_KEY set" || echo "Grok Auth: XAI_API_KEY NOT set (calls return missing-auth)"
-else
-  echo "Grok: NOT CONFIGURED"
-fi
-
-# Check 5: OpenRouter MCP server + bridge health
-OR_CONFIG=$(claude mcp get deliberation-openrouter 2>/dev/null)
-if echo "$OR_CONFIG" | grep -q "server/openrouter/index.js"; then
-  OR_HEALTH=$(printf '{"jsonrpc":"2.0","id":"health","method":"initialize","params":{}}\n' \
-    | node "${CLAUDE_PLUGIN_ROOT}/server/openrouter/index.js" 2>/dev/null \
-    | grep -q '"id":"health"' && echo "OpenRouter Bridge: HEALTHY" || echo "OpenRouter Bridge: UNHEALTHY")
-  echo "$OR_HEALTH"
-else
-  echo "OpenRouter: NOT CONFIGURED"
-fi
-
-# Check 6: Rules installed (count files)
-ls ~/.claude/rules/deliberation/*.md 2>/dev/null | wc -l
-
-# Check 7: Codex auth status
-codex login status 2>&1 | head -1 || echo "Codex: Run 'codex login'"
+gh api -X PUT /user/starred/antonbabenko/deliberation 2>/dev/null && echo "Starred. Thank you!" || echo "Could not star via gh; star manually at https://github.com/antonbabenko/deliberation"
 ```
 
-## Step 5: Report Status
-
-Display actual values from the checks above:
-
-```
-deliberation Status
-───────────────────────────────────────────────────
-Codex CLI:       [version from check 1]
-Antigravity CLI: [agy install signal from check 1]
-Codex MCP:       [status + model from check 2]
-Gemini MCP:      [status + model from check 3]
-Gemini Bridge:   [status from check 4]
-Gemini model:    [value from check 4a]
-Grok MCP:        [status + model from check 4b]
-Rules:           ✓ [N] files in ~/.claude/rules/deliberation/
-Codex Auth:      [status from check 7]
-Grok Auth:       [XAI_API_KEY status from check 4b]
-───────────────────────────────────────────────────
-```
-
-If any check fails, report the specific issue and how to fix it.
-
-## Step 6: Final Instructions
-
-```
-Setup complete!
-
-Next steps:
-1. Restart Claude Code to load MCP server(s)
-2. Authenticate providers as needed:
-   - Codex: Run `codex login`
-   - Gemini: Run `agy` once and complete sign-in (or set the model in ~/.gemini/settings.json)
-   - Grok: export XAI_API_KEY=xai-... (get a key at https://console.x.ai) in your shell profile, then restart Claude Code
-3. After editing plugin code or upgrading the plugin version: run `/mcp` in your Claude Code session and press `Reconnect` on `deliberation-gemini` and `deliberation-grok` to load the new code without restarting Claude Code. See README → "Updating the plugin".
-
-Seven experts available:
-
-┌──────────────────┬─────────────────────────────────────────────┐
-│ Architect        │ "How should I structure this service?"      │
-│                  │ "What are the tradeoffs of Redis vs X?"     │
-│                  │ → System design, architecture decisions     │
-├──────────────────┼─────────────────────────────────────────────┤
-│ Plan Reviewer    │ "Review this migration plan"                │
-│                  │ "Is this implementation plan complete?"     │
-│                  │ → Plan validation before execution          │
-├──────────────────┼─────────────────────────────────────────────┤
-│ Scope Analyst    │ "Clarify the scope of this feature"         │
-│                  │ "What am I missing in these requirements?"  │
-│                  │ → Pre-planning, catches ambiguities         │
-├──────────────────┼─────────────────────────────────────────────┤
-│ Code Reviewer    │ "Review this PR"                            │
-│                  │ "Find issues in this implementation"        │
-│                  │ → Code quality, bugs, maintainability       │
-├──────────────────┼─────────────────────────────────────────────┤
-│ Security Analyst │ "Is this authentication flow secure?"       │
-│                  │ "Harden this endpoint"                      │
-│                  │ → Vulnerabilities, threat modeling          │
-├──────────────────┼─────────────────────────────────────────────┤
-│ Researcher       │ "How do I use this library?"                │
-│                  │ "Find examples of X"                        │
-│                  │ → External libraries, docs, best practices  │
-├──────────────────┼─────────────────────────────────────────────┤
-│ Debugger         │ "Why does this crash?" / "Debug this"       │
-│                  │ "This failing test - find the bug"          │
-│                  │ → Root-cause hypotheses, minimal fixes      │
-└──────────────────┴─────────────────────────────────────────────┘
-
-Every expert can advise (read-only) OR implement (write).
-Expert is auto-detected based on your request.
-Explicit: "Ask GPT to...", "Ask Gemini to...", or "Ask Grok to..."
-```
-
-## Step 7: Ask About Starring
-
-Use AskUserQuestion to ask the user if they'd like to ⭐ star the deliberation repository on GitHub to support the project.
-
-Options: "Yes, star the repo" / "No thanks"
-
-**If yes**: Check if `gh` CLI is available and run:
-```bash
-gh api -X PUT /user/starred/antonbabenko/deliberation
-```
-
-If `gh` is not available or the command fails, provide the manual link:
-```
-https://github.com/antonbabenko/deliberation
-```
-
-**If no**: Thank them and complete setup without starring.
+**If no**, thank them and finish.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -21,19 +21,15 @@ call with an AskUserQuestion, and do not split the main block.
 > with any other tool call. It is idempotent - safe to re-run.
 
 It does everything non-interactive: checks CLIs, reads `config.json` once, registers the enabled
-MCP servers at user scope (namespaced `deliberation-*`, removing any legacy bare registrations),
-installs the rules, and prints a status report.
+MCP servers at user scope (namespaced `deliberation-*`), installs the rules, and prints a status
+report.
 
 ```bash
 set -u
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required (run this via /deliberation:setup)}"
 
-# --- config path: new env > legacy env > new file > legacy file ---
-CFG="${DELIBERATION_CONFIG:-${CLAUDE_DELEGATOR_CONFIG:-}}"
-if [ -z "$CFG" ]; then
-  if [ -f "$HOME/.claude/deliberation/config.json" ]; then CFG="$HOME/.claude/deliberation/config.json"
-  else CFG="$HOME/.claude/claude-delegator/config.json"; fi
-fi
+# --- config path: env override > default deliberation path ---
+CFG="${DELIBERATION_CONFIG:-$HOME/.claude/deliberation/config.json}"
 
 json_eval() { node -e "$1" "$CFG" 2>/dev/null; }
 # providers.<name>.enabled: missing => enabled (returns 1); explicit false => 0.
@@ -59,15 +55,11 @@ command -v agy   >/dev/null 2>&1 && AGY_STATUS="installed" || AGY_STATUS="MISSIN
 # --- register servers (each gated on provider_enabled; missing config = all on) ---
 # Codex: inherits model from ~/.codex/config.toml. Pin with `-c model=<id>` (see notes below).
 if [ "$(provider_enabled codex)" = "1" ]; then add_mcp deliberation-codex codex mcp-server; else remove_mcp deliberation-codex; fi
-remove_mcp codex   # drop legacy bare name
 
 if [ "$(provider_enabled gemini)" = "1" ]; then add_mcp deliberation-gemini node "$PLUGIN_ROOT/server/gemini/index.js"; else remove_mcp deliberation-gemini; fi
-remove_mcp gemini
 
 if [ "$(provider_enabled grok)" = "1" ]; then add_mcp deliberation-grok node "$PLUGIN_ROOT/server/grok/index.js"; else remove_mcp deliberation-grok; fi
-remove_mcp grok
 
-remove_mcp openrouter   # drop legacy bare name
 if [ "$(openrouter_enabled)" = "1" ]; then
   add_mcp deliberation-openrouter node "$PLUGIN_ROOT/server/openrouter/index.js"
   KEYENV="$(or_key_env)"; [ -z "$(printenv "$KEYENV" 2>/dev/null)" ] && echo "Note: \$$KEYENV is empty; OpenRouter calls return auth errors until you export it."
@@ -96,7 +88,6 @@ echo "OpenRouter auth: $([ -n "${OPENROUTER_API_KEY:-}" ] && echo set || echo "n
 echo "MCP servers registered (user scope). Run 'claude mcp list' to confirm."
 echo
 echo "Restart Claude Code so the deliberation-* tools load; until then /ask-* may not find them."
-[ -d "$HOME/.claude/rules/delegator" ] && echo "Note: legacy ~/.claude/rules/delegator/ is unused after the rename; remove it manually if you want."
 ```
 
 After it runs, report the printed status to the user.
@@ -121,9 +112,7 @@ After it runs, report the printed status to the user.
 ## Step 2: Optional short command names
 
 The commands are always available namespaced (`/deliberation:ask-gpt`, `:ask-all`, `:consensus`,
-...). The short aliases (`/ask-gpt` etc.) are an opt-in copy into `~/.claude/commands/`. (The
-namespaced form changed from `/claude-delegator:*` to `/deliberation:*`; the unnamespaced aliases
-are unaffected by the rename.)
+...). The short aliases (`/ask-gpt` etc.) are an opt-in copy into `~/.claude/commands/`.
 
 Ask with `AskUserQuestion` (this turn has NO Bash call): "Also install short command names
 (/ask-gpt etc.) into ~/.claude/commands?" Options: "Yes (recommended)" / "No, keep namespaced

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -146,7 +146,7 @@ echo "COLLISIONS:${collisions:- none}"
 
 If `COLLISIONS` is `none`, done. If it lists names, ask with `AskUserQuestion` (own turn, no Bash):
 "These alias file(s) already exist:[list]. Overwrite with the bundled versions?" Options (default
-first = keep): "No, keep existing (recommended)" / "Yes, overwrite".
+first = overwrite): "Yes, overwrite (recommended)" / "No, keep existing".
 
 **Only if "Yes, overwrite"**, run this as ONE isolated Bash call (collided names only):
 

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -25,28 +25,26 @@ If cancelled, stop here.
 > Run the block below as ONE Bash call. Do NOT split it, and do NOT batch it with any other tool
 > call. Every removal is tolerant of absence (no error if already gone).
 
-It removes the namespaced `deliberation-*` servers, the unified `deliberation` server, any legacy
-bare registrations, both rules dirs (new + legacy), both Grok cache dirs (new + legacy), and only
-the aliases that are byte-identical to the bundled commands (a user-authored same-named command is
-left untouched).
+It removes the namespaced `deliberation-*` servers, the unified `deliberation` server, the rules
+dir, the Grok cache dir, and only the aliases that are byte-identical to the bundled commands (a
+user-authored same-named command is left untouched).
 
 ```bash
 set -u
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
 
-# --- MCP registrations (namespaced + unified + legacy bare) ---
-for s in deliberation-codex deliberation-gemini deliberation-grok deliberation-openrouter deliberation \
-         codex gemini grok openrouter; do
+# --- MCP registrations (namespaced + unified) ---
+for s in deliberation deliberation-codex deliberation-gemini deliberation-grok deliberation-openrouter; do
   claude mcp remove --scope user "$s" >/dev/null 2>&1 || true
 done
 echo "Removed MCP registrations (user scope)."
 
-# --- rules dirs (new + legacy) ---
-rm -rf "$HOME/.claude/rules/deliberation/" "$HOME/.claude/rules/delegator/" 2>/dev/null || true
-echo "Removed rules dirs."
+# --- rules dir ---
+rm -rf "$HOME/.claude/rules/deliberation/" 2>/dev/null || true
+echo "Removed rules dir."
 
-# --- Grok dedup cache (new + legacy); metadata only, safe to drop ---
-rm -rf "$HOME/.claude/cache/deliberation/" "$HOME/.claude/cache/claude-delegator/" 2>/dev/null || true
+# --- Grok dedup cache; metadata only, safe to drop ---
+rm -rf "$HOME/.claude/cache/deliberation/" 2>/dev/null || true
 echo "Removed Grok file cache."
 
 # --- short command aliases: remove ONLY if byte-identical to the bundled command ---
@@ -64,7 +62,7 @@ done
 # Obsolete /ask-both (renamed to /ask-all in 1.7.0): remove only if it carries the bundled
 # fingerprint, so a user-authored ask-both.md is left untouched.
 ob="$HOME/.claude/commands/ask-both.md"
-if [ -e "$ob" ] && grep -q "name: ask-both" "$ob" 2>/dev/null && grep -qE "claude-delegator|deliberation" "$ob" 2>/dev/null; then
+if [ -e "$ob" ] && grep -q "name: ask-both" "$ob" 2>/dev/null && grep -q "deliberation" "$ob" 2>/dev/null; then
   rm -f "$ob" && removed="$removed /ask-both"
 elif [ -e "$ob" ]; then
   kept="$kept /ask-both"
@@ -85,5 +83,5 @@ only cleans up the user-scope MCP registrations, rules, cache, and copied aliase
 - Grok remote uploads: if you still have `XAI_API_KEY` and want to drain xAI-side uploads before
   uninstalling, run `/grok-files prune --older-than 0s --yes` (or `/grok-files gc` to see what is
   already gone) BEFORE Step 2.
-- Config (`~/.claude/deliberation/config.json` or the legacy path) is left in place - it holds your
-  OpenRouter model setup and API-key env names. Remove it manually if you want a full wipe.
+- Config (`~/.claude/deliberation/config.json`) is left in place - it holds your OpenRouter model
+  setup and API-key env names. Remove it manually if you want a full wipe.

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -1,101 +1,89 @@
 ---
 name: uninstall
 description: Uninstall deliberation (remove MCP config and rules)
-allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
+allowed-tools: Bash, Read, AskUserQuestion
 timeout: 30000
 ---
 
 # Uninstall
 
-Remove deliberation from Claude Code.
+Remove deliberation from Claude Code: MCP registrations, installed rules, the local Grok cache,
+and any short command aliases that `/setup` copied.
 
-## Confirm Removal
+This runs as one confirmation turn, then ONE main Bash call. Do not batch the Bash call with the
+AskUserQuestion.
 
-**Question**: "Remove Codex/Gemini/Grok/OpenRouter MCP configuration and plugin rules?"
-**Options**:
-- "Yes, uninstall"
-- "No, cancel"
+## Step 1: Confirm
+
+Ask with `AskUserQuestion` (this turn has NO Bash call): "Remove deliberation MCP servers, rules,
+Grok cache, and short command aliases?" Options: "Yes, uninstall" / "No, cancel".
 
 If cancelled, stop here.
 
-## Remove MCP Configuration
+## Step 2: Remove everything
 
-Remove both the namespaced `deliberation-*` registrations, the unified `deliberation`
-server, and any legacy bare registrations from an earlier install. Each remove is
-tolerant of absence.
+> Run the block below as ONE Bash call. Do NOT split it, and do NOT batch it with any other tool
+> call. Every removal is tolerant of absence (no error if already gone).
 
-```bash
-claude mcp remove --scope user deliberation-codex 2>/dev/null || true
-claude mcp remove --scope user deliberation-gemini 2>/dev/null || true
-claude mcp remove --scope user deliberation-grok 2>/dev/null || true
-claude mcp remove --scope user deliberation-openrouter 2>/dev/null || true
-claude mcp remove --scope user deliberation 2>/dev/null || true
-claude mcp remove --scope user codex 2>/dev/null || true
-claude mcp remove --scope user gemini 2>/dev/null || true
-claude mcp remove --scope user grok 2>/dev/null || true
-claude mcp remove --scope user openrouter 2>/dev/null || true
-```
-
-## Remove Installed Rules
-
-Remove both the new and legacy rules directories (tolerant of absence).
+It removes the namespaced `deliberation-*` servers, the unified `deliberation` server, any legacy
+bare registrations, both rules dirs (new + legacy), both Grok cache dirs (new + legacy), and only
+the aliases that are byte-identical to the bundled commands (a user-authored same-named command is
+left untouched).
 
 ```bash
-rm -rf ~/.claude/rules/deliberation/
-rm -rf ~/.claude/rules/delegator/
-```
+set -u
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
 
-## Remove Local Grok File Cache (optional)
+# --- MCP registrations (namespaced + unified + legacy bare) ---
+for s in deliberation-codex deliberation-gemini deliberation-grok deliberation-openrouter deliberation \
+         codex gemini grok openrouter; do
+  claude mcp remove --scope user "$s" >/dev/null 2>&1 || true
+done
+echo "Removed MCP registrations (user scope)."
 
-The Grok bridge keeps a SHA-256 dedup cache at
-`~/.claude/cache/claude-delegator/grok-files.json`. It only holds upload metadata
-(no payload), but it is orphaned once the plugin is gone. Remove it explicitly:
+# --- rules dirs (new + legacy) ---
+rm -rf "$HOME/.claude/rules/deliberation/" "$HOME/.claude/rules/delegator/" 2>/dev/null || true
+echo "Removed rules dirs."
 
-```bash
-rm -rf ~/.claude/cache/claude-delegator/
-```
+# --- Grok dedup cache (new + legacy); metadata only, safe to drop ---
+rm -rf "$HOME/.claude/cache/deliberation/" "$HOME/.claude/cache/claude-delegator/" 2>/dev/null || true
+echo "Removed Grok file cache."
 
-If you still have an `XAI_API_KEY` and want to also drain the remote uploads on
-xAI's side before uninstall, run `/grok-files prune --older-than 0s --yes` first
-(or `/grok-files gc` to discover what's already gone), then this `rm -rf`.
-
-## Remove Short Command Aliases (if installed)
-
-Only the aliases that `/setup` may have copied; the namespaced
-`deliberation:*` commands are removed by uninstalling the plugin itself.
-Ownership-aware: a copied alias is removed only if it is byte-identical to the
-plugin's bundled command (so an unrelated user-authored same-named command,
-which `/setup` would have skipped rather than overwritten, is left untouched).
-```bash
+# --- short command aliases: remove ONLY if byte-identical to the bundled command ---
+removed=""; kept=""
 for c in ask-gpt ask-gemini ask-grok ask-openrouter ask-all consensus grok-files; do
-  dest=~/.claude/commands/$c.md
-  src="${CLAUDE_PLUGIN_ROOT}/commands/$c.md"
-  if [ ! -e "$dest" ]; then
-    continue
-  elif [ -f "$src" ] && cmp -s "$src" "$dest"; then
-    rm -f "$dest" && echo "removed /$c"
+  dest="$HOME/.claude/commands/$c.md"
+  src="$PLUGIN_ROOT/commands/$c.md"
+  [ ! -e "$dest" ] && continue
+  if [ -n "$PLUGIN_ROOT" ] && [ -f "$src" ] && cmp -s "$src" "$dest"; then
+    rm -f "$dest" && removed="$removed /$c"
   else
-    echo "skip $c: ~/.claude/commands/$c.md differs from plugin copy (left untouched)"
+    kept="$kept /$c"
   fi
 done
-
-# ask-both was renamed to ask-all in 1.7.0; the plugin no longer ships ask-both.md.
-# Remove a copied ask-both alias only when it carries the delegator fingerprint
-# (so a user-authored ask-both.md is left untouched).
-olddest=~/.claude/commands/ask-both.md
-if [ -e "$olddest" ] && grep -q "claude-delegator/claude-delegator" "$olddest" && grep -q "name: ask-both" "$olddest"; then
-  rm -f "$olddest" && echo "removed obsolete /ask-both (renamed to /ask-all)"
-elif [ -e "$olddest" ]; then
-  echo "skip ask-both: ~/.claude/commands/ask-both.md not recognized as a plugin alias (left untouched)"
+# Obsolete /ask-both (renamed to /ask-all in 1.7.0): remove only if it carries the bundled
+# fingerprint, so a user-authored ask-both.md is left untouched.
+ob="$HOME/.claude/commands/ask-both.md"
+if [ -e "$ob" ] && grep -q "name: ask-both" "$ob" 2>/dev/null && grep -qE "claude-delegator|deliberation" "$ob" 2>/dev/null; then
+  rm -f "$ob" && removed="$removed /ask-both"
+elif [ -e "$ob" ]; then
+  kept="$kept /ask-both"
 fi
+echo "Aliases removed:${removed:- none}"
+[ -n "$kept" ] && echo "Aliases left untouched (differ from bundled / user-authored):$kept"
+
+echo
+echo "Uninstall complete. Restart Claude Code so the removed MCP servers drop from the session."
+echo "To reinstall: /deliberation:setup"
 ```
 
-## Confirm Completion
+After it runs, report the printed summary. The plugin itself is removed via `/plugin` (this command
+only cleans up the user-scope MCP registrations, rules, cache, and copied aliases).
 
-```
-✓ Removed providers from MCP servers
-✓ Removed rules from ~/.claude/rules/deliberation/
-✓ Removed short command aliases from ~/.claude/commands/ (if present)
+## Notes
 
-To reinstall: /deliberation:setup
-```
+- Grok remote uploads: if you still have `XAI_API_KEY` and want to drain xAI-side uploads before
+  uninstalling, run `/grok-files prune --older-than 0s --yes` (or `/grok-files gc` to see what is
+  already gone) BEFORE Step 2.
+- Config (`~/.claude/deliberation/config.json` or the legacy path) is left in place - it holds your
+  OpenRouter model setup and API-key env names. Remove it manually if you want a full wipe.

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -1,13 +1,13 @@
 ---
 name: uninstall
-description: Uninstall claude-delegator (remove MCP config and rules)
+description: Uninstall deliberation (remove MCP config and rules)
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 timeout: 30000
 ---
 
 # Uninstall
 
-Remove claude-delegator from Claude Code.
+Remove deliberation from Claude Code.
 
 ## Confirm Removal
 
@@ -20,16 +20,28 @@ If cancelled, stop here.
 
 ## Remove MCP Configuration
 
+Remove both the namespaced `deliberation-*` registrations, the unified `deliberation`
+server, and any legacy bare registrations from an earlier install. Each remove is
+tolerant of absence.
+
 ```bash
-claude mcp remove --scope user codex
-claude mcp remove --scope user gemini
-claude mcp remove --scope user grok
-claude mcp remove --scope user openrouter
+claude mcp remove --scope user deliberation-codex 2>/dev/null || true
+claude mcp remove --scope user deliberation-gemini 2>/dev/null || true
+claude mcp remove --scope user deliberation-grok 2>/dev/null || true
+claude mcp remove --scope user deliberation-openrouter 2>/dev/null || true
+claude mcp remove --scope user deliberation 2>/dev/null || true
+claude mcp remove --scope user codex 2>/dev/null || true
+claude mcp remove --scope user gemini 2>/dev/null || true
+claude mcp remove --scope user grok 2>/dev/null || true
+claude mcp remove --scope user openrouter 2>/dev/null || true
 ```
 
 ## Remove Installed Rules
 
+Remove both the new and legacy rules directories (tolerant of absence).
+
 ```bash
+rm -rf ~/.claude/rules/deliberation/
 rm -rf ~/.claude/rules/delegator/
 ```
 
@@ -50,7 +62,7 @@ xAI's side before uninstall, run `/grok-files prune --older-than 0s --yes` first
 ## Remove Short Command Aliases (if installed)
 
 Only the aliases that `/setup` may have copied; the namespaced
-`claude-delegator:*` commands are removed by uninstalling the plugin itself.
+`deliberation:*` commands are removed by uninstalling the plugin itself.
 Ownership-aware: a copied alias is removed only if it is byte-identical to the
 plugin's bundled command (so an unrelated user-authored same-named command,
 which `/setup` would have skipped rather than overwritten, is left untouched).
@@ -82,8 +94,8 @@ fi
 
 ```
 ✓ Removed providers from MCP servers
-✓ Removed rules from ~/.claude/rules/delegator/
+✓ Removed rules from ~/.claude/rules/deliberation/
 ✓ Removed short command aliases from ~/.claude/commands/ (if present)
 
-To reinstall: /claude-delegator:setup
+To reinstall: /deliberation:setup
 ```

--- a/core/paths.js
+++ b/core/paths.js
@@ -1,15 +1,13 @@
 "use strict";
 
 /**
- * core/paths.js - shared config + cache path resolver for the deliberation rebrand.
+ * core/paths.js - shared config + cache path resolver for deliberation.
  *
  * Zero runtime dependencies. CommonJS. JSDoc-typed so it passes strict `tsc`
  * (it is inside the strict tsconfig include).
  *
- * Resolves which on-disk file the bridges and the unified server should use,
- * preferring the new `deliberation` paths while transparently migrating from the
- * legacy `claude-delegator` paths. Migration is a best-effort side effect: on any
- * filesystem error it degrades to reading the legacy file in place and never throws.
+ * Resolves which on-disk file the bridges and the unified server should use.
+ * Deliberation-only: there is no fallback or migration from older path layouts.
  *
  * Exports:
  *   - resolveConfigPath(opts?)    -> absolute path to the config.json to use
@@ -22,7 +20,6 @@
 
 const os = require("node:os");
 const path = require("node:path");
-const fs = require("node:fs");
 
 /**
  * @typedef {Object} ResolveOptions
@@ -30,140 +27,12 @@ const fs = require("node:fs");
  * @property {NodeJS.ProcessEnv} [env] Environment to read overrides from. Defaults to process.env.
  */
 
-// --- warn-once state (module scope, one print per distinct warning per process) ---
-let warnedEnvConflict = false;
-let warnedConfigMigrate = false;
-let warnedGrokMigrate = false;
-
 /**
- * Emit a one-line stderr note at most once per process for a given flag.
- * @param {"envConflict"|"configMigrate"|"grokMigrate"} kind
- * @param {string} message
- * @returns {void}
- */
-function warnOnce(kind, message) {
-  if (kind === "envConflict") {
-    if (warnedEnvConflict) return;
-    warnedEnvConflict = true;
-  } else if (kind === "configMigrate") {
-    if (warnedConfigMigrate) return;
-    warnedConfigMigrate = true;
-  } else if (kind === "grokMigrate") {
-    if (warnedGrokMigrate) return;
-    warnedGrokMigrate = true;
-  }
-  process.stderr.write(message.endsWith("\n") ? message : message + "\n");
-}
-
-/**
- * Test-only hook: reset the warn-once flags so each test can observe a fresh
- * "at most once" window. Not part of the public Wave-1 contract.
- * @returns {void}
- */
-function _resetWarnOnceForTests() {
-  warnedEnvConflict = false;
-  warnedConfigMigrate = false;
-  warnedGrokMigrate = false;
-}
-
-/**
- * True if the path exists on disk.
- * @param {string} p
- * @returns {boolean}
- */
-function exists(p) {
-  try {
-    return fs.existsSync(p);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Atomically migrate `legacyPath` -> `newPath`: mkdir -p the new dir, write the
- * legacy contents to a temp file in the NEW dir, then renameSync onto newPath.
- * Leaves the legacy file in place (enables downgrade). On ANY error, cleans up
- * the temp file and rethrows so the caller can fall back to legacy-in-place.
- *
- * @param {string} legacyPath
- * @param {string} newPath
- * @returns {void}
- */
-function atomicMigrate(legacyPath, newPath) {
-  const newDir = path.dirname(newPath);
-  const tmpPath = newPath + ".tmp-" + process.pid;
-  fs.mkdirSync(newDir, { recursive: true });
-  try {
-    const data = fs.readFileSync(legacyPath);
-    fs.writeFileSync(tmpPath, data);
-    fs.renameSync(tmpPath, newPath);
-  } catch (err) {
-    // Best-effort temp cleanup; never let cleanup mask the original error.
-    try {
-      if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
-    } catch {
-      /* ignore */
-    }
-    throw err;
-  }
-}
-
-/**
- * Core precedence shared by config + grok-cache resolution (minus env override).
- *
- * 1. NEW path exists -> return NEW (no migration).
- * 2. LEGACY exists -> migrate atomically -> return NEW. On migration failure,
- *    warn-once and return LEGACY (read in place this run).
- * 3. Neither exists -> return NEW (fresh install; caller creates on first write).
- *
- * @param {string} newPath
- * @param {string} legacyPath
- * @param {"configMigrate"|"grokMigrate"} warnKind
- * @param {string} label Human label used in the migration-failure warning.
- * @returns {string}
- */
-function resolveWithMigration(newPath, legacyPath, warnKind, label) {
-  if (exists(newPath)) return newPath;
-
-  if (exists(legacyPath)) {
-    try {
-      atomicMigrate(legacyPath, newPath);
-      return newPath;
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      warnOnce(
-        warnKind,
-        "[deliberation] could not migrate " +
-          label +
-          " from " +
-          legacyPath +
-          " to " +
-          newPath +
-          " (" +
-          reason +
-          "); reading legacy path in place.",
-      );
-      return legacyPath;
-    }
-  }
-
-  return newPath;
-}
-
-/**
- * Resolve the absolute path to the config.json the caller should use, performing
- * legacy->new migration as a side effect when needed.
+ * Resolve the absolute path to the config.json the caller should use.
  *
  * Precedence:
- *   1. Env override (verbatim, NO migration):
- *      - DELIBERATION_CONFIG if non-empty -> return it.
- *      - else CLAUDE_DELEGATOR_CONFIG if non-empty -> return it (legacy honored).
- *      - if BOTH set, DELIBERATION_CONFIG wins and a one-line stderr note is
- *        emitted (warn-once).
- *   2. NEW `~/.claude/deliberation/config.json` if it exists -> return it.
- *   3. LEGACY `~/.claude/claude-delegator/config.json` if it exists -> migrate
- *      atomically -> return NEW (or LEGACY in place if migration fails).
- *   4. Neither exists -> return NEW (fresh install).
+ *   1. DELIBERATION_CONFIG if non-empty -> return it verbatim.
+ *   2. else -> `~/.claude/deliberation/config.json`.
  *
  * @param {ResolveOptions} [opts]
  * @returns {string} absolute path to the config.json to use
@@ -172,70 +41,28 @@ function resolveConfigPath(opts) {
   const home = (opts && opts.home) || os.homedir();
   const env = (opts && opts.env) || process.env;
 
-  const deliberationEnv = env.DELIBERATION_CONFIG;
-  const legacyEnv = env.CLAUDE_DELEGATOR_CONFIG;
-  const hasDeliberationEnv =
-    typeof deliberationEnv === "string" && deliberationEnv.length > 0;
-  const hasLegacyEnv = typeof legacyEnv === "string" && legacyEnv.length > 0;
-
-  if (hasDeliberationEnv) {
-    if (hasLegacyEnv) {
-      warnOnce(
-        "envConflict",
-        "[deliberation] both DELIBERATION_CONFIG and CLAUDE_DELEGATOR_CONFIG are set; using DELIBERATION_CONFIG.",
-      );
-    }
-    return deliberationEnv;
-  }
-  if (hasLegacyEnv) {
-    return legacyEnv;
+  const override = env.DELIBERATION_CONFIG;
+  if (typeof override === "string" && override.length > 0) {
+    return override;
   }
 
-  const newPath = path.join(home, ".claude", "deliberation", "config.json");
-  const legacyPath = path.join(
-    home,
-    ".claude",
-    "claude-delegator",
-    "config.json",
-  );
-
-  return resolveWithMigration(newPath, legacyPath, "configMigrate", "config");
+  return path.join(home, ".claude", "deliberation", "config.json");
 }
 
 /**
- * Resolve the absolute path to the Grok files cache the caller should use,
- * performing legacy->new migration as a side effect when needed. Same precedence
- * shape as resolveConfigPath but with NO env override (the grok cache has none).
+ * Resolve the absolute path to the Grok files cache the caller should use.
  *
- * NEW    `~/.claude/cache/deliberation/grok-files.json`
- * LEGACY `~/.claude/cache/claude-delegator/grok-files.json`
+ * Always `~/.claude/cache/deliberation/grok-files.json` (no env override).
  *
  * @param {ResolveOptions} [opts]
  * @returns {string} absolute path to the grok-files.json cache to use
  */
 function resolveGrokCachePath(opts) {
   const home = (opts && opts.home) || os.homedir();
-
-  const newPath = path.join(
-    home,
-    ".claude",
-    "cache",
-    "deliberation",
-    "grok-files.json",
-  );
-  const legacyPath = path.join(
-    home,
-    ".claude",
-    "cache",
-    "claude-delegator",
-    "grok-files.json",
-  );
-
-  return resolveWithMigration(newPath, legacyPath, "grokMigrate", "grok cache");
+  return path.join(home, ".claude", "cache", "deliberation", "grok-files.json");
 }
 
 module.exports = {
   resolveConfigPath,
   resolveGrokCachePath,
-  _resetWarnOnceForTests,
 };

--- a/core/paths.js
+++ b/core/paths.js
@@ -1,0 +1,241 @@
+"use strict";
+
+/**
+ * core/paths.js - shared config + cache path resolver for the deliberation rebrand.
+ *
+ * Zero runtime dependencies. CommonJS. JSDoc-typed so it passes strict `tsc`
+ * (it is inside the strict tsconfig include).
+ *
+ * Resolves which on-disk file the bridges and the unified server should use,
+ * preferring the new `deliberation` paths while transparently migrating from the
+ * legacy `claude-delegator` paths. Migration is a best-effort side effect: on any
+ * filesystem error it degrades to reading the legacy file in place and never throws.
+ *
+ * Exports:
+ *   - resolveConfigPath(opts?)    -> absolute path to the config.json to use
+ *   - resolveGrokCachePath(opts?) -> absolute path to the grok-files.json cache to use
+ *
+ * Both accept an optional `{ home, env }` injection so callers (and tests) can
+ * point at a temp HOME and a fake env without mutating real process state. When
+ * omitted they default to `os.homedir()` and `process.env`.
+ */
+
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+
+/**
+ * @typedef {Object} ResolveOptions
+ * @property {string} [home] Home directory to resolve `~/.claude/...` against. Defaults to os.homedir().
+ * @property {NodeJS.ProcessEnv} [env] Environment to read overrides from. Defaults to process.env.
+ */
+
+// --- warn-once state (module scope, one print per distinct warning per process) ---
+let warnedEnvConflict = false;
+let warnedConfigMigrate = false;
+let warnedGrokMigrate = false;
+
+/**
+ * Emit a one-line stderr note at most once per process for a given flag.
+ * @param {"envConflict"|"configMigrate"|"grokMigrate"} kind
+ * @param {string} message
+ * @returns {void}
+ */
+function warnOnce(kind, message) {
+  if (kind === "envConflict") {
+    if (warnedEnvConflict) return;
+    warnedEnvConflict = true;
+  } else if (kind === "configMigrate") {
+    if (warnedConfigMigrate) return;
+    warnedConfigMigrate = true;
+  } else if (kind === "grokMigrate") {
+    if (warnedGrokMigrate) return;
+    warnedGrokMigrate = true;
+  }
+  process.stderr.write(message.endsWith("\n") ? message : message + "\n");
+}
+
+/**
+ * Test-only hook: reset the warn-once flags so each test can observe a fresh
+ * "at most once" window. Not part of the public Wave-1 contract.
+ * @returns {void}
+ */
+function _resetWarnOnceForTests() {
+  warnedEnvConflict = false;
+  warnedConfigMigrate = false;
+  warnedGrokMigrate = false;
+}
+
+/**
+ * True if the path exists on disk.
+ * @param {string} p
+ * @returns {boolean}
+ */
+function exists(p) {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Atomically migrate `legacyPath` -> `newPath`: mkdir -p the new dir, write the
+ * legacy contents to a temp file in the NEW dir, then renameSync onto newPath.
+ * Leaves the legacy file in place (enables downgrade). On ANY error, cleans up
+ * the temp file and rethrows so the caller can fall back to legacy-in-place.
+ *
+ * @param {string} legacyPath
+ * @param {string} newPath
+ * @returns {void}
+ */
+function atomicMigrate(legacyPath, newPath) {
+  const newDir = path.dirname(newPath);
+  const tmpPath = newPath + ".tmp-" + process.pid;
+  fs.mkdirSync(newDir, { recursive: true });
+  try {
+    const data = fs.readFileSync(legacyPath);
+    fs.writeFileSync(tmpPath, data);
+    fs.renameSync(tmpPath, newPath);
+  } catch (err) {
+    // Best-effort temp cleanup; never let cleanup mask the original error.
+    try {
+      if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+/**
+ * Core precedence shared by config + grok-cache resolution (minus env override).
+ *
+ * 1. NEW path exists -> return NEW (no migration).
+ * 2. LEGACY exists -> migrate atomically -> return NEW. On migration failure,
+ *    warn-once and return LEGACY (read in place this run).
+ * 3. Neither exists -> return NEW (fresh install; caller creates on first write).
+ *
+ * @param {string} newPath
+ * @param {string} legacyPath
+ * @param {"configMigrate"|"grokMigrate"} warnKind
+ * @param {string} label Human label used in the migration-failure warning.
+ * @returns {string}
+ */
+function resolveWithMigration(newPath, legacyPath, warnKind, label) {
+  if (exists(newPath)) return newPath;
+
+  if (exists(legacyPath)) {
+    try {
+      atomicMigrate(legacyPath, newPath);
+      return newPath;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      warnOnce(
+        warnKind,
+        "[deliberation] could not migrate " +
+          label +
+          " from " +
+          legacyPath +
+          " to " +
+          newPath +
+          " (" +
+          reason +
+          "); reading legacy path in place.",
+      );
+      return legacyPath;
+    }
+  }
+
+  return newPath;
+}
+
+/**
+ * Resolve the absolute path to the config.json the caller should use, performing
+ * legacy->new migration as a side effect when needed.
+ *
+ * Precedence:
+ *   1. Env override (verbatim, NO migration):
+ *      - DELIBERATION_CONFIG if non-empty -> return it.
+ *      - else CLAUDE_DELEGATOR_CONFIG if non-empty -> return it (legacy honored).
+ *      - if BOTH set, DELIBERATION_CONFIG wins and a one-line stderr note is
+ *        emitted (warn-once).
+ *   2. NEW `~/.claude/deliberation/config.json` if it exists -> return it.
+ *   3. LEGACY `~/.claude/claude-delegator/config.json` if it exists -> migrate
+ *      atomically -> return NEW (or LEGACY in place if migration fails).
+ *   4. Neither exists -> return NEW (fresh install).
+ *
+ * @param {ResolveOptions} [opts]
+ * @returns {string} absolute path to the config.json to use
+ */
+function resolveConfigPath(opts) {
+  const home = (opts && opts.home) || os.homedir();
+  const env = (opts && opts.env) || process.env;
+
+  const deliberationEnv = env.DELIBERATION_CONFIG;
+  const legacyEnv = env.CLAUDE_DELEGATOR_CONFIG;
+  const hasDeliberationEnv =
+    typeof deliberationEnv === "string" && deliberationEnv.length > 0;
+  const hasLegacyEnv = typeof legacyEnv === "string" && legacyEnv.length > 0;
+
+  if (hasDeliberationEnv) {
+    if (hasLegacyEnv) {
+      warnOnce(
+        "envConflict",
+        "[deliberation] both DELIBERATION_CONFIG and CLAUDE_DELEGATOR_CONFIG are set; using DELIBERATION_CONFIG.",
+      );
+    }
+    return deliberationEnv;
+  }
+  if (hasLegacyEnv) {
+    return legacyEnv;
+  }
+
+  const newPath = path.join(home, ".claude", "deliberation", "config.json");
+  const legacyPath = path.join(
+    home,
+    ".claude",
+    "claude-delegator",
+    "config.json",
+  );
+
+  return resolveWithMigration(newPath, legacyPath, "configMigrate", "config");
+}
+
+/**
+ * Resolve the absolute path to the Grok files cache the caller should use,
+ * performing legacy->new migration as a side effect when needed. Same precedence
+ * shape as resolveConfigPath but with NO env override (the grok cache has none).
+ *
+ * NEW    `~/.claude/cache/deliberation/grok-files.json`
+ * LEGACY `~/.claude/cache/claude-delegator/grok-files.json`
+ *
+ * @param {ResolveOptions} [opts]
+ * @returns {string} absolute path to the grok-files.json cache to use
+ */
+function resolveGrokCachePath(opts) {
+  const home = (opts && opts.home) || os.homedir();
+
+  const newPath = path.join(
+    home,
+    ".claude",
+    "cache",
+    "deliberation",
+    "grok-files.json",
+  );
+  const legacyPath = path.join(
+    home,
+    ".claude",
+    "cache",
+    "claude-delegator",
+    "grok-files.json",
+  );
+
+  return resolveWithMigration(newPath, legacyPath, "grokMigrate", "grok cache");
+}
+
+module.exports = {
+  resolveConfigPath,
+  resolveGrokCachePath,
+  _resetWarnOnceForTests,
+};

--- a/core/registry.js
+++ b/core/registry.js
@@ -2,7 +2,7 @@
 /** @typedef {import("./types.js").Provider} Provider */
 
 /**
- * A configured OpenRouter model entry from ~/.claude/claude-delegator/config.json.
+ * A configured OpenRouter model entry from ~/.claude/deliberation/config.json.
  * @typedef {Object} OrModel
  * @property {string}  alias
  * @property {string}  model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "claude-delegator",
-  "version": "1.17.0",
+  "name": "deliberation",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-delegator",
-      "version": "1.17.0",
+      "name": "deliberation",
+      "version": "1.18.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-delegator",
+  "name": "deliberation",
   "version": "1.18.0",
   "private": true,
   "scripts": {

--- a/rules/model-selection.md
+++ b/rules/model-selection.md
@@ -9,12 +9,12 @@ Before delegating, check which MCP tools are available in the current environmen
 1. **If multiple are available**:
    - Use **Gemini** (Gemini 3 via the Antigravity CLI, `agy`) for tasks requiring large context or multimodal analysis. Gemini-via-agy is **advisory-effective**: agy print-mode writes are sandboxed to a scratch dir, so it can read context to advise but cannot mutate the real workspace. Prefer it for analysis/review over file-editing (`workspace-write` is best-effort).
    - Use **GPT (Codex)** when the user explicitly asks for "GPT" or "Codex".
-   - Use **Grok (xAI)** when the user explicitly asks for "Grok". Grok is advisory-only (it cannot edit files), so never route file-editing / implementation tasks to it. It reads attached files (PDF/code/docs) via `files:[{path|file_id|file_url|dir}]` on the `mcp__grok__grok` call. Entries resolve under the top-level `roots: string[]` (first-root-wins for relative paths; absolute paths must lie under one of the roots) or `cwd` when `roots` is omitted. `{dir}` entries expand recursively via a bundled glob walker (`include`/`exclude`/`maxFiles`/`maxBytes`). Uploads are SHA-256 dedup-cached locally so repeated calls with the same content skip the upload step. Full reference: [TECHNICAL.md § Grok files and cleanup](../TECHNICAL.md#grok-files-and-cleanup). **Context parity vs GPT/Gemini:** GPT (Codex) and Gemini (agy) walk the filesystem at `cwd` under `sandbox: "read-only"` - they can glob and read any file in the repo. Grok sees ONLY what is in the `files` array. For any open-ended, repo-wide question routed to Grok (or to a parallel pattern like `/ask-all` / `/consensus`), attach an orientation bundle (2-6 files: project `CLAUDE.md` / `AGENTS.md`, top-level entrypoints, modules the question targets, total <= 48 MB) - or pass a `{dir}` entry with a tight `include` pattern - so Grok answers from real source instead of the textual description alone. Skipping this is the dominant reason Grok loses argument rounds against GPT/Gemini in repo-audit prompts.
-   - Use **OpenRouter** when the user explicitly asks for an OpenRouter alias, or when `/ask-all` / `/consensus` fan-out is configured. OpenRouter is **advisory-only** - never route implementation or file-editing tasks to it. Alias selection, expert eligibility, and fan-out participation are all declared in `~/.claude/claude-delegator/config.json` (hot-reload; see [TECHNICAL.md - OpenRouter bridge](../TECHNICAL.md#openrouter-bridge)). For `/ask-all`, models with `askAll !== false` are included up to `maxFanout` (default 3). For `/consensus`, models with `consensus === true` are included without a fanout cap (warn if >3). `openrouter-default` is the single-shot fallback for bare `/ask-openrouter` calls and is never included in fan-out. Parameter precedence: per-model overrides > `openrouter.defaults` > bridge built-ins.
+   - Use **Grok (xAI)** when the user explicitly asks for "Grok". Grok is advisory-only (it cannot edit files), so never route file-editing / implementation tasks to it. It reads attached files (PDF/code/docs) via `files:[{path|file_id|file_url|dir}]` on the `mcp__deliberation-grok__grok` call. Entries resolve under the top-level `roots: string[]` (first-root-wins for relative paths; absolute paths must lie under one of the roots) or `cwd` when `roots` is omitted. `{dir}` entries expand recursively via a bundled glob walker (`include`/`exclude`/`maxFiles`/`maxBytes`). Uploads are SHA-256 dedup-cached locally so repeated calls with the same content skip the upload step. Full reference: [TECHNICAL.md § Grok files and cleanup](../TECHNICAL.md#grok-files-and-cleanup). **Context parity vs GPT/Gemini:** GPT (Codex) and Gemini (agy) walk the filesystem at `cwd` under `sandbox: "read-only"` - they can glob and read any file in the repo. Grok sees ONLY what is in the `files` array. For any open-ended, repo-wide question routed to Grok (or to a parallel pattern like `/ask-all` / `/consensus`), attach an orientation bundle (2-6 files: project `CLAUDE.md` / `AGENTS.md`, top-level entrypoints, modules the question targets, total <= 48 MB) - or pass a `{dir}` entry with a tight `include` pattern - so Grok answers from real source instead of the textual description alone. Skipping this is the dominant reason Grok loses argument rounds against GPT/Gemini in repo-audit prompts.
+   - Use **OpenRouter** when the user explicitly asks for an OpenRouter alias, or when `/ask-all` / `/consensus` fan-out is configured. OpenRouter is **advisory-only** - never route implementation or file-editing tasks to it. Alias selection, expert eligibility, and fan-out participation are all declared in `~/.claude/deliberation/config.json` (hot-reload; see [TECHNICAL.md - OpenRouter bridge](../TECHNICAL.md#openrouter-bridge)). For `/ask-all`, models with `askAll !== false` are included up to `maxFanout` (default 3). For `/consensus`, models with `consensus === true` are included without a fanout cap (warn if >3). `openrouter-default` is the single-shot fallback for bare `/ask-openrouter` calls and is never included in fan-out. Parameter precedence: per-model overrides > `openrouter.defaults` > bridge built-ins.
    - Default to **Gemini** for general reasoning.
    - For **Researcher** (external library/docs research): prefer GPT or Gemini (tool-capable); route to Grok or OpenRouter only when the user names them, since both answer from knowledge and mark claims `[unverified]`.
 2. **If only one is available**: Use the available provider regardless of the task type (but Grok and OpenRouter cannot implement file changes - only advise).
-3. **If none are available**: Do not delegate; inform the user that they need to run `/claude-delegator:setup`.
+3. **If none are available**: Do not delegate; inform the user that they need to run `/deliberation:setup`.
 
 ## Expert Directory
 
@@ -154,7 +154,7 @@ Every expert can operate in two modes:
 
 ## Codex Parameters Reference
 
-### `mcp__codex__codex` (Start Session)
+### `mcp__deliberation-codex__codex` (Start Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -173,7 +173,7 @@ Every expert can operate in two modes:
 from the `model` key in `~/.codex/config.toml` (or a `-c model=<id>` override on
 the MCP registration). The `model` parameter above overrides it for a single call.
 
-### `mcp__codex__codex-reply` (Continue Session)
+### `mcp__deliberation-codex__codex-reply` (Continue Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -182,7 +182,7 @@ the MCP registration). The `model` parameter above overrides it for a single cal
 
 ## Gemini Parameters Reference
 
-### `mcp__gemini__gemini` (Start Session)
+### `mcp__deliberation-gemini__gemini` (Start Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -195,7 +195,7 @@ the MCP registration). The `model` parameter above overrides it for a single cal
 | `timeout` | number (ms) | Soft timeout. 1..600000. Default 300000. On expiry the bridge keeps agy alive and drains buffered stdout (stdout-drain). |
 | `recovery-grace` | number (ms) | Extra drain budget after the soft timeout. 0..600000. Default 120000. 0 disables drain. |
 
-### `mcp__gemini__gemini-reply` (Continue Session)
+### `mcp__deliberation-gemini__gemini-reply` (Continue Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -209,7 +209,7 @@ the MCP registration). The `model` parameter above overrides it for a single cal
 
 ## Grok Parameters Reference
 
-### `mcp__grok__grok` (Start Session)
+### `mcp__deliberation-grok__grok` (Start Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -221,7 +221,7 @@ the MCP registration). The `model` parameter above overrides it for a single cal
 | `model` | e.g. `grok-4.3` | Defaults to `GROK_DEFAULT_MODEL` or `grok-4.3`. |
 | `reasoning_effort` | `low` \| `medium` \| `high` \| `none` | Defaults to `GROK_REASONING_EFFORT` or `high`. |
 
-### `mcp__grok__grok-reply` (Continue Session)
+### `mcp__deliberation-grok__grok-reply` (Continue Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -251,7 +251,7 @@ Error (Gemini bridge only - bridge sets `isError: true` and adds these fields):
 
 ## OpenRouter Parameters Reference
 
-### `mcp__openrouter__openrouter` (Start Session)
+### `mcp__deliberation-openrouter__openrouter` (Start Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
@@ -261,14 +261,14 @@ Error (Gemini bridge only - bridge sets `isError: true` and adds these fields):
 | `files` | array | `{path}` or `{dir}` only. `file_id`/`file_url` are rejected. Mode coerced to inline. Per-file 256 KB cap; aggregate 1 MB cap. |
 | `cwd` | path | Working directory for resolving file paths |
 
-### `mcp__openrouter__openrouter-reply` (Continue Session)
+### `mcp__deliberation-openrouter__openrouter-reply` (Continue Session)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|
 | `threadId` | string | **Required.** Thread ID from previous `openrouter` call |
 | `prompt` | string | **Required.** Follow-up instruction |
 
-### `mcp__openrouter__openrouter-list` (List Models)
+### `mcp__deliberation-openrouter__openrouter-list` (List Models)
 
 | Parameter | Values | Notes |
 |-----------|--------|-------|

--- a/rules/orchestration.md
+++ b/rules/orchestration.md
@@ -6,19 +6,19 @@ You have access to GPT experts via MCP tools. Use them strategically based on th
 
 | Tool | Provider | Use For |
 |------|----------|---------|
-| `mcp__codex__codex` | GPT | Start a new expert session |
-| `mcp__codex__codex-reply` | GPT | Continue an existing session (multi-turn) |
-| `mcp__gemini__gemini` | Gemini | Start a new expert session |
-| `mcp__gemini__gemini-reply` | Gemini | Continue an existing session (multi-turn) |
-| `mcp__grok__grok` | Grok (xAI) | Start a new expert session (advisory-only; reads attached files) |
-| `mcp__grok__grok-reply` | Grok (xAI) | Continue a session (in-memory; lost on MCP restart) |
-| `mcp__openrouter__openrouter` | OpenRouter | Start a new advisory session (config-driven model alias) |
-| `mcp__openrouter__openrouter-reply` | OpenRouter | Continue a session (multi-turn via threadId) |
-| `mcp__openrouter__openrouter-list` | OpenRouter | List configured aliases and their eligibility flags |
+| `mcp__deliberation-codex__codex` | GPT | Start a new expert session |
+| `mcp__deliberation-codex__codex-reply` | GPT | Continue an existing session (multi-turn) |
+| `mcp__deliberation-gemini__gemini` | Gemini | Start a new expert session |
+| `mcp__deliberation-gemini__gemini-reply` | Gemini | Continue an existing session (multi-turn) |
+| `mcp__deliberation-grok__grok` | Grok (xAI) | Start a new expert session (advisory-only; reads attached files) |
+| `mcp__deliberation-grok__grok-reply` | Grok (xAI) | Continue a session (in-memory; lost on MCP restart) |
+| `mcp__deliberation-openrouter__openrouter` | OpenRouter | Start a new advisory session (config-driven model alias) |
+| `mcp__deliberation-openrouter__openrouter-reply` | OpenRouter | Continue a session (multi-turn via threadId) |
+| `mcp__deliberation-openrouter__openrouter-list` | OpenRouter | List configured aliases and their eligibility flags |
 
 > **Grok notes:** the Grok bridge talks to the xAI HTTP API, so it is advisory-only (it cannot edit files). It reads attached files via `files:[{path|file_id|file_url}]` - attach referenced local files by default and set `cwd` to the repo root so paths resolve (a path outside `cwd` is refused). It needs `XAI_API_KEY`; a missing key surfaces `errorKind: "missing-auth"`.
 
-> **OpenRouter notes:** the OpenRouter bridge is advisory-only (it cannot edit files). Model aliases are declared in `~/.claude/claude-delegator/config.json` and hot-reload without restarting. File attachment is text-inline only (`{path}`/`{dir}`; 256 KB per file, 1 MB aggregate). `/ask-all` fan-out is capped by `maxFanout` (default 3); `/consensus` is uncapped (warn if >3 models). Implementation tasks must route to Codex or Gemini.
+> **OpenRouter notes:** the OpenRouter bridge is advisory-only (it cannot edit files). Model aliases are declared in `~/.claude/deliberation/config.json` and hot-reload without restarting. File attachment is text-inline only (`{path}`/`{dir}`; 256 KB per file, 1 MB aggregate). `/ask-all` fan-out is capped by `maxFanout` (default 3); `/consensus` is uncapped (warn if >3 models). Implementation tasks must route to Codex or Gemini.
 
 ## Available Experts
 
@@ -40,7 +40,7 @@ Codex and Gemini support two delegation patterns:
 
 ### Single-Shot (Default)
 
-Use `mcp__codex__codex` or `mcp__gemini__gemini` for independent tasks. Each call starts a fresh session with no memory of previous calls. Include ALL relevant context in the delegation prompt.
+Use `mcp__deliberation-codex__codex` or `mcp__deliberation-gemini__gemini` for independent tasks. Each call starts a fresh session with no memory of previous calls. Include ALL relevant context in the delegation prompt.
 
 **Best for:** Advisory reviews, one-off analysis, independent implementation tasks.
 
@@ -50,7 +50,7 @@ Both providers support multi-turn interactions. The initial call returns a `thre
 
 ```typescript
 // Turn 1: Start session (Codex example)
-const result = mcp__codex__codex({
+const result = mcp__deliberation-codex__codex({
   prompt: "Implement input validation for the user endpoint",
   "developer-instructions": "[expert prompt]",
   cwd: "/path/to/project"
@@ -58,7 +58,7 @@ const result = mcp__codex__codex({
 // result includes threadId: "019c58e5-..."
 
 // Turn 2: Follow up with context preserved
-mcp__codex__codex-reply({
+mcp__deliberation-codex__codex-reply({
   threadId: "019c58e5-...",
   prompt: "Now add tests for the validation you just implemented"
 })
@@ -101,7 +101,7 @@ When user explicitly requests GPT/Codex, Gemini, Grok, or OpenRouter:
 | "ask GPT", "consult GPT", "ask codex" | Identify task type → route to appropriate expert |
 | "ask Gemini", "consult Gemini", "ask gemini" | Identify task type → route to appropriate expert |
 | "ask Grok", "consult Grok", "ask grox" | Identify task type → route to appropriate expert |
-| "ask OpenRouter", "use [alias]", "ask [alias]" | Advisory only - identify expert, call `mcp__openrouter__openrouter` with the named alias |
+| "ask OpenRouter", "use [alias]", "ask [alias]" | Advisory only - identify expert, call `mcp__deliberation-openrouter__openrouter` with the named alias |
 | "ask GPT to review the architecture" | Delegate to Architect |
 | "have Gemini review this code" | Delegate to Code Reviewer |
 | "GPT security review" | Delegate to Security Analyst |
@@ -154,7 +154,7 @@ Use the 7-section format from `rules/delegation-format.md`.
 Emit independent prep reads CONCURRENTLY, then dispatch in ONE message. Expert
 identification (Step 1) is *reasoning* on the request - it is not a tool read and happens
 BEFORE the prep message. Then fire every independent prep read (the expert-prompt Glob,
-plus any `~/.claude/claude-delegator/config.json` / `~/.codex/config.toml` /
+plus any `~/.claude/deliberation/config.json` / `~/.codex/config.toml` /
 `~/.gemini/settings.json` / Grok env / `openrouter-list` reads a command needs) in ONE
 message as parallel tool blocks. Build the prompt, status line/block, and delegate set
 from those results, then dispatch all providers in ONE parallel message.
@@ -168,7 +168,7 @@ run concurrently with reads. Everything else is concurrent.
 ### Step 6: Call the Expert
 ```typescript
 // Using Codex (GPT)
-mcp__codex__codex({
+mcp__deliberation-codex__codex({
   prompt: "[your 7-section delegation prompt with FULL context]",
   "developer-instructions": "[contents of the expert's prompt file]",
   sandbox: "[read-only or workspace-write based on mode]",
@@ -176,7 +176,7 @@ mcp__codex__codex({
 })
 
 // OR Using Gemini
-mcp__gemini__gemini({
+mcp__deliberation-gemini__gemini({
   prompt: "[your 7-section delegation prompt with FULL context]",
   "developer-instructions": "[contents of the expert's prompt file]",
   sandbox: "[read-only or workspace-write based on mode]",
@@ -184,10 +184,10 @@ mcp__gemini__gemini({
 })
 
 // OR Using OpenRouter (advisory-only; alias from config)
-mcp__openrouter__openrouter({
+mcp__deliberation-openrouter__openrouter({
   prompt: "[your 7-section delegation prompt with FULL context]",
   "developer-instructions": "[contents of the expert's prompt file]",
-  alias: "[model alias from ~/.claude/claude-delegator/config.json]",
+  alias: "[model alias from ~/.claude/deliberation/config.json]",
   cwd: "[current working directory]"
 })
 ```
@@ -220,10 +220,10 @@ Escalate to user
 
 ```typescript
 // Attempt 1 (Codex or Gemini)
-const result = mcp__codex__codex({ ... }) // or mcp__gemini__gemini
+const result = mcp__deliberation-codex__codex({ ... }) // or mcp__deliberation-gemini__gemini
 
 // Attempt 2 (context preserved - expert remembers attempt 1)
-mcp__codex__codex-reply({ // or mcp__gemini__gemini-reply
+mcp__deliberation-codex__codex-reply({ // or mcp__deliberation-gemini__gemini-reply
   threadId: result.threadId,
   prompt: `The previous implementation failed verification.
 Error: [exact error message]
@@ -280,7 +280,7 @@ User: "What are the tradeoffs of Redis vs in-memory caching?"
 
 **Step 5-6**:
 ```typescript
-mcp__codex__codex({
+mcp__deliberation-codex__codex({
   prompt: `TASK: Analyze tradeoffs between Redis and in-memory caching for [context].
 EXPECTED OUTCOME: Clear recommendation with rationale.
 CONTEXT: [user's situation, full details]
@@ -300,7 +300,7 @@ First attempt failed with "TypeError: Cannot read property 'x' of undefined"
 
 **Attempt 1 (initial call):**
 ```typescript
-const result = mcp__codex__codex({
+const result = mcp__deliberation-codex__codex({
   prompt: `TASK: Add input validation to the user registration endpoint.
 
 CONTEXT:
@@ -320,7 +320,7 @@ REQUIREMENTS:
 
 **Attempt 2 (retry via multi-turn):**
 ```typescript
-mcp__codex__codex-reply({
+mcp__deliberation-codex__codex-reply({
   threadId: result.threadId,
   prompt: `The previous implementation failed verification.
 Error: TypeError: Cannot read property 'x' of undefined at line 45

--- a/rules/triggers.md
+++ b/rules/triggers.md
@@ -150,19 +150,19 @@ OpenRouter and Grok are always advisory - never route implementation tasks to th
 
 ```typescript
 // Architect analyzing (advisory via Codex)
-mcp__codex__codex({
+mcp__deliberation-codex__codex({
   prompt: "Analyze tradeoffs of Redis vs in-memory caching",
   sandbox: "read-only"
 })
 
 // Architect implementing (implementation via Gemini)
-mcp__gemini__gemini({
+mcp__deliberation-gemini__gemini({
   prompt: "Refactor the caching layer to use Redis",
   sandbox: "workspace-write"
 })
 
 // Security Analyst reviewing (advisory via OpenRouter)
-mcp__openrouter__openrouter({
+mcp__deliberation-openrouter__openrouter({
   prompt: "Review this auth flow for vulnerabilities",
   alias: "gpt-4-or",
   cwd: "/path/to/project"
@@ -170,7 +170,7 @@ mcp__openrouter__openrouter({
 })
 
 // Security Analyst hardening (implementation via Codex - not OpenRouter)
-mcp__codex__codex({
+mcp__deliberation-codex__codex({
   prompt: "Fix the SQL injection vulnerability in user.ts",
   sandbox: "workspace-write"
 })

--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -259,7 +259,7 @@ async function runGemini(args, cwd, timeoutMs, recoveryGraceMs) {
           settled = true;
           clearTimers();
           process.stderr.write(
-            "[claude-delegator] recovered agy answer via stdout drain after soft timeout (" +
+            "[deliberation] recovered agy answer via stdout drain after soft timeout (" +
             Math.round((Date.now() - spawnStartMs) / 1000) + "s)\n"
           );
           return resolve({ response: out, threadId: resolveConversationId(effCwd) || "unknown", recovered: true });
@@ -274,7 +274,7 @@ async function runGemini(args, cwd, timeoutMs, recoveryGraceMs) {
         const threadId = resolveConversationId(effCwd);
         if (threadId == null) {
           process.stderr.write(
-            "[claude-delegator] no conversation id found for cwd " + effCwd +
+            "[deliberation] no conversation id found for cwd " + effCwd +
             "; returning threadId:\"unknown\" (resume will be unavailable)\n"
           );
         }
@@ -311,7 +311,7 @@ const handlers = {
     sendResponse(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
-      serverInfo: { name: "claude-delegator-gemini", version: "1.6.0" }
+      serverInfo: { name: "deliberation-gemini", version: "1.6.0" }
     });
   },
 

--- a/server/grok/cache.js
+++ b/server/grok/cache.js
@@ -7,8 +7,8 @@ const crypto = require("node:crypto");
 const { mkdirSync, readFileSync, writeFileSync, renameSync } = require("node:fs");
 const lock = require("./lock.js");
 
-const CACHE_DIR = path.join(os.homedir(), ".claude", "cache", "claude-delegator");
-const CACHE_FILE = path.join(CACHE_DIR, "grok-files.json");
+const CACHE_FILE = require("../../core/paths.js").resolveGrokCachePath();
+const CACHE_DIR = path.dirname(CACHE_FILE);
 const CACHE_VERSION = 1;
 
 function normalize(apiBase) {

--- a/server/grok/files-admin.js
+++ b/server/grok/files-admin.js
@@ -7,7 +7,7 @@
  *
  *   prune  - deletes REMOTE xAI files by filename prefix + created_at cutoff.
  *            Safe without the local cache.
- *   gc     - syncs the LOCAL cache (~/.claude/cache/claude-delegator/grok-files.json)
+ *   gc     - syncs the LOCAL cache (~/.claude/cache/deliberation/grok-files.json)
  *            with the remote file list via ONE paginated GET /v1/files. Prunes
  *            local rows whose fileId no longer exists remotely. Default scope:
  *            current XAI_API_KEY + XAI_API_BASE rows only. --all-keys widens;
@@ -17,7 +17,7 @@
  */
 
 const DEFAULT_API_BASE = process.env.XAI_API_BASE || "https://api.x.ai/v1";
-const DEFAULT_PREFIX = "claude-delegator-";
+const DEFAULT_PREFIX = "deliberation-";
 
 // Parse a human duration into seconds. Accepts Ns, Nm, Nh, Nd, or a plain
 // integer (seconds). Returns a non-negative number or throws on bad input.
@@ -235,7 +235,7 @@ async function main() {
   console.error(
     "Usage:\n" +
     "  files-admin.js list\n" +
-    "  files-admin.js prune --older-than <30m|24h|7d|seconds> [--yes] [--prefix claude-delegator-]\n" +
+    "  files-admin.js prune --older-than <30m|24h|7d|seconds> [--yes] [--prefix deliberation-]\n" +
     "  files-admin.js gc [--all-keys] [--force-local-prune]\n" +
     "\n" +
     "gc syncs the local cache with xAI: one paginated GET /v1/files; rows whose\n" +

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -15,7 +15,7 @@
  *   - dir entries are expanded by the bundled glob walker (./glob.js) with
  *     prune-before-descend, symlink-safe containment, and maxFiles/maxBytes caps.
  *   - Uploads are SHA-256 deduplicated via the local cache at
- *     ~/.claude/cache/claude-delegator/grok-files.json (./cache.js). Cache key
+ *     ~/.claude/cache/deliberation/grok-files.json (./cache.js). Cache key
  *     scopes by content + API key + normalised apiBase + effective filename.
  *   - Cross-process cache safety via mkdir-based lock with token-specific
  *     owner markers and heartbeat (./lock.js).
@@ -51,7 +51,7 @@ const FILE_TTL_SECONDS = resolveFileTtl();
 const MAX_FILE_BYTES = 48 * 1024 * 1024;
 // Filename prefix marks bridge-owned uploads so cleanup never touches the
 // user's own xAI files. Flat (no slashes/colons) to avoid filename mangling.
-const FILE_PREFIX = "claude-delegator-";
+const FILE_PREFIX = "deliberation-";
 const UPLOAD_PURPOSE = "assistants";
 
 const cacheModule = require("./cache.js");
@@ -561,7 +561,7 @@ async function resolveFiles(files, opts) {
 // and/or `.status`. `fetchImpl` is injectable for tests.
 async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl, reasoningEffort }) {
   if (!isNonEmptyString(apiKey)) {
-    const e = new Error("XAI_API_KEY is not set. Export it (export XAI_API_KEY=xai-...) or rerun /claude-delegator:setup.");
+    const e = new Error("XAI_API_KEY is not set. Export it (export XAI_API_KEY=xai-...) or rerun /deliberation:setup.");
     e.code = "missing-auth";
     throw e;
   }
@@ -843,7 +843,7 @@ const handlers = {
     sendResponse(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
-      serverInfo: { name: "claude-delegator-grok", version: "1.8.0" }
+      serverInfo: { name: "deliberation-grok", version: "1.8.0" }
     });
   },
 
@@ -1085,7 +1085,7 @@ if (require.main === module) {
     process.exit(1);
   }
   if (!isNonEmptyString(process.env.XAI_API_KEY)) {
-    console.error("[claude-delegator] warning: XAI_API_KEY is not set; grok calls will return errorKind:missing-auth until it is.");
+    console.error("[deliberation] warning: XAI_API_KEY is not set; grok calls will return errorKind:missing-auth until it is.");
   }
 }
 

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -117,9 +117,7 @@ function startStdio() {
   const { makeCodexProvider } = require("../../core/providers/codex.js");
   const configMod = /** @type {any} */ (require("../openrouter/config.js"));
   const { makeConfigReader, DEFAULT_API_BASE, DEFAULT_API_KEY_ENV } = configMod;
-  const path = require("node:path");
-  const os = require("node:os");
-  const reader = makeConfigReader(path.join(os.homedir(), ".claude", "claude-delegator", "config.json"));
+  const reader = makeConfigReader(require("../../core/paths.js").resolveConfigPath());
   /** @returns {any} */
   const getConfig = () => (reader.get().resolved || { providers: {}, openrouter: {} });
 

--- a/server/openrouter/index.js
+++ b/server/openrouter/index.js
@@ -6,7 +6,7 @@
  * Claude Delegator - OpenRouter MCP Bridge
  *
  * Zero-dependency MCP server (JSON-RPC 2.0 over stdio) calling the OpenAI-compatible
- * POST {apiBase}/chat/completions endpoint. Config in ~/.claude/claude-delegator/config.json
+ * POST {apiBase}/chat/completions endpoint. Config in ~/.claude/deliberation/config.json
  * (stat-gated hot-reload). Advisory-only. Tools: openrouter, openrouter-reply, openrouter-list.
  */
 
@@ -70,8 +70,8 @@ async function callOpenRouter({ apiBase, apiKey, model, messages, reasoningEffor
 
   const headers = {
     "Content-Type": "application/json",
-    "HTTP-Referer": "https://github.com/antonbabenko/claude-delegator",
-    "X-Title": "claude-delegator",
+    "HTTP-Referer": "https://github.com/antonbabenko/deliberation",
+    "X-Title": "deliberation",
   };
   if (isNonEmptyString(apiKey)) headers["Authorization"] = `Bearer ${apiKey}`;
 
@@ -100,8 +100,7 @@ const { makeConfigReader } = require("./config.js");
 const { resolveAlias, RESERVED_ALIAS, askAllDelegates, consensusDelegates } = require("./routing.js");
 const { inlineFiles } = require("./files.js");
 
-const CONFIG_PATH = process.env.CLAUDE_DELEGATOR_CONFIG
-  || require("node:path").join(require("node:os").homedir(), ".claude", "claude-delegator", "config.json");
+const CONFIG_PATH = require("../../core/paths.js").resolveConfigPath();
 const configReader = makeConfigReader(CONFIG_PATH);
 
 // threadId -> { turns, model, apiBase, reasoningEffort, temperature }. In-memory,
@@ -165,7 +164,7 @@ const TOOL_PROPS = {
 const handlers = {
   initialize: (id, _p, respond) => {
     if (!respond) return;
-    sendResponse(id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "claude-delegator-openrouter", version: "1.0.0" } });
+    sendResponse(id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "deliberation-openrouter", version: "1.0.0" } });
   },
   "notifications/initialized": () => {},
   "tools/list": (id, _p, respond) => {

--- a/test/core-paths.test.js
+++ b/test/core-paths.test.js
@@ -1,0 +1,222 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+
+const {
+  resolveConfigPath,
+  resolveGrokCachePath,
+  _resetWarnOnceForTests,
+} = require("../core/paths.js");
+
+// --- helpers -----------------------------------------------------------------
+
+/** Make an isolated temp HOME; never touches the real ~/.claude. */
+function makeHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "delib-paths-"));
+}
+
+function rmrf(/** @type {string} */ dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function configNewPath(/** @type {string} */ home) {
+  return path.join(home, ".claude", "deliberation", "config.json");
+}
+function configLegacyPath(/** @type {string} */ home) {
+  return path.join(home, ".claude", "claude-delegator", "config.json");
+}
+function grokNewPath(/** @type {string} */ home) {
+  return path.join(home, ".claude", "cache", "deliberation", "grok-files.json");
+}
+function grokLegacyPath(/** @type {string} */ home) {
+  return path.join(
+    home,
+    ".claude",
+    "cache",
+    "claude-delegator",
+    "grok-files.json",
+  );
+}
+
+function writeFile(/** @type {string} */ p, /** @type {string} */ contents) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, contents);
+}
+
+// --- tests -------------------------------------------------------------------
+
+// (a) both exist -> returns NEW, no migration side effect on legacy.
+test("CP1: both new and legacy exist -> returns NEW, legacy untouched", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    writeFile(configNewPath(home), '{"src":"new"}');
+    writeFile(configLegacyPath(home), '{"src":"legacy"}');
+
+    const got = resolveConfigPath({ home, env: {} });
+
+    assert.equal(got, configNewPath(home));
+    // legacy still has its original contents (no copy over it, no deletion)
+    assert.equal(fs.readFileSync(configLegacyPath(home), "utf8"), '{"src":"legacy"}');
+    assert.equal(fs.readFileSync(configNewPath(home), "utf8"), '{"src":"new"}');
+  } finally {
+    rmrf(home);
+  }
+});
+
+// (b) only legacy exists -> returns NEW path AND new file now exists w/ legacy contents.
+test("CP2: only legacy exists -> migrates atomically, returns NEW with legacy contents", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    writeFile(configLegacyPath(home), '{"src":"legacy-only"}');
+
+    const got = resolveConfigPath({ home, env: {} });
+
+    assert.equal(got, configNewPath(home));
+    assert.equal(fs.existsSync(configNewPath(home)), true);
+    assert.equal(fs.readFileSync(configNewPath(home), "utf8"), '{"src":"legacy-only"}');
+    // legacy left in place for downgrade
+    assert.equal(fs.existsSync(configLegacyPath(home)), true);
+    // no leaked temp files in the new dir
+    const newDir = path.dirname(configNewPath(home));
+    const leftovers = fs.readdirSync(newDir).filter((f) => f.includes(".tmp-"));
+    assert.deepEqual(leftovers, []);
+  } finally {
+    rmrf(home);
+  }
+});
+
+// (c) DELIBERATION_CONFIG set -> returns it verbatim, no migration.
+test("CP3: DELIBERATION_CONFIG wins verbatim, no migration", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    // legacy on disk should be ignored entirely when env override is set
+    writeFile(configLegacyPath(home), '{"src":"legacy"}');
+    const override = path.join(home, "custom", "my-config.json");
+
+    const got = resolveConfigPath({ home, env: { DELIBERATION_CONFIG: override } });
+
+    assert.equal(got, override);
+    // no migration happened: new path was never created
+    assert.equal(fs.existsSync(configNewPath(home)), false);
+  } finally {
+    rmrf(home);
+  }
+});
+
+// (d) only CLAUDE_DELEGATOR_CONFIG set -> returns it verbatim.
+test("CP4: legacy env CLAUDE_DELEGATOR_CONFIG honored verbatim when new env unset", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    const legacyOverride = path.join(home, "custom", "legacy-config.json");
+
+    const got = resolveConfigPath({
+      home,
+      env: { CLAUDE_DELEGATOR_CONFIG: legacyOverride },
+    });
+
+    assert.equal(got, legacyOverride);
+    assert.equal(fs.existsSync(configNewPath(home)), false);
+  } finally {
+    rmrf(home);
+  }
+});
+
+// (c+d combined) both env set -> DELIBERATION_CONFIG wins.
+test("CP5: both env vars set -> DELIBERATION_CONFIG wins", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    const newOverride = path.join(home, "a.json");
+    const legacyOverride = path.join(home, "b.json");
+
+    const got = resolveConfigPath({
+      home,
+      env: {
+        DELIBERATION_CONFIG: newOverride,
+        CLAUDE_DELEGATOR_CONFIG: legacyOverride,
+      },
+    });
+
+    assert.equal(got, newOverride);
+  } finally {
+    rmrf(home);
+  }
+});
+
+// (e) copy failure -> returns LEGACY path, does NOT throw.
+test("CP6: migration copy failure -> falls back to legacy path, does not throw", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    writeFile(configLegacyPath(home), '{"src":"legacy-only"}');
+
+    // Make the NEW parent dir (~/.claude/deliberation) un-mkdir-able by
+    // planting a regular FILE where the directory needs to be. mkdirSync of a
+    // child under a file path throws ENOTDIR -> migration fails -> fallback.
+    const newDir = path.dirname(configNewPath(home));
+    fs.mkdirSync(path.dirname(newDir), { recursive: true });
+    fs.writeFileSync(newDir, "i am a file, not a dir");
+
+    let got;
+    assert.doesNotThrow(() => {
+      got = resolveConfigPath({ home, env: {} });
+    });
+
+    assert.equal(got, configLegacyPath(home));
+    // legacy still intact
+    assert.equal(fs.readFileSync(configLegacyPath(home), "utf8"), '{"src":"legacy-only"}');
+  } finally {
+    rmrf(home);
+  }
+});
+
+// (f) resolveGrokCachePath: only-legacy -> migrates to new cache path.
+test("CP7: grok cache only-legacy -> migrates atomically to new cache path", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    writeFile(grokLegacyPath(home), '{"files":["legacy"]}');
+
+    const got = resolveGrokCachePath({ home });
+
+    assert.equal(got, grokNewPath(home));
+    assert.equal(fs.existsSync(grokNewPath(home)), true);
+    assert.equal(fs.readFileSync(grokNewPath(home), "utf8"), '{"files":["legacy"]}');
+    assert.equal(fs.existsSync(grokLegacyPath(home)), true);
+  } finally {
+    rmrf(home);
+  }
+});
+
+// grok cache: neither exists -> returns NEW (fresh install).
+test("CP8: grok cache neither exists -> returns NEW path, no file created", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    const got = resolveGrokCachePath({ home });
+    assert.equal(got, grokNewPath(home));
+    assert.equal(fs.existsSync(grokNewPath(home)), false);
+  } finally {
+    rmrf(home);
+  }
+});
+
+// config: neither exists -> returns NEW (fresh install).
+test("CP9: config neither exists -> returns NEW path, no file created", () => {
+  _resetWarnOnceForTests();
+  const home = makeHome();
+  try {
+    const got = resolveConfigPath({ home, env: {} });
+    assert.equal(got, configNewPath(home));
+    assert.equal(fs.existsSync(configNewPath(home)), false);
+  } finally {
+    rmrf(home);
+  }
+});

--- a/test/core-paths.test.js
+++ b/test/core-paths.test.js
@@ -5,11 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const fs = require("node:fs");
 
-const {
-  resolveConfigPath,
-  resolveGrokCachePath,
-  _resetWarnOnceForTests,
-} = require("../core/paths.js");
+const { resolveConfigPath, resolveGrokCachePath } = require("../core/paths.js");
 
 // --- helpers -----------------------------------------------------------------
 
@@ -25,197 +21,55 @@ function rmrf(/** @type {string} */ dir) {
 function configNewPath(/** @type {string} */ home) {
   return path.join(home, ".claude", "deliberation", "config.json");
 }
-function configLegacyPath(/** @type {string} */ home) {
-  return path.join(home, ".claude", "claude-delegator", "config.json");
-}
 function grokNewPath(/** @type {string} */ home) {
   return path.join(home, ".claude", "cache", "deliberation", "grok-files.json");
-}
-function grokLegacyPath(/** @type {string} */ home) {
-  return path.join(
-    home,
-    ".claude",
-    "cache",
-    "claude-delegator",
-    "grok-files.json",
-  );
-}
-
-function writeFile(/** @type {string} */ p, /** @type {string} */ contents) {
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, contents);
 }
 
 // --- tests -------------------------------------------------------------------
 
-// (a) both exist -> returns NEW, no migration side effect on legacy.
-test("CP1: both new and legacy exist -> returns NEW, legacy untouched", () => {
-  _resetWarnOnceForTests();
+// CP1: no env -> returns the deliberation config path, creates nothing.
+test("CP1: no env -> returns ~/.claude/deliberation/config.json, no file created", () => {
   const home = makeHome();
   try {
-    writeFile(configNewPath(home), '{"src":"new"}');
-    writeFile(configLegacyPath(home), '{"src":"legacy"}');
-
     const got = resolveConfigPath({ home, env: {} });
-
     assert.equal(got, configNewPath(home));
-    // legacy still has its original contents (no copy over it, no deletion)
-    assert.equal(fs.readFileSync(configLegacyPath(home), "utf8"), '{"src":"legacy"}');
-    assert.equal(fs.readFileSync(configNewPath(home), "utf8"), '{"src":"new"}');
+    assert.equal(fs.existsSync(configNewPath(home)), false);
   } finally {
     rmrf(home);
   }
 });
 
-// (b) only legacy exists -> returns NEW path AND new file now exists w/ legacy contents.
-test("CP2: only legacy exists -> migrates atomically, returns NEW with legacy contents", () => {
-  _resetWarnOnceForTests();
+// CP2: DELIBERATION_CONFIG set -> returned verbatim, deliberation path untouched.
+test("CP2: DELIBERATION_CONFIG wins verbatim", () => {
   const home = makeHome();
   try {
-    writeFile(configLegacyPath(home), '{"src":"legacy-only"}');
-
-    const got = resolveConfigPath({ home, env: {} });
-
-    assert.equal(got, configNewPath(home));
-    assert.equal(fs.existsSync(configNewPath(home)), true);
-    assert.equal(fs.readFileSync(configNewPath(home), "utf8"), '{"src":"legacy-only"}');
-    // legacy left in place for downgrade
-    assert.equal(fs.existsSync(configLegacyPath(home)), true);
-    // no leaked temp files in the new dir
-    const newDir = path.dirname(configNewPath(home));
-    const leftovers = fs.readdirSync(newDir).filter((f) => f.includes(".tmp-"));
-    assert.deepEqual(leftovers, []);
-  } finally {
-    rmrf(home);
-  }
-});
-
-// (c) DELIBERATION_CONFIG set -> returns it verbatim, no migration.
-test("CP3: DELIBERATION_CONFIG wins verbatim, no migration", () => {
-  _resetWarnOnceForTests();
-  const home = makeHome();
-  try {
-    // legacy on disk should be ignored entirely when env override is set
-    writeFile(configLegacyPath(home), '{"src":"legacy"}');
     const override = path.join(home, "custom", "my-config.json");
-
     const got = resolveConfigPath({ home, env: { DELIBERATION_CONFIG: override } });
-
     assert.equal(got, override);
-    // no migration happened: new path was never created
     assert.equal(fs.existsSync(configNewPath(home)), false);
   } finally {
     rmrf(home);
   }
 });
 
-// (d) only CLAUDE_DELEGATOR_CONFIG set -> returns it verbatim.
-test("CP4: legacy env CLAUDE_DELEGATOR_CONFIG honored verbatim when new env unset", () => {
-  _resetWarnOnceForTests();
+// CP3: empty DELIBERATION_CONFIG -> falls through to the deliberation config path.
+test("CP3: empty DELIBERATION_CONFIG falls through to deliberation config path", () => {
   const home = makeHome();
   try {
-    const legacyOverride = path.join(home, "custom", "legacy-config.json");
-
-    const got = resolveConfigPath({
-      home,
-      env: { CLAUDE_DELEGATOR_CONFIG: legacyOverride },
-    });
-
-    assert.equal(got, legacyOverride);
-    assert.equal(fs.existsSync(configNewPath(home)), false);
+    const got = resolveConfigPath({ home, env: { DELIBERATION_CONFIG: "" } });
+    assert.equal(got, configNewPath(home));
   } finally {
     rmrf(home);
   }
 });
 
-// (c+d combined) both env set -> DELIBERATION_CONFIG wins.
-test("CP5: both env vars set -> DELIBERATION_CONFIG wins", () => {
-  _resetWarnOnceForTests();
-  const home = makeHome();
-  try {
-    const newOverride = path.join(home, "a.json");
-    const legacyOverride = path.join(home, "b.json");
-
-    const got = resolveConfigPath({
-      home,
-      env: {
-        DELIBERATION_CONFIG: newOverride,
-        CLAUDE_DELEGATOR_CONFIG: legacyOverride,
-      },
-    });
-
-    assert.equal(got, newOverride);
-  } finally {
-    rmrf(home);
-  }
-});
-
-// (e) copy failure -> returns LEGACY path, does NOT throw.
-test("CP6: migration copy failure -> falls back to legacy path, does not throw", () => {
-  _resetWarnOnceForTests();
-  const home = makeHome();
-  try {
-    writeFile(configLegacyPath(home), '{"src":"legacy-only"}');
-
-    // Make the NEW parent dir (~/.claude/deliberation) un-mkdir-able by
-    // planting a regular FILE where the directory needs to be. mkdirSync of a
-    // child under a file path throws ENOTDIR -> migration fails -> fallback.
-    const newDir = path.dirname(configNewPath(home));
-    fs.mkdirSync(path.dirname(newDir), { recursive: true });
-    fs.writeFileSync(newDir, "i am a file, not a dir");
-
-    let got;
-    assert.doesNotThrow(() => {
-      got = resolveConfigPath({ home, env: {} });
-    });
-
-    assert.equal(got, configLegacyPath(home));
-    // legacy still intact
-    assert.equal(fs.readFileSync(configLegacyPath(home), "utf8"), '{"src":"legacy-only"}');
-  } finally {
-    rmrf(home);
-  }
-});
-
-// (f) resolveGrokCachePath: only-legacy -> migrates to new cache path.
-test("CP7: grok cache only-legacy -> migrates atomically to new cache path", () => {
-  _resetWarnOnceForTests();
-  const home = makeHome();
-  try {
-    writeFile(grokLegacyPath(home), '{"files":["legacy"]}');
-
-    const got = resolveGrokCachePath({ home });
-
-    assert.equal(got, grokNewPath(home));
-    assert.equal(fs.existsSync(grokNewPath(home)), true);
-    assert.equal(fs.readFileSync(grokNewPath(home), "utf8"), '{"files":["legacy"]}');
-    assert.equal(fs.existsSync(grokLegacyPath(home)), true);
-  } finally {
-    rmrf(home);
-  }
-});
-
-// grok cache: neither exists -> returns NEW (fresh install).
-test("CP8: grok cache neither exists -> returns NEW path, no file created", () => {
-  _resetWarnOnceForTests();
+// CP4: grok cache -> always the deliberation cache path, creates nothing.
+test("CP4: grok cache -> ~/.claude/cache/deliberation/grok-files.json, no file created", () => {
   const home = makeHome();
   try {
     const got = resolveGrokCachePath({ home });
     assert.equal(got, grokNewPath(home));
     assert.equal(fs.existsSync(grokNewPath(home)), false);
-  } finally {
-    rmrf(home);
-  }
-});
-
-// config: neither exists -> returns NEW (fresh install).
-test("CP9: config neither exists -> returns NEW path, no file created", () => {
-  _resetWarnOnceForTests();
-  const home = makeHome();
-  try {
-    const got = resolveConfigPath({ home, env: {} });
-    assert.equal(got, configNewPath(home));
-    assert.equal(fs.existsSync(configNewPath(home)), false);
   } finally {
     rmrf(home);
   }

--- a/test/grok-gc.test.js
+++ b/test/grok-gc.test.js
@@ -23,7 +23,7 @@ test("gc prunes local rows whose fileId is absent from remote list", async () =>
     },
   });
 
-  const fakeFetch = async () => ({ ok: true, text: async () => JSON.stringify({ data: [{ id: "file_alive", filename: "claude-delegator-foo", created_at: 1 }] }) });
+  const fakeFetch = async () => ({ ok: true, text: async () => JSON.stringify({ data: [{ id: "file_alive", filename: "deliberation-foo", created_at: 1 }] }) });
 
   const result = await admin.gc({
     cacheFile: p,
@@ -65,7 +65,7 @@ test("gc default skips foreign keyFp rows", async () => {
       "FOREIGN": { fileId: "file_other", size: 1, filename: "b", uploadedAt: 1, expiresAt: 9999999999, apiBase, keyFp: "00000000beefbeef" },
     },
   });
-  const fakeFetch = async () => ({ ok: true, text: async () => JSON.stringify({ data: [{ id: "file_alive", filename: "claude-delegator-x", created_at: 1 }] }) });
+  const fakeFetch = async () => ({ ok: true, text: async () => JSON.stringify({ data: [{ id: "file_alive", filename: "deliberation-x", created_at: 1 }] }) });
   const result = await admin.gc({
     cacheFile: p,
     apiKey: "xai-CURRENT",

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -455,8 +455,8 @@ test("G16: parseOlderThan understands s/m/h/d and plain seconds", () => {
 test("G17: selectPrunable keeps only prefixed files older than the cutoff", () => {
   const now = 1_000_000; // epoch seconds
   const files = [
-    { id: "a", filename: "claude-delegator-1-old.txt", created_at: now - 1000 },   // prefixed + old -> prune
-    { id: "b", filename: "claude-delegator-2-new.txt", created_at: now - 10 },     // prefixed + new -> keep
+    { id: "a", filename: "deliberation-1-old.txt", created_at: now - 1000 },   // prefixed + old -> prune
+    { id: "b", filename: "deliberation-2-new.txt", created_at: now - 10 },     // prefixed + new -> keep
     { id: "c", filename: "user-doc.pdf", created_at: now - 100000 },               // not prefixed -> keep
   ];
   const out = admin.selectPrunable(files, { cutoffEpochSec: now - 100 });
@@ -474,8 +474,8 @@ test("G18: prune lists, filters, and deletes only prunable ids when not a dry ru
     if (opts.method === "GET") {
       return { ok: true, status: 200, text: async () => JSON.stringify({
         data: [
-          { id: "old", filename: "claude-delegator-x.txt", created_at: nowSec - 100000 },
-          { id: "fresh", filename: "claude-delegator-y.txt", created_at: nowSec - 1 },
+          { id: "old", filename: "deliberation-x.txt", created_at: nowSec - 100000 },
+          { id: "fresh", filename: "deliberation-y.txt", created_at: nowSec - 1 },
           { id: "theirs", filename: "report.pdf", created_at: 1 },
         ],
         pagination_token: null,

--- a/test/openrouter.test.js
+++ b/test/openrouter.test.js
@@ -111,6 +111,21 @@ test("O6: tools/list advertises openrouter, -reply, -list", async () => {
   } finally { child.kill(); }
 });
 
+test("O6b: DELIBERATION_CONFIG env override wins (resolver-owned precedence)", async () => {
+  // The bridge now resolves its config path via core/paths.js, which prefers
+  // DELIBERATION_CONFIG over the legacy CLAUDE_DELEGATOR_CONFIG. A legacy path
+  // pointing at a non-existent file must be ignored when the new env is set.
+  const file = writeConfig({ version: 1, openrouter: { enabled: true, models: [{ alias: "m1", model: "a/b" }] } });
+  const child = startBridge({ DELIBERATION_CONFIG: file, CLAUDE_DELEGATOR_CONFIG: "/nonexistent/legacy.json" });
+  const c = rpc(child);
+  try {
+    await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const r = await c.request({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "openrouter-list", arguments: {} } });
+    const payload = JSON.parse(r.result.content[0].text);
+    assert.deepEqual(payload.delegates.map((d) => d.alias), ["m1"]);
+  } finally { child.kill(); }
+});
+
 test("O7: openrouter-list returns delegates object in config order", async () => {
   const file = writeConfig({ version: 1, openrouter: { enabled: true, maxFanout: 4, defaultModel: "d/m", models: [
     { alias: "x", model: "a/x" }, { alias: "y", model: "a/y", experts: [] },

--- a/test/openrouter.test.js
+++ b/test/openrouter.test.js
@@ -101,7 +101,7 @@ function rpc(child) {
 
 test("O6: tools/list advertises openrouter, -reply, -list", async () => {
   const file = writeConfig({ version: 1, openrouter: { enabled: true, models: [{ alias: "m1", model: "a/b" }] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file });
+  const child = startBridge({ DELIBERATION_CONFIG: file });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -111,12 +111,9 @@ test("O6: tools/list advertises openrouter, -reply, -list", async () => {
   } finally { child.kill(); }
 });
 
-test("O6b: DELIBERATION_CONFIG env override wins (resolver-owned precedence)", async () => {
-  // The bridge now resolves its config path via core/paths.js, which prefers
-  // DELIBERATION_CONFIG over the legacy CLAUDE_DELEGATOR_CONFIG. A legacy path
-  // pointing at a non-existent file must be ignored when the new env is set.
+test("O6b: DELIBERATION_CONFIG env points the bridge at the configured delegate", async () => {
   const file = writeConfig({ version: 1, openrouter: { enabled: true, models: [{ alias: "m1", model: "a/b" }] } });
-  const child = startBridge({ DELIBERATION_CONFIG: file, CLAUDE_DELEGATOR_CONFIG: "/nonexistent/legacy.json" });
+  const child = startBridge({ DELIBERATION_CONFIG: file });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -130,7 +127,7 @@ test("O7: openrouter-list returns delegates object in config order", async () =>
   const file = writeConfig({ version: 1, openrouter: { enabled: true, maxFanout: 4, defaultModel: "d/m", models: [
     { alias: "x", model: "a/x" }, { alias: "y", model: "a/y", experts: [] },
   ] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file });
+  const child = startBridge({ DELIBERATION_CONFIG: file });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -148,7 +145,7 @@ test("O7e: openrouter-list keeps valid delegates and reports a broken entry with
     { alias: "good", model: "a/good" },
     { alias: "qwen3.7-max", model: "qwen/qwen3.7-max" }, // illegal '.' in alias
   ] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file });
+  const child = startBridge({ DELIBERATION_CONFIG: file });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -170,7 +167,7 @@ test("O7b: openrouter-list resolves reasoning_effort (per-model > defaults > nul
       { alias: "override", model: "a/x", reasoning_effort: "high" },
       { alias: "inherit", model: "a/y" },
     ] } });
-  let child = startBridge({ CLAUDE_DELEGATOR_CONFIG: withDefaults });
+  let child = startBridge({ DELIBERATION_CONFIG: withDefaults });
   let c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -182,7 +179,7 @@ test("O7b: openrouter-list resolves reasoning_effort (per-model > defaults > nul
 
   // No defaults and no per-model value => null (always present).
   const noDefaults = writeConfig({ version: 1, openrouter: { enabled: true, models: [{ alias: "bare", model: "a/z" }] } });
-  child = startBridge({ CLAUDE_DELEGATOR_CONFIG: noDefaults });
+  child = startBridge({ DELIBERATION_CONFIG: noDefaults });
   c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -193,7 +190,7 @@ test("O7b: openrouter-list resolves reasoning_effort (per-model > defaults > nul
 
 test("O8: openrouter call with unknown alias => model-not-allowed", async () => {
   const file = writeConfig({ version: 1, openrouter: { enabled: true, models: [{ alias: "m1", model: "a/b" }] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file, OPENROUTER_API_KEY: "k" });
+  const child = startBridge({ DELIBERATION_CONFIG: file, OPENROUTER_API_KEY: "k" });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -205,7 +202,7 @@ test("O8: openrouter call with unknown alias => model-not-allowed", async () => 
 
 test("O9: allowRawModel:false rejects a raw model param", async () => {
   const file = writeConfig({ version: 1, openrouter: { enabled: true, allowRawModel: false, models: [{ alias: "m1", model: "a/b" }] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file, OPENROUTER_API_KEY: "k" });
+  const child = startBridge({ DELIBERATION_CONFIG: file, OPENROUTER_API_KEY: "k" });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -218,7 +215,7 @@ test("O9: allowRawModel:false rejects a raw model param", async () => {
 test("O10: end-to-end openrouter call via alias against a mock endpoint", async () => {
   const { server, base } = await startMock((req, res) => reply(res, 200, { choices: [{ message: { content: "delegated answer" } }] }));
   const file = writeConfig({ version: 1, openrouter: { enabled: true, apiBase: base, models: [{ alias: "m1", model: "a/b" }] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file, OPENROUTER_API_KEY: "k" });
+  const child = startBridge({ DELIBERATION_CONFIG: file, OPENROUTER_API_KEY: "k" });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -232,7 +229,7 @@ test("O11: openrouter-reply reuses the session model (no drift to default)", asy
   const seen = [];
   const { server, base } = await startMock((req, res, body) => { seen.push(JSON.parse(body).model); return reply(res, 200, { choices: [{ message: { content: "ok" } }] }); });
   const file = writeConfig({ version: 1, openrouter: { enabled: true, apiBase: base, defaultModel: "default/model", models: [{ alias: "llama", model: "meta/llama" }] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file, OPENROUTER_API_KEY: "k" });
+  const child = startBridge({ DELIBERATION_CONFIG: file, OPENROUTER_API_KEY: "k" });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -245,7 +242,7 @@ test("O11: openrouter-reply reuses the session model (no drift to default)", asy
 
 test("O12: non-array roots is rejected with -32602", async () => {
   const file = writeConfig({ version: 1, openrouter: { enabled: true, models: [{ alias: "m1", model: "a/b" }] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file, OPENROUTER_API_KEY: "k" });
+  const child = startBridge({ DELIBERATION_CONFIG: file, OPENROUTER_API_KEY: "k" });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -258,7 +255,7 @@ test("O13: openrouter-list returns object with error (not error envelope) on bad
   const dir = fsx.mkdtempSync(pathx.join(osx.tmpdir(), "cdg-orbad-"));
   const file = pathx.join(dir, "config.json");
   fsx.writeFileSync(file, "{ not json ");
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file });
+  const child = startBridge({ DELIBERATION_CONFIG: file });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
@@ -280,7 +277,7 @@ test("O14: concurrent tools/call to one bridge run in parallel, not serialized",
   const file = writeConfig({ version: 1, openrouter: { enabled: true, apiBase: base, models: [
     { alias: "m1", model: "a/m1" }, { alias: "m2", model: "a/m2" },
   ] } });
-  const child = startBridge({ CLAUDE_DELEGATOR_CONFIG: file });
+  const child = startBridge({ DELIBERATION_CONFIG: file });
   const c = rpc(child);
   try {
     await c.request({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });


### PR DESCRIPTION
## Summary

Breaking release: rebrands the project `claude-delegator` -> `deliberation` and namespaces the four bridge MCP servers. One PR, per the approved + consensus-reviewed plan (CONVERGED in 2 rounds).

Targets `dev` for integration testing. STOPS before npm/registry publish and before the GitHub repo rename (those are separate gated steps - the registry namespace is repo-bound).

## What changed (31 files, 6 commits)

- **A. Config + cache migration** - new `core/paths.js` (`resolveConfigPath`, `resolveGrokCachePath`): reads the new `~/.claude/deliberation/` path first, falls back to legacy `~/.claude/claude-delegator/`, atomically migrates on first run, never crashes on read-only home. Honors `DELIBERATION_CONFIG` (then legacy `CLAUDE_DELEGATOR_CONFIG`). Wired into the openrouter, mcp, and grok servers. 9 new tests.
- **B. Bridge MCP namespacing** - the four bridges register as `deliberation-codex` / `deliberation-gemini` / `deliberation-grok` / `deliberation-openrouter` (idempotent migration: add namespaced first, then remove the old bare name). All ~66 `mcp__<p>__*` tool-id references across commands and rules move to `mcp__deliberation-<p>__*`. serverInfo names aligned.
- **C. Plugin identity** - `name` -> `deliberation` in plugin.json / marketplace.json / package.json (one commit, version-sync intact); homepage/repository URLs updated; slash namespace becomes `/deliberation:*`.
- **D. Cache-glob dual-path** - every command resolves expert prompts from the new `.../deliberation/*/prompts/` first, legacy `.../claude-delegator/*/prompts/` as fallback, so `/ask-*` keeps working across the rename.
- **E. Docs + cosmetics** - README (Claude-first), TECHNICAL, CLAUDE.md, CONTRIBUTING, assets, HTTP headers, grok FILE_PREFIX, log prefixes.

Restart note: namespaced tool ids load at MCP-client startup. After `/setup`, restart Claude Code so the `deliberation-*` tools appear. setup.md prints this.

## Kept intentionally

- All five MCP servers stay - the bridges still own implementation mode, multi-turn (`*-reply`), and admin tools (`openrouter-list`, `grok-files`). Retiring them is a tracked future task (docs/multi-growth/future-mcp-consolidation.md, gitignored).
- Legacy paths read as fallback everywhere (zero data loss). `config/providers.json` provider keys unchanged.
- jarrodwatts upstream fork credit retained.

## Testing

```
npm ci
npm run check   # strict tsc + tests
```
215 tests pass, strict typecheck exits clean, all five servers smoke-tested over stdio.

## Out of scope (gated, separate)

- GitHub repo rename `claude-delegator` -> `deliberation` (manual; must precede registry publish).
- npm publish + Official MCP Registry submit.
- Bridge consolidation (future task).
