### PR TITLE
docs: document consensus.blindVote across config example and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,9 @@ Fan-out and single-provider:
 - `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
   models in parallel, get every answer back independently (no cross-talk).
 - `consensus` - fan out, then run one arbiter pass that cross-reviews the
-  independent answers and returns a single synthesized verdict.
+  independent answers and returns a single synthesized verdict. An optional
+  server-side blind pre-vote (`consensus.blindVote` in config) returns a
+  `blindVerdict` alongside the `verdict`.
 - `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
   provider for a single-shot second opinion.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
 | `config/config.schema.json` | JSON Schema (in `config/`) | Validates `config.json` in editors (VS Code built-in JSON support, no extension); `.vscode/` wires it for in-repo example configs |
-| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus.arbiter`. Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
+| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote`). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 

--- a/POWER.md
+++ b/POWER.md
@@ -31,7 +31,9 @@ Fan-out and single-provider:
 - `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
   models in parallel, get every answer back independently (no cross-talk).
 - `consensus` - fan out, then run one arbiter pass that cross-reviews the
-  independent answers and returns a single synthesized verdict.
+  independent answers and returns a single synthesized verdict. An optional
+  server-side blind pre-vote (`consensus.blindVote` in config) returns a
+  `blindVerdict` alongside the `verdict`.
 - `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
   provider for a single-shot second opinion.
 

--- a/README.md
+++ b/README.md
@@ -262,8 +262,9 @@ still requires `/setup`.
 
 The config has four sections: `providers` (transport / connection per provider),
 `models` (named model records keyed by id), `routing` (fan-out policy), and
-`consensus.arbiter` (who synthesizes the verdict). The `$schema` key gives editors
-validation and autocomplete - VS Code needs no extension.
+`consensus` (`arbiter` = who synthesizes the verdict; optional `blindVote` for a blind
+arbiter pre-vote). The `$schema` key gives editors validation and autocomplete - VS Code
+needs no extension.
 
 Minimal example:
 
@@ -299,7 +300,7 @@ Minimal example:
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": { "model": "claude-arb" } }
+  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true }
 }
 ```
 
@@ -316,8 +317,10 @@ per-record override over `defaults`.
 `/consensus` includes records where `consensus === true`, with no fanout cap (a warning
 is emitted when more than 3 models participate). `consensus.arbiter` picks who synthesizes:
 a shorthand string (`"auto"` / `"host"` / `"codex"` / `"gemini"` / `"grok"`) or
-`{ "model": "<id>" }` naming a record (even an out-of-panel one). Implementation tasks
-always route to Codex or Gemini - never OpenRouter.
+`{ "model": "<id>" }` naming a record (even an out-of-panel one). `consensus.blindVote`
+(boolean, default `false`) runs the arbiter cold in parallel with the panel to reduce
+anchoring - concrete-arbiter / non-host mode only. Implementation tasks always route to
+Codex or Gemini - never OpenRouter.
 
 For the full schema, the `$schema` / VS Code validation story, apiBase override matrix
 (Ollama, vLLM, LM Studio, HuggingFace), file-attachment caps, session model persistence,

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -388,7 +388,8 @@ The config has four top-level sections, each with one job:
 - **`models`** - named model records, keyed by id. Each record names its `provider` and
   `model` slug and sets routing flags. This is where you declare the models the panel uses.
 - **`routing`** - global fan-out policy (`maxFanout`).
-- **`consensus.arbiter`** - who synthesizes the consensus verdict.
+- **`consensus`** - `arbiter` (who synthesizes the consensus verdict) and `blindVote`
+  (optional blind arbiter pre-vote; boolean, default `false`).
 
 Config file schema (strict JSON, `version` must be `1`):
 
@@ -422,7 +423,7 @@ Config file schema (strict JSON, `version` must be `1`):
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": { "model": "claude-arb" } }
+  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true }
 }
 ```
 
@@ -479,6 +480,28 @@ A cross-host recommendation: a dedicated Claude record used only as the arbiter
 one of the voting providers. An unusable arbiter (unknown shorthand, a `{ model }` id that
 is not configured, or a disabled provider) soft-degrades to `"auto"` with a warning - it
 never hard-fails the config.
+
+### consensus.blindVote
+
+`consensus.blindVote` is an optional boolean (default `false`). When `true`, the arbiter
+ALSO answers the original question cold - with no peer opinions - to produce a
+`blindVerdict`, fired in parallel with the peer fan-out (no extra round). The blind pass
+reduces the arbiter anchoring on the peers' framing.
+
+Constraints and behavior:
+
+- **Concrete / server-arbiter mode only.** It runs only when a real arbiter pass runs
+  (`"auto"`, a built-in, or a `{ model }` record). In `"host"` mode the server runs no
+  arbiter pass, so there is no blind pass either - `blindVerdict` is `null`.
+- **Cost.** It adds one extra arbiter call (parallel, no extra round), which is why it is
+  off by default.
+- **Failure-isolated.** A thrown blind pass yields `blindVerdict: null` and never fails the
+  run. `blindVerdict` is also `null` when `blindVote` is off or no arbiter exists.
+- **Validation.** A non-boolean value soft-degrades to `false` with a warning - it never
+  hard-fails the config.
+
+Behavior source of truth: `consensus()` in `core/orchestrate.js` and the `blindVote`
+validation in `server/openrouter/config.js`.
 
 ### camelCase config keys, wire mapping
 

--- a/commands/consensus.md
+++ b/commands/consensus.md
@@ -106,9 +106,10 @@ For each round R:
    })
    ```
 
-   The tool returns `{ opinions: DelegationResult[], verdict: DelegationResult | null, arbiter, warnings, error? }`.
+   The tool returns `{ opinions: DelegationResult[], blindVerdict: DelegationResult | null, verdict: DelegationResult | null, arbiter, warnings, error? }`.
    - `opinions` is the cross-review panel: one `{ provider, model, text?, isError, errorKind?, ms }` per dispatched voice, where `provider` is `codex`, `gemini`, `grok`, or `openrouter:<alias>`. These are the independent external votes for this round.
    - **Claude Code runs with `consensus.arbiter: "host"`** (host = Claude is the arbiter). In host mode the server does NOT run a server-side arbiter pass: `verdict` is always `null` and `arbiter` is `{ mode: "host" }`. Claude is the real arbiter in this command - it reads the `opinions` array, runs its own blind verdict and adjudication (steps 3 and 7 below), and authors the converged plan. Do not expect or surface a server `verdict` in host mode.
+   - **`blindVerdict` is always `null` in host mode.** The server runs no blind pass here, so the server-side `consensus.blindVote` option only yields a `blindVerdict` for non-host (concrete-arbiter) hosts. It is distinct from Claude's OWN blind verdict (step 3 below), which is command-driven and always applies.
    - If `error` is `"all-providers-failed"`, every voice errored this round: no responding external, so the round CANNOT converge (see step 8). Handle it with the all-unavailable path described in the Stability rules.
 
    **Repo-wide context (file-blind voices):** the server fans out to advisory voices,

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -29,5 +29,5 @@
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": "auto" }
+  "consensus": { "arbiter": "auto", "blindVote": false }
 }

--- a/plugins/deliberation/skills/deliberation/SKILL.md
+++ b/plugins/deliberation/skills/deliberation/SKILL.md
@@ -28,7 +28,9 @@ Fan-out and single-provider:
 - `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
   models in parallel, get every answer back independently (no cross-talk).
 - `consensus` - fan out, then run one arbiter pass that cross-reviews the
-  independent answers and returns a single synthesized verdict.
+  independent answers and returns a single synthesized verdict. An optional
+  server-side blind pre-vote (`consensus.blindVote` in config) returns a
+  `blindVerdict` alongside the `verdict`.
 - `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
   provider for a single-shot second opinion.
 


### PR DESCRIPTION
## What

PR #79 shipped `consensus.blindVote` (boolean, default `false`) and the host auto-detect arbiter default. The code, JSON Schema, tests, and CHANGELOG all carry it - but the **example config and the human-facing config docs were never updated**. A user reading README/TECHNICAL or copying `config.default.json` had no signal the option exists.

This PR is **documentation + example parity only**. No behavior change.

## Changes

- **`config/config.default.json`** - add `"blindVote": false` to the consensus block (default stays off)
- **`TECHNICAL.md`** - section bullet, concrete-arbiter example (`blindVote: true`), and a new `### consensus.blindVote` subsection (concrete/server-arbiter only, +1 call, failure-isolated, non-boolean degrades to false)
- **`README.md`** - sections sentence, minimal example, and a trailing config sentence
- **`CLAUDE.md`** - config-row `Sections:` list now names `consensus` (`arbiter` + `blindVote`)
- **`commands/consensus.md`** - documented tool return shape now lists `blindVerdict`; added a host-mode note (`blindVerdict` is always `null` in host mode, distinct from Claude's own command-driven blind verdict)
- **`AGENTS.md`** - one host-neutral line on the server-side blind pre-vote
- **regenerated host artifacts** (`POWER.md`, `plugins/deliberation/skills/deliberation/SKILL.md`) via `scripts/sync-hosts.js` since they embed `AGENTS.md`

### Not touched
- `config/config.schema.json` (already defines blindVote - the source of truth)
- The separate **host-side blind verdict** mechanics in the consensus command/loop (different concept; not conflated)
- `CHANGELOG.md`, `docs/multi-growth/*` (already reference blindVote)

## Test plan

- [x] `config/config.default.json` still resolves `consensus.blindVote === false`
- [x] `npm run check` - 294/294 pass, typecheck clean
- [x] blindVote tests green (C7-C9, CB1b/CB1c)
- [x] host-artifact drift test green after `scripts/sync-hosts.js`
- [x] grep parity: every config-structure doc naming `consensus.arbiter` now also names `blindVote`