### PR TITLE
feat: deliberation-setup bin + standalone AGENTS.md + per-host rule snippets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,52 @@
-@CLAUDE.md
+# AGENTS.md
+
+Host-neutral guidance for any AI coding agent connected to the deliberation MCP
+server. This file is standalone on purpose - it is not an include of CLAUDE.md,
+so it stays portable across hosts (Cursor, Codex, Kiro, Windsurf, Zed, and
+others). Claude Code users get the same routing from CLAUDE.md and the README;
+this file is for everyone else.
+
+## What deliberation is
+
+A single MCP server that exposes GPT (via the Codex CLI), Gemini 3 (via the
+Antigravity CLI), Grok (via the xAI API), and OpenRouter models (400+, advisory)
+as expert subagents. You stay the primary agent. When a task benefits from a
+second opinion or cross-model review, call one of the tools below, read the
+result, and apply your own judgment. GPT and Gemini can also implement changes;
+Grok and OpenRouter only advise.
+
+## Tools
+
+Fan-out and single-provider:
+
+- `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
+  models in parallel, get every answer back independently (no cross-talk).
+- `consensus` - fan out, then run one arbiter pass that cross-reviews the
+  independent answers and returns a single synthesized verdict.
+- `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
+  provider for a single-shot second opinion.
+
+Expert personas (pass as the tool, or via the `expert` argument on the fan-out
+tools to apply one persona to every delegate):
+
+- `architect` - system design, tradeoffs, complex decisions.
+- `plan-reviewer` - check a plan is executable before work starts.
+- `scope-analyst` - catch ambiguities and hidden requirements before planning.
+- `code-reviewer` - bugs, security holes, maintainability on a diff or file.
+- `security-analyst` - threat modeling and vulnerability assessment.
+- `researcher` - external libraries, APIs, and best practices, with evidence.
+- `debugger` - ranked root-cause hypotheses and the smallest safe fix.
+
+Every tool takes a `prompt`. Give it full context: the goal, the relevant code
+or paths, and any prior attempts. The experts do not share your session, so a
+self-contained prompt gets a better answer.
+
+## When to delegate
+
+- Reviewing a plan or an architecture decision before you commit to it.
+- A security review of auth, untrusted input, or a new endpoint.
+- A second opinion when you are unsure, or after a fix has failed twice.
+- Cross-model consensus on a high-stakes or contested call.
+
+Skip delegation for simple edits, the first attempt at a fix, and trivial
+questions you can answer directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,21 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 
+## AGENTS.md vs CLAUDE.md
+
+Two host-facing docs, read by different agents:
+
+- **CLAUDE.md** (this file) - read natively by Claude Code. Holds the plugin-dev,
+  architecture, and release content above.
+- **AGENTS.md** - read by other hosts (Cursor, Codex, Kiro, and any agent that
+  picks up an `AGENTS.md`). It is the host-neutral tool guide: what deliberation
+  is, the MCP tool surface, and when to delegate.
+
+AGENTS.md is intentionally standalone - it is NOT an `@CLAUDE.md` include. The
+plugin-dev and release content here is internal to this repo and would mislead a
+non-Claude host. Keep AGENTS.md self-contained so a future edit does not re-merge
+CLAUDE.md into it. Per-host rule snippets live in `examples/`.
+
 ## Seven GPT Experts
 
 | Expert | Prompt | Specialty | Triggers |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Provider prerequisites are the same as the plugin (see [Requirements](#requireme
 
 Tools exposed: `ask-all`, `consensus`, `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, and the seven experts (`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`, `security-analyst`, `researcher`, `debugger`).
 
+The package also ships a `deliberation-setup` bin. Run it once with `npx -y --package @antonbabenko/deliberation-mcp deliberation-setup` to write a starter `~/.claude/deliberation/config.json` (it never overwrites an existing one). The plain `npx -y @antonbabenko/deliberation-mcp` form runs the default bin (the server), which is what your MCP host launches. For host rule wiring, see [`AGENTS.md`](AGENTS.md) and the per-host snippets in [`examples/`](examples/).
+
 </details>
 
 ## Requirements

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# Per-host rule snippets
+
+Copy-pasteable rule blocks that tell each host's model to use the deliberation
+MCP tools. Install the server first (see the project README), then drop the
+matching block into your host's rule file.
+
+- `cursor.md` - Cursor (`.cursor/rules/*.mdc` or legacy `.cursorrules`).
+- `codex.md` - Codex CLI (`AGENTS.md` in the repo root).
+- `kiro.md` - Kiro (`.kiro/steering/*.md`).
+
+The tools referenced in every block: `ask-all`, `consensus`,
+`ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, and the experts
+`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`,
+`security-analyst`, `researcher`, `debugger`.

--- a/examples/codex.md
+++ b/examples/codex.md
@@ -1,0 +1,22 @@
+# Codex CLI rule for deliberation
+
+Codex reads instructions from an `AGENTS.md` file in the repo root (and from
+`~/.codex/AGENTS.md` for a global rule). Add the section below to that file.
+
+```md
+## Deliberation MCP experts
+
+The deliberation MCP server exposes GPT, Gemini, Grok, and OpenRouter as expert
+subagents. Use its tools when a task benefits from outside input:
+
+- Plan or architecture review: call `consensus`, `architect`, or
+  `plan-reviewer`.
+- Security review of auth, untrusted input, or a new endpoint: call
+  `security-analyst`.
+- A second opinion, or after a fix has failed twice: call `ask-all` or a single
+  `ask-gpt` / `ask-gemini` / `ask-grok` tool.
+
+Put full context in the `prompt` - the experts do not share your session. Read
+the result and apply your own judgment. Skip delegation for simple edits and
+first-attempt fixes.
+```

--- a/examples/cursor.md
+++ b/examples/cursor.md
@@ -1,0 +1,27 @@
+# Cursor rule for deliberation
+
+Cursor reads project rules from `.cursor/rules/*.mdc` (newer) or a single
+`.cursorrules` file (legacy). Save the block below as
+`.cursor/rules/deliberation.mdc` with the frontmatter, or paste the body into
+`.cursorrules`.
+
+```mdc
+---
+description: Use deliberation MCP experts for review and second opinions
+alwaysApply: true
+---
+
+The deliberation MCP server gives you GPT, Gemini, Grok, and OpenRouter as
+expert subagents. Call its tools when a task warrants outside input:
+
+- Plan or architecture review: call `consensus` or the `architect` /
+  `plan-reviewer` tool.
+- Security review of auth, untrusted input, or a new endpoint: call
+  `security-analyst`.
+- A second opinion, or after a fix has failed twice: call `ask-all` or a single
+  `ask-gpt` / `ask-gemini` / `ask-grok` tool.
+
+Pass full context in the `prompt` - the experts do not share your session.
+Read the result, then apply your own judgment. Skip delegation for simple edits
+and first-attempt fixes.
+```

--- a/examples/kiro.md
+++ b/examples/kiro.md
@@ -1,0 +1,27 @@
+# Kiro steering rule for deliberation
+
+Kiro reads steering files from `.kiro/steering/*.md`. Save the block below as
+`.kiro/steering/deliberation.md`. The frontmatter `inclusion: always` keeps it
+in context for every interaction.
+
+```md
+---
+inclusion: always
+---
+
+# Deliberation MCP experts
+
+The deliberation MCP server provides GPT, Gemini, Grok, and OpenRouter as expert
+subagents. Call its tools when a task warrants outside input:
+
+- Plan or architecture review: call `consensus`, `architect`, or
+  `plan-reviewer`.
+- Security review of auth, untrusted input, or a new endpoint: call
+  `security-analyst`.
+- A second opinion, or after a fix has failed twice: call `ask-all` or a single
+  `ask-gpt` / `ask-gemini` / `ask-grok` tool.
+
+Pass full context in the `prompt` - the experts do not share your session. Read
+the result, then apply your own judgment. Skip delegation for simple edits and
+first-attempt fixes.
+```

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "description": "Deliberation for Claude Code and any MCP host - GPT, Gemini, Grok, and OpenRouter expert subagents.",
   "mcpName": "io.github.antonbabenko/deliberation",
-  "bin": { "deliberation-mcp": "./dist/index.js" },
+  "bin": { "deliberation-mcp": "./dist/index.js", "deliberation-setup": "./dist/setup.js" },
   "main": "./dist/index.js",
   "files": ["dist/"],
   "engines": { "node": ">=18" },
   "scripts": {
-    "prepack": "esbuild index.js --bundle --platform=node --target=node18 --format=cjs --outfile=dist/index.js"
+    "prepack": "esbuild index.js setup.js --bundle --platform=node --target=node18 --format=cjs --outdir=dist"
   },
   "devDependencies": { "esbuild": "^0.28.0" },
   "license": "MIT"

--- a/server/mcp/setup.js
+++ b/server/mcp/setup.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * deliberation-setup - onboarding helper for non-Claude MCP hosts.
+ *
+ * Separate bin from the stdio server (index.js). The server owns stdout for the
+ * JSON-RPC channel and must stay silent; this is its own process, so it prints
+ * setup guidance freely.
+ *
+ * Behavior:
+ *   - Resolve the config path the server uses (resolveConfigPath, honoring
+ *     DELIBERATION_CONFIG), the same logic the bridges use.
+ *   - Safe write, never clobber: if the config already exists, print the
+ *     suggested consensus block plus guidance and leave the file untouched so
+ *     the user merges by hand. If it is absent, create the parent dir and write
+ *     a starter config with a consensus block and a commented openrouter example.
+ *   - Print which env key each provider needs and the recommended cross-host
+ *     arbiter.
+ *   - Exit 0 on success, non-zero only on a real error (e.g. unwritable dir).
+ *
+ * Zero runtime deps, bundle-safe: no fs reads of bundled repo files. It reads
+ * and writes the user's config path at runtime - that is user data, not a
+ * bundled asset.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { resolveConfigPath } = require("../../core/paths.js");
+
+/** Starter config written when none exists. Consensus arbiter defaults to "auto". */
+const STARTER_CONFIG = {
+  version: 1,
+  consensus: { arbiter: "auto" },
+  openrouter: {
+    enabled: false,
+    models: [],
+  },
+};
+
+/**
+ * Starter config file text: pretty-printed JSON. The openrouter:<alias> example
+ * is printed to stdout, not embedded (JSON has no comments).
+ * @returns {string}
+ */
+function starterConfigText() {
+  return JSON.stringify(STARTER_CONFIG, null, 2) + "\n";
+}
+
+/**
+ * Lines shown for the openrouter example. Printed to stdout (not written into
+ * the JSON, which cannot carry comments).
+ * @returns {string[]}
+ */
+function openrouterExampleLines() {
+  return [
+    "Example openrouter model entry (add under openrouter.models, set enabled: true):",
+    '  { "alias": "claude", "model": "anthropic/claude-3.7-sonnet", "askAll": true, "consensus": true }',
+    "Then reference it as the arbiter with consensus.arbiter = \"openrouter:claude\".",
+  ];
+}
+
+/**
+ * Provider env-key and login guidance. Kept short.
+ * @returns {string[]}
+ */
+function providerGuidanceLines() {
+  return [
+    "Provider setup:",
+    "  GPT (Codex)   - install the Codex CLI and run `codex login` (no env key).",
+    "  Gemini        - install Antigravity and run `agy` once to sign in (no env key).",
+    "  Grok (xAI)    - set XAI_API_KEY in the server env.",
+    "  OpenRouter    - set OPENROUTER_API_KEY and declare models in the config.",
+    "",
+    "Recommended cross-host arbiter: openrouter:<a claude alias> (an out-of-panel",
+    "Claude model), so consensus is adjudicated by a model that is not one of the",
+    "voting providers. Set it with consensus.arbiter in the config.",
+  ];
+}
+
+/**
+ * The suggested consensus block, shown when the config already exists so the
+ * user can merge it by hand.
+ * @returns {string[]}
+ */
+function consensusBlockLines() {
+  return [
+    "Suggested consensus block (merge into your existing config):",
+    '  "consensus": { "arbiter": "auto" }',
+  ];
+}
+
+/**
+ * The subset of fs runSetup needs. Lets tests inject a partial mock without
+ * satisfying the full node:fs surface.
+ * @typedef {Object} FsLike
+ * @property {(p: string) => { isFile: () => boolean }} statSync
+ * @property {(p: string, opts?: { recursive?: boolean }) => string | undefined} mkdirSync
+ * @property {(p: string, data: string, opts?: { flag?: string }) => void} writeFileSync
+ */
+
+/**
+ * Run setup against an injected fs/env/out for testability. Returns the exit
+ * code; the CLI wrapper calls process.exit with it.
+ *
+ * @param {Object} [deps]
+ * @param {FsLike} [deps.fsImpl] fs implementation (default node:fs).
+ * @param {NodeJS.ProcessEnv} [deps.env] environment (default process.env).
+ * @param {(line: string) => void} [deps.out] stdout sink (default console.log).
+ * @param {string} [deps.home] home dir override forwarded to resolveConfigPath.
+ * @returns {number} exit code (0 success, non-zero on a real error)
+ */
+function runSetup(deps) {
+  const fsImpl = (deps && deps.fsImpl) || fs;
+  const env = (deps && deps.env) || process.env;
+  const out = (deps && deps.out) || ((line) => console.log(line));
+  const home = deps && deps.home;
+
+  const configPath = resolveConfigPath({ home, env });
+
+  /** @param {string[]} lines */
+  const print = (lines) => {
+    for (const line of lines) out(line);
+  };
+
+  out("deliberation setup");
+  out("");
+
+  /** Guidance printed when a regular-file config already exists: leave it, merge by hand. */
+  const leaveUnchanged = () => {
+    out(`Config already exists at ${configPath} - leaving it unchanged.`);
+    out("");
+    print(consensusBlockLines());
+    out("");
+    print(openrouterExampleLines());
+    out("");
+    print(providerGuidanceLines());
+    return 0;
+  };
+
+  // Stat first. If the path exists and is a regular file, leave it alone. If it
+  // exists but is NOT a regular file (e.g. DELIBERATION_CONFIG points at a
+  // directory), fail loudly - the server cannot read it.
+  let stat = null;
+  try {
+    stat = fsImpl.statSync(configPath);
+  } catch (_) {
+    stat = null; // ENOENT (or unstattable) -> fall through to write.
+  }
+  if (stat) {
+    if (stat.isFile()) return leaveUnchanged();
+    out(`Config path ${configPath} is not a regular file - refusing to write.`);
+    return 1;
+  }
+
+  try {
+    fsImpl.mkdirSync(path.dirname(configPath), { recursive: true });
+    // Exclusive write: "wx" fails with EEXIST if a file appears between the stat
+    // above and here (TOCTOU). Treat that race as "already exists, unchanged".
+    fsImpl.writeFileSync(configPath, starterConfigText(), { flag: "wx" });
+  } catch (err) {
+    const code = err && typeof err === "object" && "code" in err ? err.code : null;
+    if (code === "EEXIST") return leaveUnchanged();
+    const message = err instanceof Error ? err.message : String(err);
+    out(`Could not write config at ${configPath}: ${message}`);
+    return 1;
+  }
+
+  out(`Wrote starter config at ${configPath}.`);
+  out("");
+  print(openrouterExampleLines());
+  out("");
+  print(providerGuidanceLines());
+  out("");
+  out("Next: set the env keys for the providers you use, then point your MCP");
+  out("host at the deliberation server (npx -y @antonbabenko/deliberation-mcp).");
+  return 0;
+}
+
+module.exports = { runSetup, starterConfigText, STARTER_CONFIG };
+
+// CLI entry: only run when invoked directly, not when required by a test.
+if (require.main === module) {
+  process.exit(runSetup());
+}

--- a/test/core-setup.test.js
+++ b/test/core-setup.test.js
@@ -1,0 +1,122 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+
+const { runSetup, STARTER_CONFIG } = require("../server/mcp/setup.js");
+
+/** Make an isolated temp HOME; never touches the real ~/.claude. */
+function makeHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "delib-setup-"));
+}
+function rmrf(/** @type {string} */ dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+/** Capture stdout lines from runSetup. */
+function capture() {
+  /** @type {string[]} */
+  const lines = [];
+  return { out: (/** @type {string} */ l) => lines.push(l), lines };
+}
+
+// SU1: config absent -> writes a starter with a consensus block, exit 0.
+test("SU1: absent config -> writes starter with consensus block", () => {
+  const home = makeHome();
+  try {
+    const override = path.join(home, "cfg", "config.json");
+    const { out, lines } = capture();
+    const code = runSetup({ env: { DELIBERATION_CONFIG: override }, out });
+
+    assert.equal(code, 0);
+    assert.equal(fs.existsSync(override), true);
+    const written = JSON.parse(fs.readFileSync(override, "utf8"));
+    assert.deepEqual(written.consensus, { arbiter: "auto" });
+    assert.deepEqual(written, STARTER_CONFIG);
+    assert.ok(lines.some((l) => l.includes("Wrote starter config")));
+  } finally {
+    rmrf(home);
+  }
+});
+
+// SU2: config exists -> never clobbered; guidance emitted, exit 0.
+test("SU2: existing config -> not overwritten, guidance emitted", () => {
+  const home = makeHome();
+  try {
+    const override = path.join(home, "cfg", "config.json");
+    fs.mkdirSync(path.dirname(override), { recursive: true });
+    const original = '{"version":1,"my":"custom","openrouter":{"enabled":true,"models":[]}}';
+    fs.writeFileSync(override, original);
+
+    const { out, lines } = capture();
+    const code = runSetup({ env: { DELIBERATION_CONFIG: override }, out });
+
+    assert.equal(code, 0);
+    assert.equal(fs.readFileSync(override, "utf8"), original); // byte-for-byte unchanged
+    assert.ok(lines.some((l) => l.includes("leaving it unchanged")));
+    assert.ok(lines.some((l) => l.includes('"consensus"'))); // suggested block printed
+  } finally {
+    rmrf(home);
+  }
+});
+
+// SU3: unwritable parent -> non-zero exit, real error reported, nothing thrown.
+test("SU3: unwritable target -> exit 1 with error message", () => {
+  const home = makeHome();
+  try {
+    const override = path.join(home, "cfg", "config.json");
+    const fsImpl = {
+      statSync: () => { const e = new Error("ENOENT"); /** @type {any} */ (e).code = "ENOENT"; throw e; },
+      mkdirSync: () => { throw new Error("EACCES: permission denied"); },
+      writeFileSync: () => { throw new Error("should not reach writeFileSync"); },
+    };
+    const { out, lines } = capture();
+    const code = runSetup({ env: { DELIBERATION_CONFIG: override }, out, fsImpl });
+
+    assert.equal(code, 1);
+    assert.ok(lines.some((l) => l.includes("Could not write config")));
+  } finally {
+    rmrf(home);
+  }
+});
+
+// SU4: config path is a DIRECTORY -> exit 1, no write, clear message.
+test("SU4: existing path is a directory -> exit 1, no write, clear message", () => {
+  const home = makeHome();
+  try {
+    const override = path.join(home, "cfg", "config.json");
+    fs.mkdirSync(override, { recursive: true }); // create a dir AT the config path
+    const before = fs.readdirSync(override);
+
+    const { out, lines } = capture();
+    const code = runSetup({ env: { DELIBERATION_CONFIG: override }, out });
+
+    assert.equal(code, 1);
+    assert.equal(fs.statSync(override).isDirectory(), true); // still a dir, nothing written into it as a file
+    assert.deepEqual(fs.readdirSync(override), before); // untouched
+    assert.ok(lines.some((l) => l.includes("not a regular file")));
+  } finally {
+    rmrf(home);
+  }
+});
+
+// SU5: TOCTOU - file appears between stat and write -> EEXIST treated as unchanged, exit 0.
+test("SU5: write race (EEXIST) -> leave unchanged, exit 0", () => {
+  const home = makeHome();
+  try {
+    const override = path.join(home, "cfg", "config.json");
+    const fsImpl = {
+      statSync: () => { const e = new Error("ENOENT"); /** @type {any} */ (e).code = "ENOENT"; throw e; },
+      mkdirSync: () => undefined,
+      writeFileSync: () => { const e = new Error("EEXIST: file already exists"); /** @type {any} */ (e).code = "EEXIST"; throw e; },
+    };
+    const { out, lines } = capture();
+    const code = runSetup({ env: { DELIBERATION_CONFIG: override }, out, fsImpl });
+
+    assert.equal(code, 0);
+    assert.ok(lines.some((l) => l.includes("leaving it unchanged")));
+  } finally {
+    rmrf(home);
+  }
+});


### PR DESCRIPTION
## What (PLAN_0 Phase C+D — turnkey non-Claude onboarding + proactive-delegation guidance)

The last piece for "fully usable on Codex/Kiro": setup + the guidance that makes a host reach for the tools. Docs + a small CLI; no engine change.

**Phase C - `deliberation-setup` bin**
- Second bin (`server/mcp/setup.js`); `prepack` now builds both `dist/index.js` + `dist/setup.js`.
- **Safe-write, never clobbers**: an existing config is left byte-for-byte unchanged (prints the suggested `consensus` block + guidance to merge); absent → writes a starter `{ consensus: { arbiter: "auto" }, ... }` that validates against `validateConfig`. Exclusive write (`flag:"wx"`) + a `statSync` guard that refuses a non-file path (e.g. a directory `DELIBERATION_CONFIG`). Prints per-provider env-key guidance and recommends `openrouter:<claude alias>` as the cross-host arbiter.
- The stdio server keeps stdout clean (JSON-RPC only); all setup output is in the separate bin.

**Phase D - host guidance**
- `AGENTS.md` rewritten **standalone** (dropped the `@CLAUDE.md` include): what deliberation is, the 13-tool surface, when to delegate. No Claude-internal content leaks to non-Claude hosts; Claude Code reads CLAUDE.md natively and is unchanged.
- `examples/` per-host rule snippets — Cursor (`.cursor/rules/*.mdc`), Codex (`AGENTS.md`), Kiro (`.kiro/steering/*.md`) — minimal, accurate to each format, telling the host to call the deliberation tools for review/second-opinion.
- `CLAUDE.md`: an "AGENTS.md vs CLAUDE.md" rationale block (so the intentional split isn't re-merged).
- README: corrected the setup invocation to `npx -y --package @antonbabenko/deliberation-mcp deliberation-setup` (the bare form runs the server, not setup).

## Reviews

- Spec ✅ + code-quality+humanizer (approve-with-nits) + cross-model (GPT *fix-first*, Gemini *PASS*).
- Cross-review caught: an existing-**directory** config path silently exiting 0 (now refused, exit 1) and a **wrong README npx command** that wouldn't actually run setup (corrected). Plus a TOCTOU hardened with `flag:"wx"` and a stale JSDoc fixed.
- All public prose humanizer-checked + strict ASCII (verified).

## Verification

- `npm run check`: typecheck clean + **252/252** (+5 setup tests incl. existing-file no-clobber, EEXIST race, directory-path refusal).
- Tarball ships both bins; clean-room: absent→writes starter, present→unchanged, directory→exit 1; stdio server boots, 13 tools.

PR3 of 3 for PLAN_0 (A merged → B merged → **C+D**). Completes "fully usable on Codex/Kiro": real expert personas (A) + configurable arbiter (B) + setup & guidance (C+D).