### PR TITLE
feat: server-side blindVote + host auto-detect arbiter default

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -79,6 +79,11 @@
             }
           ],
           "examples": ["auto", { "model": "claude-arb" }]
+        },
+        "blindVote": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run a blind arbiter pre-vote (the arbiter answers the question cold, before seeing peer opinions) to reduce anchoring. Server/concrete-arbiter mode only; adds one extra arbiter call."
         }
       }
     }

--- a/core/orchestrate.js
+++ b/core/orchestrate.js
@@ -68,22 +68,45 @@ function buildArbiterPrompt(question, opinions) {
 }
 
 /**
- * Minimal single-round advisory consensus: fan out to all providers, then run
- * ONE arbiter pass over the successful opinions. No blind multi-round; the
- * arbiter is just another Provider (default: the first in the set).
+ * Single-round advisory consensus: fan out to all providers, then run ONE arbiter
+ * pass over the successful opinions. The arbiter is just another Provider
+ * (default: the first in the set).
+ *
+ * Optional `blindVote`: the arbiter ALSO answers the original question cold (no
+ * peer opinions) to produce a `blindVerdict`, fired in PARALLEL with the peer
+ * fan-out (no extra round). It reduces the arbiter anchoring on the peers' framing.
+ * Failure-isolated: a thrown blind pass yields `blindVerdict:null`, never failing
+ * the run. `blindVerdict` is `null` when `blindVote` is off or no arbiter exists.
  * @param {Provider[]} providers
  * @param {DelegationRequest} req
- * @param {{arbiter?:Provider, arbiterInstructions?:string}} [opts]
- * @returns {Promise<{opinions:DelegationResult[], verdict:(DelegationResult|null), error?:string}>}
+ * @param {{arbiter?:Provider, arbiterInstructions?:string, blindVote?:boolean}} [opts]
+ * @returns {Promise<{opinions:DelegationResult[], blindVerdict:(DelegationResult|null), verdict:(DelegationResult|null), error?:string}>}
  */
 async function consensus(providers, req, opts = {}) {
-  const opinions = await askAll(providers, req);
+  const arbiter = opts.arbiter || providers[0];
+  // Blind pre-vote runs concurrently with the peer fan-out. It uses the ORIGINAL
+  // prompt (no opinions) + the arbiter persona. `.then(v, () => null)` isolates a
+  // blind-pass failure so it can never reject the batch.
+  const blindPromise = opts.blindVote && arbiter
+    ? // Promise.resolve().then(...) so even a SYNCHRONOUS throw in ask() is caught
+      // by the rejection handler (a bare arbiter.ask() could throw before awaiting).
+      Promise.resolve()
+        .then(() =>
+          arbiter.ask({
+            ...req,
+            files: req.files ? req.files.map((f) => ({ ...f })) : undefined,
+            developerInstructions: opts.arbiterInstructions || req.developerInstructions,
+          })
+        )
+        .then((v) => v, () => null)
+    : Promise.resolve(/** @type {DelegationResult|null} */ (null));
+
+  const [opinions, blindVerdict] = await Promise.all([askAll(providers, req), blindPromise]);
   // The union guarantees `text` on the success branch, so `!o.isError` alone
   // narrows each survivor to DelegationSuccess - no `&& o.text` guard needed.
   const ok = /** @type {DelegationSuccess[]} */ (opinions.filter((o) => !o.isError));
-  if (!ok.length) return { opinions, verdict: null, error: "all-providers-failed" };
-  const arbiter = opts.arbiter || providers[0];
-  if (!arbiter) return { opinions, verdict: null, error: "no-arbiter" };
+  if (!ok.length) return { opinions, blindVerdict, verdict: null, error: "all-providers-failed" };
+  if (!arbiter) return { opinions, blindVerdict, verdict: null, error: "no-arbiter" };
   try {
     const verdict = await arbiter.ask({
       ...req,
@@ -91,9 +114,9 @@ async function consensus(providers, req, opts = {}) {
       prompt: buildArbiterPrompt(req.prompt, ok),
       developerInstructions: opts.arbiterInstructions || req.developerInstructions,
     });
-    return { opinions, verdict };
+    return { opinions, blindVerdict, verdict };
   } catch {
-    return { opinions, verdict: null, error: "arbiter-failed" };
+    return { opinions, blindVerdict, verdict: null, error: "arbiter-failed" };
   }
 }
 

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -178,6 +178,23 @@ async function isHealthy(p) {
 function buildServer({ providers, getConfig, getConfigError }) {
   const registry = makeRegistry(providers);
 
+  // Client identity for arbiter-default selection. Connection-scoped: set from the
+  // MCP `initialize` handshake (clientInfo.name) for the life of this stdio session.
+  let clientName = /** @type {string|null} */ (null);
+
+  /**
+   * Whether this server is running under Claude Code (or another Claude host).
+   * Primary signal: Claude Code injects `CLAUDECODE=1` into stdio MCP subprocess
+   * env (Claude Code CHANGELOG v2.1.147) - deterministic + documented. Secondary:
+   * a `clientInfo.name` containing "claude" (e.g. Claude Desktop). Used ONLY to
+   * pick the DEFAULT arbiter when the user has not set `consensus.arbiter`.
+   * @returns {boolean}
+   */
+  function isClaudeHost() {
+    if (process.env.CLAUDECODE === "1") return true;
+    return typeof clientName === "string" && clientName.toLowerCase().includes("claude");
+  }
+
   /**
    * Inject the bundled persona for `expert` when the caller did not supply its
    * own developerInstructions. Caller-supplied instructions ALWAYS win, so the
@@ -232,7 +249,12 @@ function buildServer({ providers, getConfig, getConfigError }) {
       // implicit providers[0], so any host can synthesize a real verdict.
       const cfg = getConfig() || {};
       const { providers: selected } = registry.selectForConsensus({ config: cfg, expert: expert || "" });
-      const arbiterSpec = (cfg.consensus && cfg.consensus.arbiter) || "auto";
+      const cc = cfg.consensus || {};
+      // When the user did NOT set an arbiter (arbiterDefaulted), pick the default by
+      // host: Claude Code -> "host" (the host model synthesizes); any other host ->
+      // "auto" (a real server-side verdict). An explicit arbiter always wins.
+      const arbiterSpec = cc.arbiterDefaulted ? (isClaudeHost() ? "host" : "auto") : (cc.arbiter || "auto");
+      const blindVote = !!cc.blindVote;
       const warnings = Array.isArray(cfg.consensusWarnings) ? cfg.consensusWarnings.slice() : [];
       // Surface a config load/parse error (e.g. bad config.json) instead of
       // silently swallowing it via getConfig()'s {} fallback.
@@ -245,7 +267,7 @@ function buildServer({ providers, getConfig, getConfigError }) {
       if (resolved.mode === "host") {
         // Host arbitrates: return opinions only, no server-side arbiter pass.
         const opinions = await askAll(selected, withPersona(req, expert));
-        return { content: [{ type: "text", text: JSON.stringify({ opinions, verdict: null, arbiter: { mode: "host" }, warnings }) }] };
+        return { content: [{ type: "text", text: JSON.stringify({ opinions, blindVerdict: null, verdict: null, arbiter: { mode: "host" }, warnings }) }] };
       }
 
       if (!resolved.provider) {
@@ -253,7 +275,7 @@ function buildServer({ providers, getConfig, getConfigError }) {
         // through consensus(selected, ...) so the documented all-providers-failed
         // signal is preserved instead of masquerading as host mode.
         const out = await consensus(selected, withPersona(req, expert), { arbiterInstructions: PROMPTS.arbiter });
-        return { content: [{ type: "text", text: JSON.stringify({ opinions: out.opinions, verdict: out.verdict, error: out.error, arbiter: { mode: "server", provider: null }, warnings }) }] };
+        return { content: [{ type: "text", text: JSON.stringify({ opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, error: out.error, arbiter: { mode: "server", provider: null }, warnings }) }] };
       }
 
       const arbiter = resolved.provider;
@@ -265,8 +287,8 @@ function buildServer({ providers, getConfig, getConfigError }) {
         peers = selected;
         warnings.push(`panel too small to exclude arbiter '${arbiter.name}'; kept it in the peer panel (floor of 2)`);
       }
-      const out = await consensus(peers, withPersona(req, expert), { arbiter, arbiterInstructions: PROMPTS.arbiter });
-      return { content: [{ type: "text", text: JSON.stringify({ opinions: out.opinions, verdict: out.verdict, error: out.error, arbiter: { mode: "server", provider: arbiter.name }, warnings }) }] };
+      const out = await consensus(peers, withPersona(req, expert), { arbiter, arbiterInstructions: PROMPTS.arbiter, blindVote });
+      return { content: [{ type: "text", text: JSON.stringify({ opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, error: out.error, arbiter: { mode: "server", provider: arbiter.name }, warnings }) }] };
     }
     if (Object.prototype.hasOwnProperty.call(ASK_PROVIDER, name)) {
       const p = registry.get(ASK_PROVIDER[name]);
@@ -286,6 +308,9 @@ function buildServer({ providers, getConfig, getConfigError }) {
   async function handle(msg) {
     try {
       if (msg.method === "initialize") {
+        // Capture the client name (hint for the arbiter default; see isClaudeHost).
+        const ci = msg.params && msg.params.clientInfo;
+        if (ci && typeof ci.name === "string") clientName = ci.name;
         return { jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "deliberation-mcp", version: "0.1.0" } } };
       }
       if (msg.method === "tools/list") return { jsonrpc: "2.0", id: msg.id, result: { tools: toolList() } };

--- a/server/openrouter/config.js
+++ b/server/openrouter/config.js
@@ -268,34 +268,54 @@ function resolveModels(modelsRaw) {
 function resolveConsensus(rawConsensus, models) {
   const warnings = [];
   if (rawConsensus !== undefined && !isObject(rawConsensus)) {
+    // The user DID set consensus (just malformed) -> degrade to auto but treat as
+    // explicit (arbiterDefaulted:false), so host auto-detect does not override it.
     warnings.push(`consensus must be an object (got ${JSON.stringify(rawConsensus)}); using "${DEFAULT_ARBITER}"`);
-    return { consensus: { arbiter: DEFAULT_ARBITER }, warnings };
+    return { consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: false, blindVote: false }, warnings };
   }
   const block = isObject(rawConsensus) ? rawConsensus : {};
+
+  // blindVote: optional boolean; non-boolean degrades to false + a warning. Runs
+  // a blind arbiter pre-vote (server/concrete-arbiter mode only); off by default
+  // because the extra arbiter call adds cost/latency.
+  let blindVote = false;
+  if (block.blindVote !== undefined) {
+    if (typeof block.blindVote === "boolean") blindVote = block.blindVote;
+    else warnings.push(`consensus.blindVote must be a boolean (got ${JSON.stringify(block.blindVote)}); using false`);
+  }
+
+  // arbiterDefaulted=true ONLY when the user did not set an arbiter at all, so the
+  // server can pick host (under Claude Code) vs auto (elsewhere). An explicit but
+  // invalid arbiter degrades to auto with arbiterDefaulted=false (the user did choose).
+  const wrap = (/** @type {any} */ arbiter, /** @type {boolean} */ arbiterDefaulted) => ({
+    consensus: { arbiter, arbiterDefaulted, blindVote },
+    warnings,
+  });
+
   const spec = block.arbiter;
-  if (spec === undefined) return { consensus: { arbiter: DEFAULT_ARBITER }, warnings };
+  if (spec === undefined) return wrap(DEFAULT_ARBITER, true);
 
   // Object form: { model: "<id>" } referencing a models entry.
   if (isObject(spec)) {
     const id = spec.model;
     if (typeof id !== "string" || !id.trim()) {
       warnings.push(`consensus.arbiter object must have a string "model" id (got ${JSON.stringify(spec)}); using "${DEFAULT_ARBITER}"`);
-      return { consensus: { arbiter: DEFAULT_ARBITER }, warnings };
+      return wrap(DEFAULT_ARBITER, false);
     }
-    if (models.some((m) => m.alias === id)) return { consensus: { arbiter: { model: id } }, warnings };
+    if (models.some((m) => m.alias === id)) return wrap({ model: id }, false);
     warnings.push(`consensus.arbiter model "${id}" is not a configured models id; using "${DEFAULT_ARBITER}"`);
-    return { consensus: { arbiter: DEFAULT_ARBITER }, warnings };
+    return wrap(DEFAULT_ARBITER, false);
   }
 
   if (typeof spec !== "string") {
     warnings.push(`consensus.arbiter must be a string shorthand or { model: "<id>" } (got ${JSON.stringify(spec)}); using "${DEFAULT_ARBITER}"`);
-    return { consensus: { arbiter: DEFAULT_ARBITER }, warnings };
+    return wrap(DEFAULT_ARBITER, false);
   }
   if (spec === "host" || spec === "auto" || BUILTIN_ARBITERS.has(spec)) {
-    return { consensus: { arbiter: spec }, warnings };
+    return wrap(spec, false);
   }
   warnings.push(`consensus.arbiter "${spec}" is not host/auto/codex/gemini/grok or { model: "<id>" }; using "${DEFAULT_ARBITER}"`);
-  return { consensus: { arbiter: DEFAULT_ARBITER }, warnings };
+  return wrap(DEFAULT_ARBITER, false);
 }
 
 function disabledOpenRouter() {
@@ -320,7 +340,7 @@ function makeConfigReader(filePath) {
     try {
       text = fs.readFileSync(filePath, "utf8");
     } catch (_) {
-      return { ok: true, error: null, resolved: { version: 1, providers: {}, openrouter: disabledOpenRouter(), consensus: { arbiter: DEFAULT_ARBITER }, consensusWarnings: [] } };
+      return { ok: true, error: null, resolved: { version: 1, providers: {}, openrouter: disabledOpenRouter(), consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: true, blindVote: false }, consensusWarnings: [] } };
     }
     let parsed;
     try {

--- a/test/core-orchestrate.test.js
+++ b/test/core-orchestrate.test.js
@@ -87,6 +87,47 @@ test("C5: consensus with empty providers yields a safe shape, never throws", asy
   assert.ok(out.error === "all-providers-failed" || out.error === "no-arbiter");
 });
 
+// A blind-vote-aware arbiter: the verdict pass receives a buildArbiterPrompt
+// (contains "### Opinion"); the blind pass receives the raw question.
+function blindAwareArbiter(/** @type {string} */ behavior = "") {
+  /** @type {string[]} */
+  const calls = [];
+  const provider = /** @type {any} */ ({
+    name: "arb", capabilities: {}, async health() { return { ok: true }; },
+    async ask(/** @type {any} */ req) {
+      calls.push(req.prompt);
+      const isVerdict = req.prompt.includes("### Opinion");
+      if (behavior === "blind-throws" && !isVerdict) throw new Error("blind boom");
+      return { provider: "arb", model: "m", text: isVerdict ? "verdict" : "blind", isError: false, ms: 0 };
+    },
+  });
+  return { provider, calls };
+}
+
+test("C7: blindVote runs a blind pre-vote (raw question) alongside the verdict pass", async () => {
+  const { provider, calls } = blindAwareArbiter();
+  const out = await consensus([fakeProvider("a"), fakeProvider("b")], { prompt: "hi" }, { arbiter: provider, blindVote: true });
+  assert.equal(out.blindVerdict && /** @type {any} */ (out.blindVerdict).text, "blind");
+  assert.equal(out.verdict && /** @type {any} */ (out.verdict).text, "verdict");
+  assert.ok(calls.includes("hi"), "arbiter saw the raw question (blind pass)");
+  assert.ok(calls.some((p) => p.includes("### Opinion")), "arbiter saw the opinions (verdict pass)");
+});
+
+test("C8: a thrown blind pass yields blindVerdict:null but the run still succeeds", async () => {
+  const { provider } = blindAwareArbiter("blind-throws");
+  const out = await consensus([fakeProvider("a"), fakeProvider("b")], { prompt: "hi" }, { arbiter: provider, blindVote: true });
+  assert.equal(out.blindVerdict, null);
+  assert.equal(out.verdict && /** @type {any} */ (out.verdict).text, "verdict");
+  assert.equal(out.error, undefined);
+});
+
+test("C9: blindVote off (default) -> blindVerdict is null, arbiter called once", async () => {
+  const { provider, calls } = blindAwareArbiter();
+  const out = await consensus([fakeProvider("a"), fakeProvider("b")], { prompt: "hi" }, { arbiter: provider });
+  assert.equal(out.blindVerdict, null);
+  assert.equal(calls.length, 1); // verdict pass only, no blind pass
+});
+
 test("C6: buildArbiterPrompt anonymizes opinion labels (no provider names leak)", () => {
   const opinions = /** @type {any} */ ([
     { provider: "codex", text: "alpha body" },

--- a/test/core-setup.test.js
+++ b/test/core-setup.test.js
@@ -164,7 +164,7 @@ test("SU8: STARTER_CONFIG validates under validateConfig", () => {
   assert.ok(resolved);
   // openrouter ships disabled in the starter; consensus arbiter is the auto shorthand.
   assert.equal(resolved.openrouter.enabled, false);
-  assert.deepEqual(resolved.consensus, { arbiter: "auto" });
+  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: false, blindVote: false });
   assert.deepEqual(resolved.openrouter.models, []);
   assert.equal(resolved.openrouter.maxFanout, 3);
 });

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -50,6 +50,40 @@ test("M4: consensus runs fan-out + one arbiter pass and returns opinions + verdi
   assert.ok(payload.verdict); // arbiter (first provider) produced a verdict
 });
 
+// arbiterDefaulted=true simulates a user who did NOT set consensus.arbiter, so the
+// server picks the default by host (Claude -> host, else -> auto).
+const defaultedConfig = { providers: {}, openrouter: { maxFanout: 3, models: [] }, consensus: { arbiter: "auto", arbiterDefaulted: true, blindVote: false } };
+
+async function consensusArbiterMode(clientName, claudecode) {
+  const prev = process.env.CLAUDECODE;
+  if (claudecode) process.env.CLAUDECODE = "1"; else delete process.env.CLAUDECODE;
+  try {
+    const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => defaultedConfig });
+    if (clientName) await srv.handle({ jsonrpc: "2.0", id: 1, method: "initialize", params: { clientInfo: { name: clientName } } });
+    const res = await srv.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: "consensus", arguments: { prompt: "x", expert: "architect" } } });
+    return JSON.parse(res.result.content[0].text);
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDECODE; else process.env.CLAUDECODE = prev;
+  }
+}
+
+test("M6: arbiterDefaulted + a Claude clientInfo.name defaults the arbiter to host (verdict:null)", async () => {
+  const payload = await consensusArbiterMode("claude-code", false);
+  assert.equal(payload.arbiter.mode, "host");
+  assert.equal(payload.verdict, null);
+});
+
+test("M7: arbiterDefaulted + a non-Claude client defaults the arbiter to auto (server verdict)", async () => {
+  const payload = await consensusArbiterMode("cursor", false);
+  assert.equal(payload.arbiter.mode, "server");
+  assert.ok(payload.verdict);
+});
+
+test("M8: CLAUDECODE=1 forces host default even when the client name is non-Claude", async () => {
+  const payload = await consensusArbiterMode("cursor", true);
+  assert.equal(payload.arbiter.mode, "host");
+});
+
 test("M5: ask-all expands OR per-alias and never dispatches askAll:false (issue 001 closed)", async () => {
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("openrouter")], getConfig: () => orConfig });
   const res = await srv.handle({ jsonrpc: "2.0", id: 5, method: "tools/call",

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -323,8 +323,24 @@ test("C11: malformed JSON => ok=false with parse error, no throw", () => {
 test("CB1: missing consensus block defaults arbiter to 'auto', no warnings", () => {
   const { ok, resolved } = validateConfig(base());
   assert.equal(ok, true);
-  assert.deepEqual(resolved.consensus, { arbiter: "auto" });
+  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
   assert.deepEqual(resolved.consensusWarnings, []);
+});
+
+test("CB1b: consensus.blindVote true is accepted; arbiterDefaulted false when arbiter is explicit", () => {
+  const c = base();
+  c.consensus = { arbiter: "auto", blindVote: true };
+  const { resolved } = validateConfig(c);
+  assert.equal(resolved.consensus.blindVote, true);
+  assert.equal(resolved.consensus.arbiterDefaulted, false); // arbiter was explicitly set
+});
+
+test("CB1c: non-boolean consensus.blindVote degrades to false + a warning", () => {
+  const c = base();
+  c.consensus = { blindVote: "yes" };
+  const { resolved } = validateConfig(c);
+  assert.equal(resolved.consensus.blindVote, false);
+  assert.ok(resolved.consensusWarnings.some((/** @type {string} */ w) => /blindVote must be a boolean/.test(w)));
 });
 
 test("CB2: arbiter 'host' is accepted verbatim", () => {
@@ -421,7 +437,7 @@ test("CB9: non-object consensus block degrades to auto AND warns (invalid->auto+
 
 test("CB7: omitted openrouter block still carries consensus default auto", () => {
   const { resolved } = validateConfig({ version: 1 });
-  assert.deepEqual(resolved.consensus, { arbiter: "auto" });
+  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
   assert.deepEqual(resolved.consensusWarnings, []);
 });
 
@@ -429,5 +445,5 @@ test("CB8: missing config file => disabled openrouter + consensus default auto",
   const reader = makeConfigReader(path.join(os.tmpdir(), "definitely-absent-cdg-cb.json"));
   const r = reader.get();
   assert.equal(r.ok, true);
-  assert.deepEqual(r.resolved.consensus, { arbiter: "auto" });
+  assert.deepEqual(r.resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
 });


### PR DESCRIPTION
## What

Two engine/experience-parity wins for non-Claude MCP hosts (PLAN_0 items 1 & 2). Additive to the shipped arbiter minimal cut.

### 1. Server-side `blindVote`
`core/orchestrate.js consensus()` runs a **blind arbiter pre-vote** (the arbiter answers the question cold, no peer opinions) **concurrently** with the peer fan-out, returning `blindVerdict`. Reduces the arbiter anchoring on the peers' framing — the consensus-quality lever non-Claude hosts lacked (Claude `/consensus` does it host-side).
- Config-only: `consensus.blindVote` (boolean, default `false`); server/concrete-arbiter mode only (host mode unchanged).
- Failure-isolated: `Promise.resolve().then(() => arbiter.ask(...)).then(v, () => null)` so even a **synchronous** throw degrades to `blindVerdict:null` and the run still succeeds.
- `blindVerdict` added to all consensus return shapes.

### 2. Host auto-detect for the default arbiter
When `consensus.arbiter` is **unset** (`arbiterDefaulted`), the server picks the default by host:
- Claude Code — `process.env.CLAUDECODE === "1"` (injected into stdio MCP subprocess env per the Claude Code CHANGELOG v2.1.147) **or** a `clientInfo.name` containing `claude` — → `host`.
- Any other host → `auto`, so a non-Claude host gets a real verdict with **zero config**.
- An **explicit** `consensus.arbiter` always wins; a malformed `consensus` degrades to auto (treated as explicit); missing config → packaged default.

**Intended behavior change:** a Claude Code user with NO config now defaults to host arbitration (`verdict:null`; the host synthesizes) instead of a server `auto` verdict.

`config/config.schema.json` gains `consensus.blindVote`.

## Review

Reviewed by **GPT + Gemini + Grok** (deliberation's own `code-reviewer`) **+ two Claude review agents**. Fixes folded in:
- `arbiterDefaulted:false` on a malformed (non-object) `consensus` block (GPT HIGH — otherwise it would flip Claude to host).
- Synchronous-throw isolation in the blind pass (Gemini + qwen).
- `blindVote` added to the JSON schema (GPT).
Reviewer agents + Grok APPROVED; qwen's "null-safety crash" flags were verified non-issues (`cc`/`clientInfo` already guarded).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `node --test test/*.test.js` — **294 pass** (new: C7-C9 blindVote concurrency/isolation/default; CB1b/CB1c config; M6-M8 host-detect with deterministic CLAUDECODE save/restore)
- [ ] Live: a Claude Code zero-config `/consensus` now returns host mode; a non-Claude host returns a server verdict; `consensus.blindVote:true` returns `blindVerdict` (needs MCP server reload)

## Scope
PLAN_0 item 3 (session store + convergence loop) is deferred. `docs/multi-growth/PLAN_0_claude_parity.md` has the full plan; `docs/` is gitignored so it's not in this diff.