### PR TITLE
fix(core): drop core->server bridge import so core is self-contained

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,10 +125,16 @@ Releases are automated from Conventional Commits on `master`. Do not hand-edit v
 | `feat!:` or `BREAKING CHANGE:` | Major |
 | `feat:` | Minor |
 | `fix:` | Patch |
-| Other (`chore`, `docs`, `refactor`, ...) | Patch |
+| `docs`, `refactor`, `build`, `chore`, `style`, `test`, `ci`, `perf` | No release |
 
-`version.json` is the single source of truth. On merge to `master`, `automated-release.yml`
-bumps it, regenerates `CHANGELOG.md`, and runs `.github/release/pre-commit.js` to sync the
+Only `feat:` / `fix:` / breaking cut a release. The release uses the `conventionalcommits`
+preset with `skip-on-empty: true`; the other types are "hidden" in that preset, so a push that
+contains ONLY hidden-type commits produces an empty changelog and is skipped (no bump, no PR).
+Those commits still ship - they ride along in the next `feat:` / `fix:` release's tag and
+changelog. (The release-PR job also self-skips its own `chore(release):` commit as a loop guard.)
+
+`version.json` is the single source of truth. When a releasable commit lands on `master`,
+`automated-release.yml` bumps it, regenerates `CHANGELOG.md`, and runs `.github/release/pre-commit.js` to sync the
 version in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and
 `package.json`. After the release PR merges, `tag-release.yml` tags `vX.Y.Z`, publishes the
 GitHub Release, and nudges the `antonbabenko/agent-plugins` marketplace to re-pin. The

--- a/README.md
+++ b/README.md
@@ -118,21 +118,6 @@ Tools exposed: `ask-all`, `consensus`, `ask-gpt` / `ask-gemini` / `ask-grok` / `
 
 </details>
 
-<details>
-<summary>Updating an existing install</summary>
-
-After editing plugin code or upgrading the plugin version:
-
-1. `/mcp`
-2. `gemini` → `Reconnect`
-3. `grok` → `Reconnect`
-
-No `claude` restart needed. Session context is preserved.
-
-Do NOT use `/reload-plugins` - it only applies a manifest diff and ignores source edits.
-
-</details>
-
 ## Requirements
 
 You need at least one provider:

--- a/core/providers/antigravity.js
+++ b/core/providers/antigravity.js
@@ -9,9 +9,11 @@ const { toErrorResult } = require("../provider.js");
  * @returns {Provider}
  */
 function makeAntigravityProvider(opts = {}) {
-  // Cast the bridge to any: its CJS module.exports is typed as bare Object, and
-  // casting also stops tsc from deep-checking the legacy bridge transitively.
-  const bridge = /** @type {any} */ (opts.bridge || require("../../server/gemini/index.js"));
+  // Core is transport-agnostic: the caller injects the bridge (the composition
+  // root wires it). Cast to any - the CJS bridge exports as a bare Object, and
+  // the cast also stops tsc from deep-checking the legacy bridge transitively.
+  const bridge = /** @type {any} */ (opts.bridge);
+  if (!bridge) throw new Error("makeAntigravityProvider requires opts.bridge (core is transport-agnostic; inject the gemini bridge)");
   const model = opts.model || process.env.GEMINI_DEFAULT_MODEL || "auto-gemini-3";
 
   return {

--- a/core/providers/grok.js
+++ b/core/providers/grok.js
@@ -10,9 +10,10 @@ const { toErrorResult } = require("../provider.js");
  * @returns {Provider}
  */
 function makeGrokProvider(opts = {}) {
-  // The bridge's module.exports is typed as bare Object (untyped CJS export);
-  // cast to any so adapter property access typechecks. Runtime is unchanged.
-  const bridge = /** @type {any} */ (opts.bridge || require("../../server/grok/index.js"));
+  // Core is transport-agnostic: the caller injects the bridge. Cast to any - the
+  // bridge's module.exports is typed as bare Object (untyped CJS export).
+  const bridge = /** @type {any} */ (opts.bridge);
+  if (!bridge) throw new Error("makeGrokProvider requires opts.bridge (core is transport-agnostic; inject the grok bridge)");
   const model = opts.model || process.env.GROK_DEFAULT_MODEL || "grok-4.3";
   const apiBase = opts.apiBase || process.env.XAI_API_BASE || "https://api.x.ai/v1";
 

--- a/core/providers/openai-compatible.js
+++ b/core/providers/openai-compatible.js
@@ -19,9 +19,11 @@ const MAX_SESSIONS = 100;
  */
 function makeOpenAICompatibleProvider(opts) {
   const { name = "openrouter", apiBase, apiKeyEnv, resolveModel } = opts;
-  // Cast the bridge to any: its CJS module.exports is typed as bare Object, and
-  // casting also stops tsc from deep-checking the legacy bridge transitively.
-  const bridge = /** @type {any} */ (opts.bridge || require("../../server/openrouter/index.js"));
+  // Core is transport-agnostic: the caller injects the bridge. Cast to any - the
+  // CJS bridge exports as a bare Object, and the cast also stops tsc from
+  // deep-checking the legacy bridge transitively.
+  const bridge = /** @type {any} */ (opts.bridge);
+  if (!bridge) throw new Error("makeOpenAICompatibleProvider requires opts.bridge (core is transport-agnostic; inject the bridge)");
   const sessions = new Map(); // threadId -> turns
 
   return /** @type {any} */ ({

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -123,15 +123,18 @@ function startStdio() {
 
   const initialOr = (getConfig().openrouter) || {};
   /** @type {Provider[]} */
+  // Composition root: core is transport-agnostic, so wire each adapter to its
+  // bridge here. Codex spawns the `codex` CLI directly and needs no bridge.
   const providers = [
     makeCodexProvider({}),
-    makeAntigravityProvider({}),
-    makeGrokProvider({}),
+    makeAntigravityProvider({ bridge: require("../gemini/index.js") }),
+    makeGrokProvider({ bridge: require("../grok/index.js") }),
     makeOpenAICompatibleProvider({
       name: "openrouter",
       apiBase: initialOr.apiBase || DEFAULT_API_BASE,
       apiKeyEnv: DEFAULT_API_KEY_ENV,
       resolveModel: (req) => req.model || (getConfig().openrouter && getConfig().openrouter.defaultModel) || "",
+      bridge: require("../openrouter/index.js"),
     }),
   ];
   const srv = buildServer({ providers, getConfig });


### PR DESCRIPTION
## What

Remove the layering inversion where `core/` reached up into the `server/` transport bridges, so `core` is a self-contained, honestly publishable engine. Injection-only (the light option) - no transport relocation, no plugin/mcp.json changes.

Before: `core/providers/{antigravity,grok,openai-compatible}.js` fell back to `|| require("../../server/<bridge>/index.js")` when no bridge was injected - the only thing pulling `server/` into `core/`.

After:
- The three adapters require `opts.bridge` and throw a clear error if it is missing.
- `server/mcp/index.js` (the composition root) injects the bridges explicitly: `{ bridge: require("../gemini/index.js") }`, etc. Codex needs none (spawns the `codex` CLI).
- Dependency now runs one way: `server -> core`.

## Why

`core` is meant to be host-neutral and eventually publishable as `@antonbabenko/deliberation-core`. A "host-neutral" engine importing its own transport shims was an inversion. This removes it with a ~4-file change and no behavior change. (npm publish of core is deferred - no consumer yet.)

## Verification

- `grep -rn 'require("../../server' core/` -> zero results
- `npm run check` -> typecheck clean, 210/210 tests pass (tests already inject bridges)
- Bundled mcp server: 0 escaping requires in `dist/index.js`; clean-room install boots and `tools/list` returns 13 tools, no `MODULE_NOT_FOUND`, no `requires opts.bridge`

Also includes a docs commit removing the README "Updating an existing install" section.