### PR TITLE
fix: add glama.json for Glama MCP directory

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["antonbabenko"]
+}


### PR DESCRIPTION
## What

Adds `glama.json` at the repo root declaring `antonbabenko` as maintainer.

## Why

Lets the [Glama](https://glama.ai/mcp) MCP directory listing for `@antonbabenko/deliberation-mcp` be claimed and quality-scored. Glama auto-crawls the repo; this file claims maintainer ownership.

## Notes

- Schema: `https://glama.ai/mcp/schemas/server.json` (verified live — `maintainers` is the only required field).
- Maintainer matches the Official MCP Registry namespace `io.github.antonbabenko/deliberation`.
- Public/safe: declares only the maintainer username.

## Test plan

- [ ] glama.json is valid JSON against the schema
- [ ] Glama picks up the maintainer claim after merge