### PR TITLE
fix(commands): resolve plugin root when CLAUDE_PLUGIN_ROOT is unset

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -26,7 +26,21 @@ report.
 
 ```bash
 set -u
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required (run this via /deliberation:setup)}"
+
+# --- resolve plugin root: env var -> marketplace cache (highest semver) -> current checkout ---
+# A candidate is valid only if it contains server/mcp/index.js.
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/server/mcp/index.js" ]; then
+    printf '%s' "$CLAUDE_PLUGIN_ROOT"; return 0; fi
+  # marketplace cache, highest version (use find, not a glob - a failed zsh glob warns on stderr)
+  local c
+  c=$(find "$HOME/.claude/plugins/cache" -maxdepth 6 -path '*/deliberation/*/server/mcp/index.js' -type f 2>/dev/null | sort -V | tail -1)
+  if [ -n "$c" ]; then printf '%s' "${c%/server/mcp/index.js}"; return 0; fi
+  if [ -f "$PWD/server/mcp/index.js" ] && grep -q '"name": "deliberation"' "$PWD/.claude-plugin/plugin.json" 2>/dev/null; then
+    printf '%s' "$PWD"; return 0; fi
+  return 1
+}
+PLUGIN_ROOT="$(resolve_plugin_root)" || { echo "Error: cannot locate the deliberation plugin root. Install via /plugin, run from the plugin checkout, or set CLAUDE_PLUGIN_ROOT."; exit 1; }
 
 # --- config path: env override > default deliberation path ---
 CFG="${DELIBERATION_CONFIG:-$HOME/.claude/deliberation/config.json}"
@@ -122,7 +136,14 @@ only".
 
 ```bash
 set -u
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required}"
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/server/mcp/index.js" ]; then printf '%s' "$CLAUDE_PLUGIN_ROOT"; return 0; fi
+  local c; c=$(find "$HOME/.claude/plugins/cache" -maxdepth 6 -path '*/deliberation/*/server/mcp/index.js' -type f 2>/dev/null | sort -V | tail -1)
+  if [ -n "$c" ]; then printf '%s' "${c%/server/mcp/index.js}"; return 0; fi
+  if [ -f "$PWD/server/mcp/index.js" ] && grep -q '"name": "deliberation"' "$PWD/.claude-plugin/plugin.json" 2>/dev/null; then printf '%s' "$PWD"; return 0; fi
+  return 1
+}
+PLUGIN_ROOT="$(resolve_plugin_root)" || { echo "Error: cannot locate the deliberation plugin root."; exit 1; }
 mkdir -p "$HOME/.claude/commands"
 collisions=""
 for c in ask-gpt ask-gemini ask-grok ask-openrouter ask-all consensus grok-files; do
@@ -141,7 +162,14 @@ first = overwrite): "Yes, overwrite (recommended)" / "No, keep existing".
 
 ```bash
 set -u
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is required}"
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/server/mcp/index.js" ]; then printf '%s' "$CLAUDE_PLUGIN_ROOT"; return 0; fi
+  local c; c=$(find "$HOME/.claude/plugins/cache" -maxdepth 6 -path '*/deliberation/*/server/mcp/index.js' -type f 2>/dev/null | sort -V | tail -1)
+  if [ -n "$c" ]; then printf '%s' "${c%/server/mcp/index.js}"; return 0; fi
+  if [ -f "$PWD/server/mcp/index.js" ] && grep -q '"name": "deliberation"' "$PWD/.claude-plugin/plugin.json" 2>/dev/null; then printf '%s' "$PWD"; return 0; fi
+  return 1
+}
+PLUGIN_ROOT="$(resolve_plugin_root)" || { echo "Error: cannot locate the deliberation plugin root."; exit 1; }
 for c in <collided names>; do
   cp -f "$PLUGIN_ROOT/commands/$c.md" "$HOME/.claude/commands/$c.md" && echo "overwrote /$c"
 done

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -31,7 +31,17 @@ user-authored same-named command is left untouched).
 
 ```bash
 set -u
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+
+# --- resolve plugin root (non-fatal): env var -> cache (highest semver) -> current checkout ---
+# Only the byte-identical alias check below needs it; empty is fine - MCP/rules/cache still purge.
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/server/mcp/index.js" ]; then printf '%s' "$CLAUDE_PLUGIN_ROOT"; return 0; fi
+  local c; c=$(find "$HOME/.claude/plugins/cache" -maxdepth 6 -path '*/deliberation/*/server/mcp/index.js' -type f 2>/dev/null | sort -V | tail -1)
+  if [ -n "$c" ]; then printf '%s' "${c%/server/mcp/index.js}"; return 0; fi
+  if [ -f "$PWD/server/mcp/index.js" ] && grep -q '"name": "deliberation"' "$PWD/.claude-plugin/plugin.json" 2>/dev/null; then printf '%s' "$PWD"; return 0; fi
+  return 1
+}
+PLUGIN_ROOT="$(resolve_plugin_root || true)"
 
 # --- MCP registrations (namespaced + unified) ---
 for s in deliberation deliberation-codex deliberation-gemini deliberation-grok deliberation-openrouter; do


### PR DESCRIPTION
## Problem

`/deliberation:setup` (and its alias-install + the uninstall block) hard-failed with
`${CLAUDE_PLUGIN_ROOT:?...}` when that env var was unset - i.e. run via plain `claude`
without `--plugin-dir`. The block aborted on its first line.

## Fix

A `resolve_plugin_root` helper used by setup (3 blocks) and uninstall:

1. `$CLAUDE_PLUGIN_ROOT` when it points at a real checkout.
2. Marketplace cache `~/.claude/plugins/cache/*/deliberation/*/`, highest version
   (`sort -V | tail -1`).
3. Current directory when it's a deliberation checkout.
4. Else abort with guidance (setup) or continue non-fatally (uninstall still purges
   MCP/rules/cache).

The cache step uses `find` rather than a shell glob: under zsh a failed glob prints
`no matches found` to stderr.

## Scope

Only `commands/setup.md` and `commands/uninstall.md` change. The expert-prompt and
grok-files lookups already used the correct `*/deliberation/*` path and are untouched.

## Test plan

- [x] All setup/uninstall bash blocks pass `bash -n`.
- [x] Unset `CLAUDE_PLUGIN_ROOT`, run from the checkout -> resolves to `$PWD`, zero stderr.
- [x] Synthetic cache `.../deliberation/{1.0.0,2.0.0}/server/mcp/index.js` -> resolves the 2.0.0 root.
- [x] No env, no cache, unrelated dir -> aborts with guidance, exit 1.