### PR TITLE
docs: repo layout (CLAUDE.md) + standalone MCP-host install (README)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,26 @@ No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok,
 
 ## Architecture
 
+### Repository layout
+
+- **`core/`** - host-neutral, zero runtime deps, strict-typed. Provider interface +
+  `toErrorResult` (`types.js` / `provider.js`); `registry.js` (`selectForAskAll` /
+  `selectForConsensus`); `orchestrate.js` (`askAll` / `askOne` / `consensus`); `providers/*.js`
+  adapters (`codex.js` spawns the Codex CLI; `antigravity.js` / `grok.js` /
+  `openai-compatible.js` wrap their bridge via an injectable `opts.bridge`); `paths.js`
+  (config + cache path resolver, `DELIBERATION_CONFIG` override).
+- **`server/mcp/`** - stdio JSON-RPC MCP server over `core`. Published as
+  `@antonbabenko/deliberation-mcp`: an esbuild `prepack` step bundles `core` + the three bridges
+  into a self-contained `dist/index.js` (build-time devDep only; `dist/` gitignored). `server.json`
+  at the repo root is the Official MCP Registry manifest.
+- **`server/{gemini,grok,openrouter}/`** - the provider bridges (gemini wraps the `agy` CLI;
+  grok = xAI HTTP; openrouter = any OpenAI-compatible HTTP) plus openrouter `config.js`
+  (`validateConfig` / `makeConfigReader`, the config SSOT). Registered as their own MCP servers in
+  `.claude-plugin/mcp.json` for the single-provider commands.
+- **Typecheck gate** - `tsconfig.json` strict `checkJs` over `core/**` + `server/mcp/**/*.js`
+  (excludes `server/mcp/dist`). `npm run check` = `typecheck` + `node --test test/*.test.js`,
+  enforced in CI by `.github/workflows/validate.yml`.
+
 ### Orchestration Flow
 
 Claude acts as orchestrator - delegates to specialized experts based on task type. Supports both **single-shot** (independent calls) and **multi-turn** (context preserved via `threadId`).

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ The orchestration server is also published on its own - npm [`@antonbabenko/deli
 
 **One-click install:**
 
-[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-blue?style=flat-square&logo=cursor)](https://cursor.com/en-US/install-mcp?name=Deliberation&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhbnRvbmJhYmVua28vZGVsaWJlcmF0aW9uLW1jcCJdfQ==)
-[![Install in VS Code](https://img.shields.io/badge/Install-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
-[![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro)](https://kiro.dev/launch/mcp/add?name=Deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
+[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-blue?style=flat-square&logo=cursor)](https://cursor.com/en-US/install-mcp?name=deliberation&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhbnRvbmJhYmVua28vZGVsaWJlcmF0aW9uLW1jcCJdfQ==)
+[![Install in VS Code](https://img.shields.io/badge/Install-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
+[![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro)](https://kiro.dev/launch/mcp/add?name=deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
 
 **Manual config** - add this to your host's MCP config (most hosts use the `mcpServers` key):
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ accordingly. OpenRouter is advisory-only and config-driven: models are declared 
 
 ## Install
 
-Inside a Claude Code instance, run:
+### Cloud Code plugin (recommended):
 
 **1. Add the marketplace - [antonbabenko/agent-plugins](https://github.com/antonbabenko/agent-plugins)**
 ```
@@ -68,20 +68,18 @@ Inside a Claude Code instance, run:
 
 Claude now routes complex tasks to your GPT, Gemini, Grok, and OpenRouter experts (Grok and OpenRouter advise; GPT and Gemini can also implement).
 
-The canonical marketplace is [`antonbabenko/agent-plugins`](https://github.com/antonbabenko/agent-plugins) (above), which also bundles the other plugins.
-
-<details>
-<summary>Use in any MCP host (standalone, without the Claude Code plugin)</summary>
+### Alternative: Use `deliberation` MCP server (standalone, works with any agents)
 
 The orchestration server is also published on its own - npm [`@antonbabenko/deliberation-mcp`](https://www.npmjs.com/package/@antonbabenko/deliberation-mcp), Official MCP Registry name `io.github.antonbabenko/deliberation`.
 
 **One-click install:**
 
-[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-blue?style=flat-square&logo=cursor)](https://cursor.com/en-US/install-mcp?name=deliberation&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhbnRvbmJhYmVua28vZGVsaWJlcmF0aW9uLW1jcCJdfQ==)
-[![Install in VS Code](https://img.shields.io/badge/Install-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
-[![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro)](https://kiro.dev/launch/mcp/add?name=deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
+[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-blue?style=flat-square&logo=cursor)](https://cursor.com/en-US/install-mcp?name=deliberation&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhbnRvbmJhYmVua28vZGVsaWJlcmF0aW9uLW1jcCJdfQ==) [![Install in VS Code](https://img.shields.io/badge/Install-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D) [![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro)](https://kiro.dev/launch/mcp/add?name=deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
 
-**Manual config** - add this to your host's MCP config (most hosts use the `mcpServers` key):
+<details>
+<summary>Manual config for any MCP clients</summary>
+
+Add this to your host's MCP config (most hosts use the `mcpServers` key):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ Claude now routes complex tasks to your GPT, Gemini, Grok, and OpenRouter expert
 The canonical marketplace is [`antonbabenko/agent-plugins`](https://github.com/antonbabenko/agent-plugins) (above), which also bundles the other plugins.
 
 <details>
+<summary>Use in any MCP host (standalone, without the Claude Code plugin)</summary>
+
+The orchestration server is also published on its own - npm [`@antonbabenko/deliberation-mcp`](https://www.npmjs.com/package/@antonbabenko/deliberation-mcp), Official MCP Registry name `io.github.antonbabenko/deliberation`. Add it to any stdio MCP host:
+
+```json
+{ "command": "npx", "args": ["-y", "@antonbabenko/deliberation-mcp"], "type": "stdio" }
+```
+
+Provider prerequisites are the same as the plugin (see [Requirements](#requirements)): the Codex CLI for GPT, `agy` for Gemini, `XAI_API_KEY` for Grok, and `OPENROUTER_API_KEY` plus `~/.claude/deliberation/config.json` for OpenRouter (override the config path with `DELIBERATION_CONFIG`).
+
+Tools exposed: `ask-all`, `consensus`, `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, and the seven experts (`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`, `security-analyst`, `researcher`, `debugger`).
+
+</details>
+
+<details>
 <summary>Updating an existing install</summary>
 
 After editing plugin code or upgrading the plugin version:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ accordingly. OpenRouter is advisory-only and config-driven: models are declared 
 
 ## Install
 
-### Cloud Code plugin (recommended):
+### Claude Code plugin (recommended):
 
 **1. Add the marketplace - [antonbabenko/agent-plugins](https://github.com/antonbabenko/agent-plugins)**
 ```

--- a/README.md
+++ b/README.md
@@ -73,11 +73,37 @@ The canonical marketplace is [`antonbabenko/agent-plugins`](https://github.com/a
 <details>
 <summary>Use in any MCP host (standalone, without the Claude Code plugin)</summary>
 
-The orchestration server is also published on its own - npm [`@antonbabenko/deliberation-mcp`](https://www.npmjs.com/package/@antonbabenko/deliberation-mcp), Official MCP Registry name `io.github.antonbabenko/deliberation`. Add it to any stdio MCP host:
+The orchestration server is also published on its own - npm [`@antonbabenko/deliberation-mcp`](https://www.npmjs.com/package/@antonbabenko/deliberation-mcp), Official MCP Registry name `io.github.antonbabenko/deliberation`.
+
+**One-click install:**
+
+[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-blue?style=flat-square&logo=cursor)](https://cursor.com/en-US/install-mcp?name=Deliberation&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhbnRvbmJhYmVua28vZGVsaWJlcmF0aW9uLW1jcCJdfQ==)
+[![Install in VS Code](https://img.shields.io/badge/Install-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=Deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
+[![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro)](https://kiro.dev/launch/mcp/add?name=Deliberation&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40antonbabenko%2Fdeliberation-mcp%22%5D%7D)
+
+**Manual config** - add this to your host's MCP config (most hosts use the `mcpServers` key):
 
 ```json
-{ "command": "npx", "args": ["-y", "@antonbabenko/deliberation-mcp"], "type": "stdio" }
+{
+  "mcpServers": {
+    "deliberation": { "command": "npx", "args": ["-y", "@antonbabenko/deliberation-mcp"] }
+  }
+}
 ```
+
+Per-host config location and the key it expects:
+
+| Host | Config | Key |
+|------|--------|-----|
+| Claude Code | `claude mcp add deliberation -- npx -y @antonbabenko/deliberation-mcp` (or project `.mcp.json`) | `mcpServers` |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS), `%APPDATA%\Claude\claude_desktop_config.json` (Windows) | `mcpServers` |
+| Cursor | `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project) | `mcpServers` |
+| VS Code | `.vscode/mcp.json` - note: each entry needs `"type": "stdio"` | `servers` |
+| Codex CLI | `~/.codex/config.toml` - TOML, e.g. `[mcp_servers.deliberation]` | `mcp_servers` |
+| Gemini CLI | `~/.gemini/settings.json` | `mcpServers` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` |
+| Zed | `settings.json` | `context_servers` |
+| Cline | the extension's MCP settings (Cline panel -> MCP Servers) | `mcpServers` |
 
 Provider prerequisites are the same as the plugin (see [Requirements](#requirements)): the Codex CLI for GPT, `agy` for Gemini, `XAI_API_KEY` for Grok, and `OPENROUTER_API_KEY` plus `~/.claude/deliberation/config.json` for OpenRouter (override the config path with `DELIBERATION_CONFIG`).
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,19 @@ The orchestration server is also published on its own - npm [`@antonbabenko/deli
 ```json
 {
   "mcpServers": {
-    "deliberation": { "command": "npx", "args": ["-y", "@antonbabenko/deliberation-mcp"] }
+    "deliberation": {
+      "command": "npx",
+      "args": ["-y", "@antonbabenko/deliberation-mcp"],
+      "env": {
+        "XAI_API_KEY": "xai-...",
+        "OPENROUTER_API_KEY": "sk-or-v1-..."
+      }
+    }
   }
 }
 ```
+
+The `env` block is how you set provider keys outside Claude Code. GPT and Gemini do not read keys here - they use the `codex` and `agy` CLIs (logged in separately), so drop those lines if you only use GPT/Gemini. `XAI_API_KEY` enables Grok; `OPENROUTER_API_KEY` enables OpenRouter (which also needs models declared in `~/.claude/deliberation/config.json`, or point elsewhere with `DELIBERATION_CONFIG`). The one-click buttons above cannot carry secrets - add the `env` block by hand after installing.
 
 Per-host config location and the key it expects:
 


### PR DESCRIPTION
## What

Close the two doc gaps left after the npm + MCP Registry launch.

1. **CLAUDE.md** - add a compact `### Repository layout` under `## Architecture` (core/, server/mcp/ published+esbuild-bundled, the three provider bridges, the typecheck gate). Per discussion (+ GPT/Gemini), the layout is consolidated in CLAUDE.md as the single source of truth; **AGENTS.md stays the bare `@CLAUDE.md` include** (no duplication, inherits automatically).
2. **README.md** - add a standalone "Use in any MCP host" path now that `@antonbabenko/deliberation-mcp` 0.1.0 + registry `io.github.antonbabenko/deliberation` are live. The Claude Code plugin path stays primary.

## Verification

- ASCII typography scan clean (strict mode; no opt-in heading in CLAUDE.md)
- AGENTS.md untouched; only CLAUDE.md + README.md changed
- `npm run check`: typecheck clean, 210/210 tests pass (docs-only sanity)

Docs-only; `docs:` commit -> automated patch-bump release PR on merge (expected).