### PR TITLE
fix: setup bash avoids $1/$2 so slash-arg interpolation can't blank server names

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "disabledMcpjsonServers": ["deliberation"]
+}

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -70,10 +70,19 @@ if [ ! -f "$CFG" ]; then
   fi
 fi
 
-json_eval() { node -e "$1" "$CFG" 2>/dev/null; }
+# Helpers take their first arg WITHOUT the literal $1/$2 tokens: Claude Code
+# interpolates $1..$9 / $ARGUMENTS in a command body before bash runs, and this is a
+# no-arg command, so any $1 here would be blanked. `for x in "$@"; do break; done`
+# binds x to the first arg; the guarded shift drops it so "$@" is the remainder.
+# `$@` is NOT a slash-command placeholder, so it survives intact.
+json_eval() {
+  local prog="" ; for prog in "$@"; do break; done ; [ "$#" -gt 0 ] && shift
+  node -e "$prog" "$CFG" "$@" 2>/dev/null
+}
 # providers.<name>.enabled: missing => enabled (returns 1); explicit false => 0.
 provider_enabled() {
-  json_eval 'try{const c=require(process.argv[1]);const p=(c.providers&&c.providers[process.argv[2]])||{};process.stdout.write(p.enabled===false?"0":"1")}catch(e){process.stdout.write("1")}' "$1"
+  local prov="" ; for prov in "$@"; do break; done
+  json_eval 'try{const c=require(process.argv[1]);const p=(c.providers&&c.providers[process.argv[2]])||{};process.stdout.write(p.enabled===false?"0":"1")}catch(e){process.stdout.write("1")}' "$prov"
 }
 # openrouter on iff providers.openrouter.enabled!=false AND (>=1 models record OR defaultModel).
 # Unified v1 shape: connection lives under providers.openrouter; models is the top-level map.
@@ -84,9 +93,16 @@ or_key_env() {
   json_eval 'try{const c=require(process.argv[1]);const p=(c.providers&&c.providers.openrouter)||{};process.stdout.write(p.apiKeyEnv||"OPENROUTER_API_KEY")}catch(e){process.stdout.write("OPENROUTER_API_KEY")}'
 }
 
-remove_mcp() { claude mcp remove "$1" >/dev/null 2>&1 || true; }
+remove_mcp() {
+  local name="" ; for name in "$@"; do break; done
+  claude mcp remove "$name" >/dev/null 2>&1 || true
+}
 # remove-then-add (do not assume `claude mcp add` upserts). Never aborts the rest on one failure.
-add_mcp() { name="$1"; shift; remove_mcp "$name"; claude mcp add --transport stdio --scope user "$name" -- "$@" || echo "WARN: failed to register $name"; }
+add_mcp() {
+  local name="" ; for name in "$@"; do break; done ; [ "$#" -gt 0 ] && shift
+  remove_mcp "$name"
+  claude mcp add --transport stdio --scope user "$name" -- "$@" || echo "WARN: failed to register $name"
+}
 
 # --- CLI presence (external tools; bridges ship with the plugin so are not checked) ---
 command -v codex >/dev/null 2>&1 && CODEX_STATUS="$(codex --version 2>&1 | head -1)" || CODEX_STATUS="MISSING (npm i -g @openai/codex)"


### PR DESCRIPTION
## Problem

`/deliberation:setup` registered **zero** MCP servers on first run - `claude mcp add ... -- ...` failed with `Server name is required`. Re-running by hand with literal args worked.

Root cause: Claude Code interpolates slash-command argument placeholders (`$ARGUMENTS`, `$1`..`$9`) in a command body **before** the bash runs. `setup.md` is a no-arg command, but its Step-1 helpers used shell positional `$1`/`$2`. With no args, every `$1`/`$2` collapsed to an empty string:

- `json_eval() { node -e "$1" ... }` -> `node -e ""` (empty program)
- `add_mcp() { name="$1"; ... }` -> empty server name -> `Server name is required`

`$@` is not a placeholder, so it survived - only the numbered positionals broke.

## Fix

Rewrite `json_eval` / `provider_enabled` / `remove_mcp` / `add_mcp` to take their first arg via `for x in "$@"; do break; done` (+ guarded `shift`), so **no `$1`/`$2` tokens remain**. Call sites are unchanged. `local` scoping means no parent-scope leak; `set -u`-safe on empty `$@`.

Bonus: `json_eval` now forwards `"$@"` to node, fixing a latent bug where `provider_enabled`'s `process.argv[2]` was always `undefined` (so `enabled:false` was silently ignored).

Also disables the colliding `.mcp.json`/plugin-bundled npx `deliberation` server via `.claude/settings.json` (`disabledMcpjsonServers`), leaving the working user-scope node server.

## Review

Validated via `/consensus` (Plan Reviewer): converged round 2, GPT + Gemini + Grok all APPROVE. The `"$@"` loop-extraction design and the guarded `shift` came directly from reviewer feedback; the latent `process.argv[2]` bug was surfaced during review.

## Test plan

- [x] Static: `rg '"\$1"|"\$2"' commands/setup.md` -> no matches
- [x] `claude --plugin-dir <repo>` then `/deliberation:setup` -> all enabled `deliberation-*` register on first run (no "Server name is required"); `claude mcp list` confirms