### PR TITLE
feat: opt-in session store + session tools (PLAN_1c)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "disabledMcpjsonServers": ["deliberation"],
   "env": {
-    "ECC_DISABLED_HOOKS": "pre:edit-write:gateguard-fact-force"
+    "ECC_DISABLED_HOOKS": "pre:edit-write:gateguard-fact-force",
+    ""
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "disabledMcpjsonServers": ["deliberation"]
+  "disabledMcpjsonServers": ["deliberation"],
+  "env": {
+    "ECC_DISABLED_HOOKS": "pre:edit-write:gateguard-fact-force"
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "disabledMcpjsonServers": ["deliberation"],
+  "disabledMcpjsonServers": [
+    "deliberation"
+  ],
   "env": {
-    "ECC_DISABLED_HOOKS": "pre:edit-write:gateguard-fact-force",
-    ""
+    "ECC_DISABLED_HOOKS": "pre:edit-write:gateguard-fact-force"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,12 @@
 {
+  "json.schemaDownload.enable": true,
   "json.schemas": [
     {
-      "fileMatch": ["**/deliberation/config.json", "config.json", "config/config.default.json"],
+      "fileMatch": [
+        "**/deliberation/config.json",
+        "config.json",
+        "config/config.default.json"
+      ],
       "url": "./config/config.schema.json"
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,15 @@ tools to apply one persona to every delegate):
 - `researcher` - external libraries, APIs, and best practices, with evidence.
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
-Every tool takes a `prompt`. Give it full context: the goal, the relevant code
+Session tools (only useful when `sessions.persist` is enabled in config; they report
+"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
+
+- `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
+- `session-revisit { sessionId }` - re-run the recorded question with the current
+  providers/config and save a linked child record.
+- `session-annotate { sessionId, note }` - append a note to a run's audit trail.
+
+Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code
 or paths, and any prior attempts. The experts do not share your session, so a
 self-contained prompt gets a better answer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
 | `config/config.schema.json` | JSON Schema (in `config/`) | Validates `config.json` in editors (VS Code built-in JSON support, no extension); `.vscode/` wires it for in-repo example configs |
-| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote`). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
+| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote`), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 
@@ -131,6 +131,7 @@ Grok reads attached files via `files[]` and resolves them under `roots[]` (top-l
 3. **Dual mode** - Any expert can advise or implement based on task
 4. **Synthesize, don't passthrough** - Claude interprets expert output, applies judgment
 5. **Proactive triggers** - Claude checks for delegation triggers on every message
+6. **Opt-in session store** - `consensus`/`ask-all` runs persist only when `sessions.persist` is on (default off); per-file JSON at `<XDG cache>/deliberation/sessions/` (override `DELIBERATION_SESSIONS`), secrets scrubbed, retention by count + age (`-1` = unlimited). Tools: `session-get`/`session-revisit`/`session-annotate`. Details in [TECHNICAL.md § Session persistence](TECHNICAL.md#session-persistence).
 
 ## Commit Conventions & Releases
 

--- a/POWER.md
+++ b/POWER.md
@@ -48,7 +48,15 @@ tools to apply one persona to every delegate):
 - `researcher` - external libraries, APIs, and best practices, with evidence.
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
-Every tool takes a `prompt`. Give it full context: the goal, the relevant code
+Session tools (only useful when `sessions.persist` is enabled in config; they report
+"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
+
+- `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
+- `session-revisit { sessionId }` - re-run the recorded question with the current
+  providers/config and save a linked child record.
+- `session-annotate { sessionId, note }` - append a note to a run's audit trail.
+
+Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code
 or paths, and any prior attempts. The experts do not share your session, so a
 self-contained prompt gets a better answer.
 

--- a/README.md
+++ b/README.md
@@ -260,11 +260,12 @@ truth: changes to `models`, `routing`, or the `providers.openrouter` block hot-r
 without restarting Claude Code. Toggling a built-in provider (codex / gemini / grok)
 still requires `/setup`.
 
-The config has four sections: `providers` (transport / connection per provider),
-`models` (named model records keyed by id), `routing` (fan-out policy), and
+The config has five sections: `providers` (transport / connection per provider),
+`models` (named model records keyed by id), `routing` (fan-out policy),
 `consensus` (`arbiter` = who synthesizes the verdict; optional `blindVote` for a blind
-arbiter pre-vote). The `$schema` key gives editors validation and autocomplete - VS Code
-needs no extension.
+arbiter pre-vote), and `sessions` (opt-in run persistence; default off - see
+[Session persistence](#session-persistence)). The `$schema` key gives editors validation
+and autocomplete - VS Code needs no extension.
 
 Minimal example:
 
@@ -300,7 +301,8 @@ Minimal example:
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true }
+  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true },
+  "sessions": { "persist": false, "maxRecords": 200, "maxAgeDays": 30 }
 }
 ```
 
@@ -326,6 +328,38 @@ For the full schema, the `$schema` / VS Code validation story, apiBase override 
 (Ollama, vLLM, LM Studio, HuggingFace), file-attachment caps, session model persistence,
 consensus cost model, and error kinds, see
 [TECHNICAL.md - OpenRouter bridge](TECHNICAL.md#openrouter-bridge).
+
+### Session persistence
+
+Opt-in, **default off**: nothing about your questions or results is written to disk
+unless you turn it on. Enable it with a `sessions` block in the config:
+
+```json
+"sessions": { "persist": true, "maxRecords": 200, "maxAgeDays": 30 }
+```
+
+- `persist` (boolean, default `false`) - when true, each `/consensus` and `/ask-all`
+  run is saved as one JSON file and the tool result includes a `sessionId`. When off,
+  the `session-*` tools report "persistence disabled".
+- `maxRecords` (default `200`) - keep at most this many newest records; older ones are
+  trimmed after each write. Use `-1` for unlimited (never trim by count).
+- `maxAgeDays` (default `30`) - delete records older than this. Use `-1` for unlimited
+  (never delete by age).
+
+Records live at `<XDG cache>/deliberation/sessions/<id>.json` (macOS/Linux:
+`~/.cache/deliberation/sessions`; Windows: `%LOCALAPPDATA%\deliberation\sessions`),
+written atomically with mode `0600`. Override the directory with `DELIBERATION_SESSIONS`.
+API-key shapes are scrubbed and each opinion/verdict is capped (~100 KB) before writing;
+attachment **paths** are stored (scrubbed), never file bodies.
+
+Three MCP tools operate on the store (they appear always but report "disabled" until
+`persist` is on): `session-get` (fetch a record), `session-revisit` (re-run a record's
+original question with the *current* providers/config and save a linked child record),
+and `session-annotate` (append a note to the audit trail). Full details:
+[TECHNICAL.md - Session persistence](TECHNICAL.md#session-persistence).
+
+> Distinct from "session model persistence" above, which is OpenRouter multi-turn
+> (`threadId`) reuse - unrelated to this on-disk store.
 
 For provider defaults, environment variables, and manual MCP setup, see [TECHNICAL.md](TECHNICAL.md#environment-variables).
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -16,6 +16,7 @@ and the Gemini recovery paths.
 - [Gemini timeout recovery](#gemini-timeout-recovery)
 - [Grok files and cleanup](#grok-files-and-cleanup)
 - [OpenRouter bridge](#openrouter-bridge)
+- [Session persistence](#session-persistence)
 - [Customizing expert prompts](#customizing-expert-prompts)
 - [Troubleshooting](#troubleshooting)
 - [Known limitations](#known-limitations)
@@ -142,6 +143,7 @@ This is the single source of truth for the bridge environment variables.
 | `XAI_API_BASE` | Grok | `https://api.x.ai/v1` | API endpoint override |
 | `GROK_REASONING_EFFORT` | Grok | `high` | `low`/`medium`/`high`; `none` or `off` omits the field |
 | `GROK_FILE_TTL_SECONDS` | Grok | `604800` (7 days) | Upload lifetime, clamped 1h..30d |
+| `DELIBERATION_SESSIONS` | sessions | `<XDG cache>/deliberation/sessions` | Override the session store directory (see [Session persistence](#session-persistence)) |
 
 Codex has no bridge environment variables: it ships its own native MCP server and
 reads `~/.codex/config.toml` directly. The **model** comes from the `model` key in
@@ -637,6 +639,76 @@ token count. There is no hard spend cap - the warning is informational only.
 | `model-not-allowed` | Requested alias is not in the config, or a raw `model` was passed with `allowRawModel:false`, or no alias/model was given and no `defaultModel` is set |
 | `unknown-thread` | `-reply` called with a threadId that does not exist |
 | `unknown` | Catch-all for unclassified errors |
+
+## Session persistence
+
+An opt-in, single-user local store that records each `/consensus` and `/ask-all`
+run so it can be fetched, re-run, and annotated later. Default OFF - nothing is
+written to disk unless `sessions.persist` is true. Implemented in `core/sessions.js`
+(synchronous, zero-dep); the store directory is resolved by `resolveSessionsDir` in
+`core/paths.js`; config is validated by `resolveSessions` in
+`server/openrouter/config.js`; the MCP wiring lives in `server/mcp/index.js`.
+
+### Configuration
+
+```json
+"sessions": { "persist": false, "maxRecords": 200, "maxAgeDays": 30 }
+```
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `persist` | boolean | `false` | Save each run and return a `sessionId`. Non-boolean degrades to `false` + warning. |
+| `maxRecords` | integer | `200` | Keep at most this many newest records. `-1` = unlimited (never trim by count). `0`/invalid -> default + warning. |
+| `maxAgeDays` | integer | `30` | Delete records older than this. `-1` = unlimited (never delete by age). `0`/invalid -> default + warning. |
+
+Validation soft-degrades: a bad value never rejects the config, it falls back to the
+default and the reason rides the same `consensusWarnings` channel the bridge already
+surfaces.
+
+### Store layout
+
+- One JSON file per session at `<dir>/<id>.json`, where `<dir>` is
+  `DELIBERATION_SESSIONS` if set, else `<XDG cache>/deliberation/sessions` (macOS/Linux
+  `~/.cache/...`; Windows `%LOCALAPPDATA%\...`).
+- Written atomically: the temp file is created with mode `0600` directly (no
+  world-readable window), then renamed into place; a failed rename removes the temp.
+- No global lock - each file is independent. The only read-modify-write is
+  `session-annotate` on one file, documented last-writer-wins (fine for a local
+  single-user stdio server).
+- Retention runs after every write: delete by age, then trim by count (both honoring
+  `-1` = unlimited). Orphaned `<id>.json.tmp.<pid>.<ts>` fragments older than an hour
+  are also reaped.
+
+### Record shape (`schemaVersion: 1`)
+
+```
+{ id, parentId|null, schemaVersion: 1, createdAt: <ISO>,
+  tool: "consensus"|"ask-all", question, expert|null,
+  files: [{ path|dir|file_id|file_url, mode? }]|null,   // attachment REFS, never bodies
+  opinions: [{ provider, model, text }],
+  blindVerdict|null, verdict|null,
+  arbiter: { mode, provider }|null, warnings: [], annotations: [{ note, at }] }
+```
+
+Before writing, `scrubSecrets` redacts common key shapes (OpenAI `sk-`, OpenRouter
+`sk-or-`, xAI `xai-`, GitHub `gh[pousr]_`, AWS `AKIA`, Google `AIza`, and `Bearer`
+tokens) in the question, opinion/verdict text, `warnings`, annotation notes, and the
+file `path`/`dir` strings; each opinion/verdict is capped at ~100 KB. Scrubbing is
+best-effort - user transcript text may still carry secrets in unrecognized shapes.
+
+### Tools
+
+Each takes its own input schema (no `prompt`), and reports
+`"session persistence is disabled (set sessions.persist)"` when off.
+
+| Tool | Input | Effect |
+|------|-------|--------|
+| `session-get` | `{ sessionId }` | Return the record, or a not-found message. Read-only. |
+| `session-revisit` | `{ sessionId, cwd? }` | Re-run the record's original question (and its file refs) with the CURRENT providers/config, write a CHILD record (`parentId` = original id), return the new `sessionId` + result. Re-run, not snapshot-replay. |
+| `session-annotate` | `{ sessionId, note }` | Append `{ note, at }` to the record's audit trail and rewrite the file. |
+
+When `persist` is on, `consensus` and `ask-all` also include a top-level `sessionId`
+in their result.
 
 ## Customizing expert prompts
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -57,6 +57,21 @@ else
   CFG="$XDG_BASE/deliberation/config.json"
 fi
 
+# --- sessions store dir: env override > canonical XDG cache ---
+# Mirrors core/paths.js resolveSessionsDir / canonicalCacheDir: DELIBERATION_SESSIONS
+# wins; else ${XDG_CACHE_HOME or ~/.cache}/deliberation/sessions. A RELATIVE
+# XDG_CACHE_HOME is ignored (XDG spec) and the default used.
+if [ -n "${DELIBERATION_SESSIONS:-}" ]; then
+  SESSIONS_DIR="$DELIBERATION_SESSIONS"
+else
+  if [ -n "${XDG_CACHE_HOME:-}" ] && [ "${XDG_CACHE_HOME#/}" != "${XDG_CACHE_HOME}" ]; then
+    CACHE_BASE="$XDG_CACHE_HOME"
+  else
+    CACHE_BASE="$HOME/.cache"
+  fi
+  SESSIONS_DIR="$CACHE_BASE/deliberation/sessions"
+fi
+
 # --- seed a default config on first run (never clobber an existing file) ---
 # Codex/Gemini/Grok enabled; OpenRouter disabled with two example model records
 # (also disabled). Edit $CFG to turn OpenRouter / the models on, then re-run setup.
@@ -91,6 +106,11 @@ openrouter_enabled() {
 }
 or_key_env() {
   json_eval 'try{const c=require(process.argv[1]);const p=(c.providers&&c.providers.openrouter)||{};process.stdout.write(p.apiKeyEnv||"OPENROUTER_API_KEY")}catch(e){process.stdout.write("OPENROUTER_API_KEY")}'
+}
+# sessions: "ON|OFF" + max records + max age, rendering -1 as "unlimited". Missing
+# config or block => default OFF / 200 / 30d. Output shape: "<ON|OFF>|<recs>|<age>".
+sessions_summary() {
+  json_eval 'try{const c=require(process.argv[1]);const s=c.sessions||{};const on=s.persist===true?"ON":"OFF";const mr=Number.isInteger(s.maxRecords)?s.maxRecords:200;const md=Number.isInteger(s.maxAgeDays)?s.maxAgeDays:30;const recs=mr===-1?"unlimited":String(mr);const age=md===-1?"unlimited":md+"d";process.stdout.write(on+"|"+recs+"|"+age)}catch(e){process.stdout.write("OFF|200|30d")}'
 }
 
 remove_mcp() {
@@ -140,6 +160,10 @@ echo "Antigravity CLI: $AGY_STATUS"
 echo "Config file:     $CFG"
 [ "$CONFIG_CREATED" = "1" ] && echo "                 (created from default - codex/gemini/grok on, OpenRouter off, 2 example models off)"
 echo "                 Edit it to enable OpenRouter and the example models, then re-run /deliberation:setup."
+SESS="$(sessions_summary)"; SESS_STATE="${SESS%%|*}"; SESS_REST="${SESS#*|}"; SESS_RECS="${SESS_REST%%|*}"; SESS_AGE="${SESS_REST#*|}"
+echo "Sessions:        persistence $SESS_STATE (opt-in; default OFF)"
+[ "$SESS_STATE" = "OFF" ] && echo "                 turn on: set \"sessions\": { \"persist\": true } in $CFG"
+echo "                 store: $SESSIONS_DIR (max records: $SESS_RECS, max age: $SESS_AGE; -1 = unlimited)"
 echo "Rules:           $RULE_COUNT files in ~/.claude/rules/deliberation/"
 echo "Grok auth:       $([ -n "${XAI_API_KEY:-}" ] && echo "XAI_API_KEY set" || echo "XAI_API_KEY not set (calls return missing-auth)")"
 echo "OpenRouter auth: $([ -n "${OPENROUTER_API_KEY:-}" ] && echo set || echo "not set")"

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -29,5 +29,6 @@
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": "auto", "blindVote": false }
+  "consensus": { "arbiter": "auto", "blindVote": false },
+  "sessions": { "persist": false, "maxRecords": 200, "maxAgeDays": 30 }
 }

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -86,6 +86,30 @@
           "description": "Run a blind arbiter pre-vote (the arbiter answers the question cold, before seeing peer opinions) to reduce anchoring. Server/concrete-arbiter mode only; adds one extra arbiter call."
         }
       }
+    },
+    "sessions": {
+      "type": "object",
+      "description": "Opt-in per-session persistence (decision records + revisit + audit trail). Default OFF; nothing is written to disk unless persist is true.",
+      "additionalProperties": false,
+      "properties": {
+        "persist": {
+          "type": "boolean",
+          "default": false,
+          "description": "Persist consensus/ask-all runs to <cache>/deliberation/sessions/<id>.json (atomic write, mode 0600). Default OFF."
+        },
+        "maxRecords": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 200,
+          "description": "Keep at most this many newest records; older ones are trimmed after each write."
+        },
+        "maxAgeDays": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 30,
+          "description": "Delete records older than this many days after each write."
+        }
+      }
     }
   },
   "$defs": {

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -72,7 +72,7 @@
               "properties": {
                 "model": {
                   "type": "string",
-                  "description": "id of a models record to use as the arbiter (any record, even askAll:false / consensus:false).",
+                  "description": "id of one of THIS config's `models` records to use as the arbiter (a local record id, not an OpenRouter model slug). Any record qualifies, even askAll:false / consensus:false. An id that is not a configured record soft-degrades to \"auto\" at runtime with a warning.",
                   "examples": ["claude-arb"]
                 }
               }

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -99,15 +99,15 @@
         },
         "maxRecords": {
           "type": "integer",
-          "minimum": 1,
+          "anyOf": [{ "const": -1 }, { "minimum": 1 }],
           "default": 200,
-          "description": "Keep at most this many newest records; older ones are trimmed after each write."
+          "description": "Keep at most this many newest records; older ones are trimmed after each write. Use -1 for unlimited (never trim by count)."
         },
         "maxAgeDays": {
           "type": "integer",
-          "minimum": 1,
+          "anyOf": [{ "const": -1 }, { "minimum": 1 }],
           "default": 30,
-          "description": "Delete records older than this many days after each write."
+          "description": "Delete records older than this many days after each write. Use -1 for unlimited (never delete by age)."
         }
       }
     }

--- a/core/paths.js
+++ b/core/paths.js
@@ -14,6 +14,7 @@
  * Exports:
  *   - resolveConfigPath(opts?)    -> DELIBERATION_CONFIG override else canonical config.json
  *   - resolveGrokCachePath(opts?) -> DELIBERATION_CACHE override else canonical grok-files.json
+ *   - resolveSessionsDir(opts?)   -> DELIBERATION_SESSIONS override else canonical sessions/ dir
  *
  * Both accept an optional `{ home, env, platform }` injection so callers (and
  * tests) can point at a temp HOME, a fake env, and a fixed platform without
@@ -151,7 +152,32 @@ function resolveGrokCachePath(opts) {
   return path.join(canonicalCacheDir(home, env, platform), "grok-files.json");
 }
 
+/**
+ * Resolve the absolute path to the sessions DIR the caller should use for the
+ * opt-in per-session store (core/sessions.js).
+ *
+ * Precedence:
+ *   1. DELIBERATION_SESSIONS if non-empty -> return it verbatim.
+ *   2. Else `<canonicalCacheDir>/sessions`.
+ *
+ * Pure path logic - no FS access, no side effects.
+ *
+ * @param {ResolveOptions} [opts]
+ * @returns {string} absolute path to the sessions directory to use
+ */
+function resolveSessionsDir(opts) {
+  const { home, env, platform } = resolveInjection(opts);
+
+  const override = env.DELIBERATION_SESSIONS;
+  if (typeof override === "string" && override.length > 0) {
+    return override;
+  }
+
+  return path.join(canonicalCacheDir(home, env, platform), "sessions");
+}
+
 module.exports = {
   resolveConfigPath,
   resolveGrokCachePath,
+  resolveSessionsDir,
 };

--- a/core/sessions.js
+++ b/core/sessions.js
@@ -81,17 +81,25 @@ function scrubSecrets(text) {
   if (typeof text !== "string" || text.length === 0) return text;
   return text
     // Leading \b so a key embedded in a normal word (e.g. "risk-analysis" ->
-    // "sk-analysis") is NOT matched. OpenRouter (sk-or-) BEFORE OpenAI (sk-) so the
-    // more specific shape wins.
-    .replace(/\bsk-or-[A-Za-z0-9_-]{8,}/g, "[REDACTED]")
-    .replace(/\bsk-[A-Za-z0-9_-]{8,}/g, "[REDACTED]")
+    // "sk-analysis") is NOT matched. {20,} (not {8,}) so short hyphenated terms
+    // (e.g. "sk-folding-cube", "xai-explainability") are not mistaken for keys -
+    // real OpenAI/OpenRouter/xAI keys are well over 20 chars. OpenRouter (sk-or-)
+    // BEFORE OpenAI (sk-) so the more specific shape wins.
+    .replace(/\bsk-or-[A-Za-z0-9_-]{20,}/g, "[REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}/g, "[REDACTED]")
     // xAI keys.
-    .replace(/\bxai-[A-Za-z0-9_-]{8,}/g, "[REDACTED]")
+    .replace(/\bxai-[A-Za-z0-9_-]{20,}/g, "[REDACTED]")
+    // GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_) and AWS access key ids (AKIA...).
+    .replace(/\bgh[pousr]_[A-Za-z0-9]{20,}/g, "[REDACTED]")
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED]")
     // Google API keys: AIza + >=35 chars. {35,} (not {35}) so a longer-than-39
     // key cannot leak its tail; over-matching only redacts MORE, never less.
     .replace(/\bAIza[0-9A-Za-z_-]{35,}/g, "[REDACTED]")
-    // Generic `Bearer <token>` headers.
-    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer [REDACTED]");
+    // `Bearer <token>` headers. No `i` flag (HTTP uses capital "Bearer") so the
+    // English word "bearer" is not matched; {20,} min + base64/base64url charset
+    // (+ / ~ -) and optional = padding so a real token is fully redacted, not
+    // partially leaked.
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/-]{20,}={0,2}/g, "Bearer [REDACTED]");
 }
 
 /**
@@ -149,6 +157,19 @@ function sanitizeRecord(record) {
   if (record.blindVerdict != null) out.blindVerdict = capText(scrubSecrets(String(record.blindVerdict)));
   if (Array.isArray(record.files)) {
     out.files = record.files.map((f) => ({ path: scrubSecrets(String(f && f.path != null ? f.path : "")) }));
+  }
+  // warnings come from config/provider error channels and can echo a key in an
+  // error string; scrub them too (they would otherwise ride the spread untouched).
+  if (Array.isArray(record.warnings)) {
+    out.warnings = record.warnings.map((w) => scrubSecrets(String(w == null ? "" : w)));
+  }
+  // Defensive: a hand-built record could carry annotation notes; scrub them too
+  // (annotateSession already scrubs on append - this just makes write idempotent).
+  if (Array.isArray(record.annotations)) {
+    out.annotations = record.annotations.map((a) => ({
+      note: scrubSecrets(String(a && a.note != null ? a.note : "")),
+      at: a && a.at,
+    }));
   }
   return out;
 }
@@ -275,6 +296,21 @@ function pruneSessions(opts) {
   const md = opts.maxAgeDays;
   const maxRecords = typeof mr === "number" && Number.isInteger(mr) && mr > 0 ? mr : DEFAULT_MAX_RECORDS;
   const maxAgeDays = typeof md === "number" && Number.isInteger(md) && md > 0 ? md : DEFAULT_MAX_AGE_DAYS;
+  // Sweep orphaned temp files first. A crash between writeFileSync(tmp) and the
+  // rename leaves a `<id>.json.tmp.<pid>.<ts>` that listSessions ignores (non-.json),
+  // so nothing else would ever reap it. Only sweep ones older than an hour to avoid
+  // racing a write in flight from another process.
+  const TMP_REAP_MS = 60 * 60 * 1000;
+  try {
+    for (const name of fs.readdirSync(opts.dir)) {
+      if (!name.includes(".tmp.")) continue;
+      const p = path.join(opts.dir, name);
+      let mt;
+      try { mt = fs.statSync(p).mtimeMs; } catch { continue; }
+      if (Date.now() - mt > TMP_REAP_MS) removeFile(p);
+    }
+  } catch { /* missing dir: nothing to sweep */ }
+
   const entries = listSessions({ dir: opts.dir });
   const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
   let removed = 0;

--- a/core/sessions.js
+++ b/core/sessions.js
@@ -306,14 +306,18 @@ function removeFile(file) {
 /**
  * Delete records older than maxAgeDays, then trim to the newest maxRecords.
  * Called after each write. Best-effort + ENOENT-tolerant.
+ *
+ * `-1` means UNLIMITED for either limit (skip that retention rule): maxAgeDays:-1
+ * never deletes by age, maxRecords:-1 never trims by count. Any other non-positive
+ * or non-integer value falls back to the default.
  * @param {{dir:string, maxRecords?:number, maxAgeDays?:number}} opts
  * @returns {{removed:number}}
  */
 function pruneSessions(opts) {
   const mr = opts.maxRecords;
   const md = opts.maxAgeDays;
-  const maxRecords = typeof mr === "number" && Number.isInteger(mr) && mr > 0 ? mr : DEFAULT_MAX_RECORDS;
-  const maxAgeDays = typeof md === "number" && Number.isInteger(md) && md > 0 ? md : DEFAULT_MAX_AGE_DAYS;
+  const maxRecords = typeof mr === "number" && Number.isInteger(mr) && (mr === -1 || mr > 0) ? mr : DEFAULT_MAX_RECORDS;
+  const maxAgeDays = typeof md === "number" && Number.isInteger(md) && (md === -1 || md > 0) ? md : DEFAULT_MAX_AGE_DAYS;
   // Sweep orphaned temp files first. A crash between writeFileSync(tmp) and the
   // rename leaves a `<id>.json.tmp.<pid>.<ts>` that listSessions ignores (non-.json),
   // so nothing else would ever reap it. Only sweep ones older than an hour to avoid
@@ -330,19 +334,21 @@ function pruneSessions(opts) {
   } catch { /* missing dir: nothing to sweep */ }
 
   const entries = listSessions({ dir: opts.dir });
-  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  // maxAgeDays === -1 -> unlimited age: never delete by age (cutoff stays null).
+  const cutoff = maxAgeDays === -1 ? null : Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
   let removed = 0;
   /** @type {SessionListEntry[]} */
   const survivors = [];
   for (const e of entries) {
-    if (e.mtimeMs < cutoff) {
+    if (cutoff !== null && e.mtimeMs < cutoff) {
       if (removeFile(e.file)) removed++;
     } else {
       survivors.push(e);
     }
   }
-  // survivors stays newest-first; trim the tail beyond maxRecords.
-  if (survivors.length > maxRecords) {
+  // survivors stays newest-first; trim the tail beyond maxRecords. maxRecords === -1
+  // -> unlimited count: never trim.
+  if (maxRecords !== -1 && survivors.length > maxRecords) {
     for (const e of survivors.slice(maxRecords)) {
       if (removeFile(e.file)) removed++;
     }

--- a/core/sessions.js
+++ b/core/sessions.js
@@ -1,0 +1,335 @@
+"use strict";
+
+/**
+ * core/sessions.js - opt-in per-session store for deliberation.
+ *
+ * Zero runtime dependencies (node builtins only). SYNCHRONOUS API to match
+ * core/paths.js and server/grok/cache.js. JSDoc-typed so it passes strict `tsc`
+ * (it is inside the strict tsconfig include).
+ *
+ * One JSON file per session at `<dir>/<id>.json`, written atomically
+ * (temp -> rename) with mode 0600. No global lock - each file is independent;
+ * the only read-modify-write race is `annotateSession` on ONE file, documented
+ * last-writer-wins (acceptable for a local single-user stdio server).
+ *
+ * SECURITY: `scrubSecrets` is best-effort. User-provided transcript text may
+ * still carry secrets in shapes this does not recognize.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+/** Current on-disk record shape version. 1a enrichment will bump this. */
+const SCHEMA_VERSION = 1;
+/** Anchored id guard: rejects `../`, dots, slashes - no path traversal. */
+const ID_RE = /^[A-Za-z0-9-]+$/;
+/** ~100 KB cap per stored opinion/verdict text, so a runaway response can't bloat the store. */
+const MAX_TEXT_BYTES = 100 * 1024;
+
+const DEFAULT_MAX_RECORDS = 200;
+const DEFAULT_MAX_AGE_DAYS = 30;
+
+/**
+ * @typedef {Object} SessionOpinion
+ * @property {string} provider
+ * @property {string} [model]
+ * @property {string} [text]
+ */
+
+/**
+ * @typedef {Object} SessionFileRef
+ * @property {string} path  attachment ref (path only, scrubbed) - NOT the body
+ */
+
+/**
+ * @typedef {Object} SessionAnnotation
+ * @property {string} note
+ * @property {string} at  ISO timestamp
+ */
+
+/**
+ * @typedef {Object} SessionArbiter
+ * @property {string} mode
+ * @property {(string|null)} [provider]
+ */
+
+/**
+ * @typedef {Object} SessionRecord
+ * @property {string} id
+ * @property {(string|null)} parentId
+ * @property {number} schemaVersion
+ * @property {string} createdAt  ISO timestamp
+ * @property {("consensus"|"ask-all")} tool
+ * @property {string} question
+ * @property {(string|null)} [expert]
+ * @property {(SessionFileRef[]|null)} [files]
+ * @property {SessionOpinion[]} opinions
+ * @property {(string|null)} [blindVerdict]
+ * @property {(string|null)} [verdict]
+ * @property {(SessionArbiter|null)} [arbiter]
+ * @property {string[]} [warnings]
+ * @property {SessionAnnotation[]} [annotations]
+ */
+
+/**
+ * Redact common API-key shapes from a string. Best-effort - see module note.
+ * @param {string} text
+ * @returns {string}
+ */
+function scrubSecrets(text) {
+  if (typeof text !== "string" || text.length === 0) return text;
+  return text
+    // Leading \b so a key embedded in a normal word (e.g. "risk-analysis" ->
+    // "sk-analysis") is NOT matched. OpenRouter (sk-or-) BEFORE OpenAI (sk-) so the
+    // more specific shape wins.
+    .replace(/\bsk-or-[A-Za-z0-9_-]{8,}/g, "[REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}/g, "[REDACTED]")
+    // xAI keys.
+    .replace(/\bxai-[A-Za-z0-9_-]{8,}/g, "[REDACTED]")
+    // Google API keys: AIza + >=35 chars. {35,} (not {35}) so a longer-than-39
+    // key cannot leak its tail; over-matching only redacts MORE, never less.
+    .replace(/\bAIza[0-9A-Za-z_-]{35,}/g, "[REDACTED]")
+    // Generic `Bearer <token>` headers.
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer [REDACTED]");
+}
+
+/**
+ * Cap text at MAX_TEXT_BYTES (byte-aware so multibyte text cannot exceed the
+ * cap); append a truncation note when cut.
+ * @param {string} text
+ * @returns {string}
+ */
+function capText(text) {
+  if (typeof text !== "string") return text;
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= MAX_TEXT_BYTES) return text;
+  const suffix = `\n\n[truncated: original ${buf.length} bytes]`;
+  // Reserve room for the suffix so the RETURNED string stays within the cap, and
+  // back up off any UTF-8 continuation byte so we never split a codepoint (which
+  // would otherwise emit a 3-byte U+FFFD and bloat past the budget).
+  let end = Math.max(0, MAX_TEXT_BYTES - Buffer.byteLength(suffix, "utf8"));
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end).toString("utf8") + suffix;
+}
+
+/**
+ * True only for a non-empty id matching the anchored safe-id shape.
+ * @param {unknown} id
+ * @returns {id is string}
+ */
+function isSafeId(id) {
+  return typeof id === "string" && ID_RE.test(id);
+}
+
+/** @returns {string} a fresh session id ([0-9a-f-], matches the safe-id guard). */
+function newSessionId() {
+  return crypto.randomUUID();
+}
+
+/**
+ * Scrub secrets + cap large text on a record before it is written. Returns a NEW
+ * record; never mutates the input. Applies to question, each opinion text,
+ * verdict, blindVerdict, and the `files[].path` refs.
+ * @param {SessionRecord} record
+ * @returns {SessionRecord}
+ */
+function sanitizeRecord(record) {
+  /** @type {SessionRecord} */
+  const out = { ...record };
+  out.question = scrubSecrets(String(record.question == null ? "" : record.question));
+  if (Array.isArray(record.opinions)) {
+    out.opinions = record.opinions.map((o) => ({
+      provider: o.provider,
+      model: o.model,
+      text: typeof o.text === "string" ? capText(scrubSecrets(o.text)) : undefined,
+    }));
+  }
+  if (record.verdict != null) out.verdict = capText(scrubSecrets(String(record.verdict)));
+  if (record.blindVerdict != null) out.blindVerdict = capText(scrubSecrets(String(record.blindVerdict)));
+  if (Array.isArray(record.files)) {
+    out.files = record.files.map((f) => ({ path: scrubSecrets(String(f && f.path != null ? f.path : "")) }));
+  }
+  return out;
+}
+
+/**
+ * Write a session record atomically as `<dir>/<id>.json`. Secrets are scrubbed
+ * and large text capped first. The temp file is created with mode 0600 DIRECTLY
+ * (not write-then-chmod, which would leave a world-readable window). Prunes the
+ * store after the write.
+ * @param {SessionRecord} record  must carry a safe `id`
+ * @param {{dir:string, maxRecords?:number, maxAgeDays?:number}} opts
+ * @returns {string} the written id
+ */
+function writeSession(record, opts) {
+  const dir = opts.dir;
+  const id = record.id;
+  if (!isSafeId(id)) throw new Error(`unsafe session id: ${String(id)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  const json = JSON.stringify(sanitizeRecord(record));
+  const dest = path.join(dir, `${id}.json`);
+  const tmp = `${dest}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, json, { mode: 0o600 });
+  try {
+    fs.renameSync(tmp, dest);
+  } catch (e) {
+    // A failed rename would otherwise orphan the temp file (listSessions/prune
+    // ignore non-.json names, so it would never be cleaned up). Remove it, then
+    // surface the original error.
+    removeFile(tmp);
+    throw e;
+  }
+  pruneSessions({ dir, maxRecords: opts.maxRecords, maxAgeDays: opts.maxAgeDays });
+  return id;
+}
+
+/**
+ * Read + parse a session record. Returns null when the id is unsafe, the file is
+ * absent, or the JSON is corrupt - never throws on those.
+ * @param {string} id
+ * @param {{dir:string}} opts
+ * @returns {(SessionRecord|null)}
+ */
+function readSession(id, opts) {
+  if (!isSafeId(id)) return null;
+  const file = path.join(opts.dir, `${id}.json`);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const obj = JSON.parse(raw);
+    if (obj && typeof obj === "object") return /** @type {SessionRecord} */ (obj);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @typedef {Object} SessionListEntry
+ * @property {string} id
+ * @property {string} file
+ * @property {number} mtimeMs
+ */
+
+/**
+ * List records newest-first by mtime. A missing dir yields []. Best-effort: a
+ * file that disappears mid-listing is skipped.
+ * @param {{dir:string}} opts
+ * @returns {SessionListEntry[]}
+ */
+function listSessions(opts) {
+  const dir = opts.dir;
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  /** @type {SessionListEntry[]} */
+  const out = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const id = name.slice(0, -5);
+    if (!isSafeId(id)) continue;
+    const file = path.join(dir, name);
+    let mtimeMs;
+    try {
+      mtimeMs = fs.statSync(file).mtimeMs;
+    } catch {
+      continue;
+    }
+    out.push({ id, file, mtimeMs });
+  }
+  out.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return out;
+}
+
+/**
+ * Best-effort, ENOENT-tolerant delete. A concurrent prune racing on the same
+ * file never throws (rmSync force:true).
+ * @param {string} file
+ * @returns {boolean} true when a delete call succeeded
+ */
+function removeFile(file) {
+  try {
+    fs.rmSync(file, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete records older than maxAgeDays, then trim to the newest maxRecords.
+ * Called after each write. Best-effort + ENOENT-tolerant.
+ * @param {{dir:string, maxRecords?:number, maxAgeDays?:number}} opts
+ * @returns {{removed:number}}
+ */
+function pruneSessions(opts) {
+  const mr = opts.maxRecords;
+  const md = opts.maxAgeDays;
+  const maxRecords = typeof mr === "number" && Number.isInteger(mr) && mr > 0 ? mr : DEFAULT_MAX_RECORDS;
+  const maxAgeDays = typeof md === "number" && Number.isInteger(md) && md > 0 ? md : DEFAULT_MAX_AGE_DAYS;
+  const entries = listSessions({ dir: opts.dir });
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  let removed = 0;
+  /** @type {SessionListEntry[]} */
+  const survivors = [];
+  for (const e of entries) {
+    if (e.mtimeMs < cutoff) {
+      if (removeFile(e.file)) removed++;
+    } else {
+      survivors.push(e);
+    }
+  }
+  // survivors stays newest-first; trim the tail beyond maxRecords.
+  if (survivors.length > maxRecords) {
+    for (const e of survivors.slice(maxRecords)) {
+      if (removeFile(e.file)) removed++;
+    }
+  }
+  return { removed };
+}
+
+/**
+ * Append an annotation to an existing record and rewrite it. Returns the updated
+ * record, or null when the id is unsafe/unknown. Last-writer-wins (documented;
+ * single-user local server).
+ * @param {string} id
+ * @param {string} note
+ * @param {{dir:string, at?:string, maxRecords?:number, maxAgeDays?:number}} opts
+ * @returns {(SessionRecord|null)}
+ */
+function annotateSession(id, note, opts) {
+  const rec = readSession(id, { dir: opts.dir });
+  if (!rec) return null;
+  const at = typeof opts.at === "string" && opts.at ? opts.at : new Date().toISOString();
+  const annotations = Array.isArray(rec.annotations) ? rec.annotations.slice() : [];
+  annotations.push({ note: capText(scrubSecrets(String(note == null ? "" : note))), at });
+  /** @type {SessionRecord} */
+  const updated = { ...rec, annotations };
+  writeSession(updated, { dir: opts.dir, maxRecords: opts.maxRecords, maxAgeDays: opts.maxAgeDays });
+  return updated;
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  MAX_TEXT_BYTES,
+  DEFAULT_MAX_RECORDS,
+  DEFAULT_MAX_AGE_DAYS,
+  scrubSecrets,
+  capText,
+  sanitizeRecord,
+  isSafeId,
+  newSessionId,
+  writeSession,
+  readSession,
+  listSessions,
+  pruneSessions,
+  annotateSession,
+};

--- a/core/sessions.js
+++ b/core/sessions.js
@@ -24,6 +24,8 @@ const crypto = require("node:crypto");
 const SCHEMA_VERSION = 1;
 /** Anchored id guard: rejects `../`, dots, slashes - no path traversal. */
 const ID_RE = /^[A-Za-z0-9-]+$/;
+/** Exact shape of a write temp file (`<id>.json.tmp.<pid>.<ms>`) - reaped if orphaned. */
+const TMP_RE = /^[A-Za-z0-9-]+\.json\.tmp\.\d+\.\d+$/;
 /** ~100 KB cap per stored opinion/verdict text, so a runaway response can't bloat the store. */
 const MAX_TEXT_BYTES = 100 * 1024;
 
@@ -38,8 +40,15 @@ const DEFAULT_MAX_AGE_DAYS = 30;
  */
 
 /**
+ * Input attachment REF (never the body). Mirrors the request FileRef shape so a
+ * revisit re-runs with the same context regardless of ref kind. Location strings
+ * (path/dir) are scrubbed; file_id/file_url/mode pass through.
  * @typedef {Object} SessionFileRef
- * @property {string} path  attachment ref (path only, scrubbed) - NOT the body
+ * @property {string} [path]
+ * @property {string} [dir]
+ * @property {string} [file_id]
+ * @property {string} [file_url]
+ * @property {string} [mode]
  */
 
 /**
@@ -156,7 +165,16 @@ function sanitizeRecord(record) {
   if (record.verdict != null) out.verdict = capText(scrubSecrets(String(record.verdict)));
   if (record.blindVerdict != null) out.blindVerdict = capText(scrubSecrets(String(record.blindVerdict)));
   if (Array.isArray(record.files)) {
-    out.files = record.files.map((f) => ({ path: scrubSecrets(String(f && f.path != null ? f.path : "")) }));
+    out.files = record.files.map((f) => {
+      /** @type {SessionFileRef} */
+      const ref = {};
+      if (f && typeof f.path === "string") ref.path = scrubSecrets(f.path);
+      if (f && typeof f.dir === "string") ref.dir = scrubSecrets(f.dir);
+      if (f && typeof f.file_id === "string") ref.file_id = f.file_id;
+      if (f && typeof f.file_url === "string") ref.file_url = f.file_url;
+      if (f && typeof f.mode === "string") ref.mode = f.mode;
+      return ref;
+    });
   }
   // warnings come from config/provider error channels and can echo a key in an
   // error string; scrub them too (they would otherwise ride the spread untouched).
@@ -303,7 +321,7 @@ function pruneSessions(opts) {
   const TMP_REAP_MS = 60 * 60 * 1000;
   try {
     for (const name of fs.readdirSync(opts.dir)) {
-      if (!name.includes(".tmp.")) continue;
+      if (!TMP_RE.test(name)) continue; // only OUR write temps, not any ".tmp." file
       const p = path.join(opts.dir, name);
       let mt;
       try { mt = fs.statSync(p).mtimeMs; } catch { continue; }

--- a/plugins/deliberation/skills/deliberation/SKILL.md
+++ b/plugins/deliberation/skills/deliberation/SKILL.md
@@ -45,7 +45,15 @@ tools to apply one persona to every delegate):
 - `researcher` - external libraries, APIs, and best practices, with evidence.
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
-Every tool takes a `prompt`. Give it full context: the goal, the relevant code
+Session tools (only useful when `sessions.persist` is enabled in config; they report
+"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
+
+- `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
+- `session-revisit { sessionId }` - re-run the recorded question with the current
+  providers/config and save a linked child record.
+- `session-annotate { sessionId, note }` - append a note to a run's audit trail.
+
+Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code
 or paths, and any prior attempts. The experts do not share your session, so a
 self-contained prompt gets a better answer.
 

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -266,13 +266,21 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
     return jsonResult({ error: `session not found: ${String(id)}` });
   }
 
-  /** @param {any} files @returns {({path:string}[]|null)} input attachment REFS only (paths), never bodies */
+  /** @param {any} files @returns {(any[]|null)} input attachment REFS only (never bodies); preserves path/dir/file_id/file_url/mode so a revisit re-runs with the same context regardless of ref kind */
   function refsFromFiles(files) {
     if (!Array.isArray(files)) return null;
-    /** @type {{path:string}[]} */
+    /** @type {any[]} */
     const refs = [];
     for (const f of files) {
-      if (f && typeof f.path === "string") refs.push({ path: f.path });
+      if (!f || typeof f !== "object") continue;
+      /** @type {any} */
+      const ref = {};
+      if (typeof f.path === "string") ref.path = f.path;
+      if (typeof f.dir === "string") ref.dir = f.dir;
+      if (typeof f.file_id === "string") ref.file_id = f.file_id;
+      if (typeof f.file_url === "string") ref.file_url = f.file_url;
+      if (typeof f.mode === "string") ref.mode = f.mode;
+      if (Object.keys(ref).length) refs.push(ref);
     }
     return refs.length ? refs : null;
   }
@@ -464,8 +472,16 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       // Carry the original attachment REFS so the re-run sees the same file
       // context the parent did (paths were scrubbed on write).
       const childFiles = Array.isArray(rec.files) && rec.files.length ? rec.files : undefined;
+      // Build childReq EXPLICITLY from the persisted record (+ cwd) - do NOT spread
+      // `req`, or a raw caller could smuggle developerInstructions/reasoningEffort
+      // into the rerun even though session-revisit only advertises sessionId + cwd.
       /** @type {DelegationRequest} */
-      const childReq = { ...req, prompt: rec.question, expert: childExpert, files: childFiles };
+      const childReq = {
+        prompt: rec.question,
+        expert: childExpert,
+        files: childFiles,
+        cwd: typeof args.cwd === "string" ? args.cwd : undefined,
+      };
       const tool = rec.tool === "ask-all" ? "ask-all" : "consensus";
       const { payload, parts } = tool === "ask-all"
         ? await runAskAll(childReq, childExpert)

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -58,7 +58,10 @@ function inputSchema() {
 // Session tools take a sessionId (+ note for annotate), NOT a prompt - so they
 // need their OWN input schemas rather than the prompt-required inputSchema().
 function sessionGetInputSchema() {
-  return { type: "object", required: ["sessionId"], properties: { sessionId: { type: "string" } } };
+  // `cwd` is advertised (optional) so session-revisit can resolve the original
+  // file refs against the caller's workspace, not the server process dir. It
+  // flows through req.cwd -> childReq.cwd. session-get ignores it harmlessly.
+  return { type: "object", required: ["sessionId"], properties: { sessionId: { type: "string" }, cwd: { type: "string" } } };
 }
 function sessionAnnotateInputSchema() {
   return { type: "object", required: ["sessionId", "note"], properties: { sessionId: { type: "string" }, note: { type: "string" } } };

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -55,7 +55,17 @@ function inputSchema() {
   };
 }
 
+// Session tools take a sessionId (+ note for annotate), NOT a prompt - so they
+// need their OWN input schemas rather than the prompt-required inputSchema().
+function sessionGetInputSchema() {
+  return { type: "object", required: ["sessionId"], properties: { sessionId: { type: "string" } } };
+}
+function sessionAnnotateInputSchema() {
+  return { type: "object", required: ["sessionId", "note"], properties: { sessionId: { type: "string" }, note: { type: "string" } } };
+}
+
 function toolList() {
+  /** @type {any[]} */
   const tools = [
     { name: "ask-all", description: "Fan out one question to GPT, Gemini, Grok, and any configured OpenRouter models in parallel for independent second opinions, then return all results (advisory, no cross-contamination). Pass `expert` to apply a persona to every delegate.", inputSchema: inputSchema(), annotations: ADVISORY },
     { name: "consensus", description: "Fan out one question to all enabled providers, then run a single arbiter pass that cross-reviews the independent opinions and returns one synthesized verdict (advisory). Pass `expert` to apply a persona to the fan-out and arbiter.", inputSchema: inputSchema(), annotations: ADVISORY },
@@ -66,6 +76,10 @@ function toolList() {
   for (const e of EXPERTS) {
     tools.push({ name: e, description: EXPERT_DESCRIPTIONS[e], inputSchema: inputSchema(), annotations: ADVISORY });
   }
+  // Session store tools (opt-in; report "disabled" when sessions.persist is off).
+  tools.push({ name: "session-get", description: "Fetch a persisted consensus/ask-all session record by id (opinions, verdict, arbiter, annotations). Requires sessions.persist; advisory, read-only.", inputSchema: sessionGetInputSchema(), annotations: ADVISORY });
+  tools.push({ name: "session-revisit", description: "Re-run a persisted session's original question with the CURRENT providers/config and save a linked child record (parentId). Requires sessions.persist; advisory.", inputSchema: sessionGetInputSchema(), annotations: ADVISORY });
+  tools.push({ name: "session-annotate", description: "Append a freeform note to a persisted session's audit trail. Requires sessions.persist; writes to the local session store.", inputSchema: sessionAnnotateInputSchema() });
   return tools;
 }
 
@@ -174,9 +188,11 @@ async function isHealthy(p) {
  * @param {Provider[]} deps.providers
  * @param {() => any} deps.getConfig
  * @param {() => (string|null)} [deps.getConfigError]  // last config load error (e.g. JSON parse), or null
+ * @param {string} [deps.sessionsDir]  // dir for the opt-in session store; omit to disable persistence
  */
-function buildServer({ providers, getConfig, getConfigError }) {
+function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
   const registry = makeRegistry(providers);
+  const sessions = /** @type {any} */ (require("../../core/sessions.js"));
 
   // Client identity for arbiter-default selection. Connection-scoped: set from the
   // MCP `initialize` handshake (clientInfo.name) for the life of this stdio session.
@@ -215,6 +231,169 @@ function buildServer({ providers, getConfig, getConfigError }) {
     return { ...request, developerInstructions: persona };
   }
 
+  // --- session store wiring -------------------------------------------------
+  // Persistence is opt-in (sessions.persist) AND requires a configured dir. When
+  // either is missing, the session-* tools report "disabled" and the
+  // consensus/ask-all paths write nothing / return no sessionId.
+
+  /** @returns {{persist:boolean, maxRecords:number, maxAgeDays:number}} */
+  function sessionsCfg() {
+    const c = getConfig() || {};
+    const s = c.sessions || {};
+    return {
+      persist: !!s.persist,
+      maxRecords: typeof s.maxRecords === "number" ? s.maxRecords : sessions.DEFAULT_MAX_RECORDS,
+      maxAgeDays: typeof s.maxAgeDays === "number" ? s.maxAgeDays : sessions.DEFAULT_MAX_AGE_DAYS,
+    };
+  }
+  /** @returns {boolean} */
+  function persistEnabled() {
+    return !!sessionsDir && sessionsCfg().persist;
+  }
+
+  /** @param {any} obj @returns {{content:{type:string,text:string}[]}} */
+  function jsonResult(obj) {
+    return { content: [{ type: "text", text: JSON.stringify(obj) }] };
+  }
+  function disabledMsg() {
+    return jsonResult({ error: "session persistence is disabled (set sessions.persist)" });
+  }
+  /** @param {unknown} id */
+  function notFoundMsg(id) {
+    return jsonResult({ error: `session not found: ${String(id)}` });
+  }
+
+  /** @param {any} files @returns {({path:string}[]|null)} input attachment REFS only (paths), never bodies */
+  function refsFromFiles(files) {
+    if (!Array.isArray(files)) return null;
+    /** @type {{path:string}[]} */
+    const refs = [];
+    for (const f of files) {
+      if (f && typeof f.path === "string") refs.push({ path: f.path });
+    }
+    return refs.length ? refs : null;
+  }
+  /** @param {any} results @returns {{provider:string, model:string, text:(string|undefined)}[]} */
+  function opinionsFrom(results) {
+    if (!Array.isArray(results)) return [];
+    return results.map((r) => ({
+      provider: r && r.provider,
+      model: r && r.model,
+      text: r && r.isError === false && typeof r.text === "string" ? r.text : undefined,
+    }));
+  }
+  /** @param {any} result @returns {(string|null)} the verdict text, or null */
+  function textOf(result) {
+    if (!result) return null;
+    if (typeof result === "string") return result;
+    if (result.isError === false && typeof result.text === "string") return result.text;
+    return null;
+  }
+
+  /**
+   * Persist a completed run when persistence is on. Best-effort: a write failure
+   * never fails the tool call. Returns the new sessionId, or null when off.
+   * @param {("consensus"|"ask-all")} tool
+   * @param {DelegationRequest} req
+   * @param {string|undefined} expert
+   * @param {any} parts  // { opinions, blindVerdict?, verdict?, arbiter?, warnings?, parentId? }
+   * @returns {(string|null)}
+   */
+  function persistRun(tool, req, expert, parts) {
+    if (!persistEnabled()) return null;
+    const cfg = sessionsCfg();
+    const id = sessions.newSessionId();
+    const record = {
+      id,
+      parentId: parts.parentId == null ? null : parts.parentId,
+      schemaVersion: sessions.SCHEMA_VERSION,
+      createdAt: new Date().toISOString(),
+      tool,
+      question: typeof req.prompt === "string" ? req.prompt : "",
+      expert: expert || null,
+      files: refsFromFiles(req.files),
+      opinions: opinionsFrom(parts.opinions),
+      blindVerdict: textOf(parts.blindVerdict),
+      verdict: textOf(parts.verdict),
+      arbiter: parts.arbiter || null,
+      warnings: Array.isArray(parts.warnings) ? parts.warnings : [],
+      annotations: [],
+    };
+    try {
+      sessions.writeSession(record, { dir: sessionsDir, maxRecords: cfg.maxRecords, maxAgeDays: cfg.maxAgeDays });
+      return id;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Run the ask-all fan-out. Returns the response payload plus the parts needed
+   * to persist a record. Shared by the ask-all tool and session-revisit.
+   * @param {DelegationRequest} req
+   * @param {string|undefined} expert
+   * @returns {Promise<{payload:any, parts:any}>}
+   */
+  async function runAskAll(req, expert) {
+    const { providers: selected, omitted } = registry.selectForAskAll({ config: getConfig(), expert: expert || "" });
+    const results = await askAll(selected, withPersona(req, expert));
+    return {
+      payload: { results, omitted },
+      parts: { opinions: results, blindVerdict: null, verdict: null, arbiter: null, warnings: [] },
+    };
+  }
+
+  /**
+   * Run the consensus fan-out + arbiter resolution. Returns the response payload
+   * plus the parts needed to persist a record. Shared by the consensus tool and
+   * session-revisit.
+   * @param {DelegationRequest} req
+   * @param {string|undefined} expert
+   * @returns {Promise<{payload:any, parts:any}>}
+   */
+  async function runConsensus(req, expert) {
+    const cfg = getConfig() || {};
+    const { providers: selected } = registry.selectForConsensus({ config: cfg, expert: expert || "" });
+    const cc = cfg.consensus || {};
+    const arbiterSpec = cc.arbiterDefaulted ? (isClaudeHost() ? "host" : "auto") : (cc.arbiter || "auto");
+    const blindVote = !!cc.blindVote;
+    const warnings = Array.isArray(cfg.consensusWarnings) ? cfg.consensusWarnings.slice() : [];
+    const cfgErr = typeof getConfigError === "function" ? getConfigError() : null;
+    if (cfgErr) warnings.push(`config not loaded: ${cfgErr}`);
+
+    const resolved = await resolveArbiter(arbiterSpec, selected, registry, getConfig);
+    if (resolved.warning) warnings.push(resolved.warning);
+
+    if (resolved.mode === "host") {
+      const opinions = await askAll(selected, withPersona(req, expert));
+      const arbiter = { mode: "host" };
+      const body = { opinions, blindVerdict: null, verdict: null, arbiter, warnings };
+      return { payload: body, parts: body };
+    }
+
+    if (!resolved.provider) {
+      const out = await consensus(selected, withPersona(req, expert), { arbiterInstructions: PROMPTS.arbiter });
+      const arbiter = { mode: "server", provider: null };
+      return {
+        payload: { opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, error: out.error, arbiter, warnings },
+        parts: { opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, arbiter, warnings },
+      };
+    }
+
+    const arbiterP = resolved.provider;
+    let peers = selected.filter((p) => p.name !== arbiterP.name);
+    if (peers.length < 2) {
+      peers = selected;
+      warnings.push(`panel too small to exclude arbiter '${arbiterP.name}'; kept it in the peer panel (floor of 2)`);
+    }
+    const out = await consensus(peers, withPersona(req, expert), { arbiter: arbiterP, arbiterInstructions: PROMPTS.arbiter, blindVote });
+    const arbiter = { mode: "server", provider: arbiterP.name };
+    return {
+      payload: { opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, error: out.error, arbiter, warnings },
+      parts: { opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, arbiter, warnings },
+    };
+  }
+
   /**
    * @param {string} name
    * @param {any} args  // untrusted JSON-RPC tool arguments
@@ -239,56 +418,59 @@ function buildServer({ providers, getConfig, getConfigError }) {
     };
     if (name === "ask-all") {
       // selectForAskAll returns a FLAT provider list: enabled built-ins + per-alias OR wrappers.
-      const { providers: selected, omitted } = registry.selectForAskAll({ config: getConfig(), expert: expert || "" });
-      const results = await askAll(selected, withPersona(req, expert));
-      return { content: [{ type: "text", text: JSON.stringify({ results, omitted }) }] };
+      const { payload, parts } = await runAskAll(req, expert);
+      const sid = persistRun("ask-all", req, expert, parts);
+      if (sid) payload.sessionId = sid;
+      return jsonResult(payload);
     }
     if (name === "consensus") {
       // selectForConsensus returns a FLAT, uncapped voting panel. The arbiter is
       // resolved from config (host/auto/builtin/openrouter:<alias>) instead of the
-      // implicit providers[0], so any host can synthesize a real verdict.
-      const cfg = getConfig() || {};
-      const { providers: selected } = registry.selectForConsensus({ config: cfg, expert: expert || "" });
-      const cc = cfg.consensus || {};
-      // When the user did NOT set an arbiter (arbiterDefaulted), pick the default by
-      // host: Claude Code -> "host" (the host model synthesizes); any other host ->
-      // "auto" (a real server-side verdict). An explicit arbiter always wins.
-      const arbiterSpec = cc.arbiterDefaulted ? (isClaudeHost() ? "host" : "auto") : (cc.arbiter || "auto");
-      const blindVote = !!cc.blindVote;
-      const warnings = Array.isArray(cfg.consensusWarnings) ? cfg.consensusWarnings.slice() : [];
-      // Surface a config load/parse error (e.g. bad config.json) instead of
-      // silently swallowing it via getConfig()'s {} fallback.
-      const cfgErr = typeof getConfigError === "function" ? getConfigError() : null;
-      if (cfgErr) warnings.push(`config not loaded: ${cfgErr}`);
-
-      const resolved = await resolveArbiter(arbiterSpec, selected, registry, getConfig);
-      if (resolved.warning) warnings.push(resolved.warning);
-
-      if (resolved.mode === "host") {
-        // Host arbitrates: return opinions only, no server-side arbiter pass.
-        const opinions = await askAll(selected, withPersona(req, expert));
-        return { content: [{ type: "text", text: JSON.stringify({ opinions, blindVerdict: null, verdict: null, arbiter: { mode: "host" }, warnings }) }] };
-      }
-
-      if (!resolved.provider) {
-        // Server mode but no usable arbiter (empty / all-unhealthy panel). Route
-        // through consensus(selected, ...) so the documented all-providers-failed
-        // signal is preserved instead of masquerading as host mode.
-        const out = await consensus(selected, withPersona(req, expert), { arbiterInstructions: PROMPTS.arbiter });
-        return { content: [{ type: "text", text: JSON.stringify({ opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, error: out.error, arbiter: { mode: "server", provider: null }, warnings }) }] };
-      }
-
-      const arbiter = resolved.provider;
-      // Exclude the arbiter from the peer panel so it does not review its own
-      // opinion. Floor of 2: never shrink the panel below two voices - if removing
-      // the arbiter would, keep it in and note it.
-      let peers = selected.filter((p) => p.name !== arbiter.name);
-      if (peers.length < 2) {
-        peers = selected;
-        warnings.push(`panel too small to exclude arbiter '${arbiter.name}'; kept it in the peer panel (floor of 2)`);
-      }
-      const out = await consensus(peers, withPersona(req, expert), { arbiter, arbiterInstructions: PROMPTS.arbiter, blindVote });
-      return { content: [{ type: "text", text: JSON.stringify({ opinions: out.opinions, blindVerdict: out.blindVerdict, verdict: out.verdict, error: out.error, arbiter: { mode: "server", provider: arbiter.name }, warnings }) }] };
+      // implicit providers[0], so any host can synthesize a real verdict. The whole
+      // pass lives in runConsensus so session-revisit can re-run it identically.
+      const { payload, parts } = await runConsensus(req, expert);
+      const sid = persistRun("consensus", req, expert, parts);
+      if (sid) payload.sessionId = sid;
+      return jsonResult(payload);
+    }
+    if (name === "session-get") {
+      if (!persistEnabled()) return disabledMsg();
+      const rec = sessions.readSession(String(args.sessionId == null ? "" : args.sessionId), { dir: sessionsDir });
+      if (!rec) return notFoundMsg(args.sessionId);
+      return jsonResult({ session: rec });
+    }
+    if (name === "session-annotate") {
+      if (!persistEnabled()) return disabledMsg();
+      const cfg = sessionsCfg();
+      const updated = sessions.annotateSession(
+        String(args.sessionId == null ? "" : args.sessionId),
+        String(args.note == null ? "" : args.note),
+        { dir: sessionsDir, maxRecords: cfg.maxRecords, maxAgeDays: cfg.maxAgeDays }
+      );
+      if (!updated) return notFoundMsg(args.sessionId);
+      return jsonResult({ session: updated });
+    }
+    if (name === "session-revisit") {
+      if (!persistEnabled()) return disabledMsg();
+      const rec = sessions.readSession(String(args.sessionId == null ? "" : args.sessionId), { dir: sessionsDir });
+      if (!rec) return notFoundMsg(args.sessionId);
+      // Re-run the ORIGINAL question with the CURRENT providers/config via the same
+      // path, then write a CHILD record linked by parentId. Re-run (not replay):
+      // revisit's purpose is to re-evaluate against the current context.
+      const childExpert = rec.expert || undefined;
+      // Carry the original attachment REFS so the re-run sees the same file
+      // context the parent did (paths were scrubbed on write).
+      const childFiles = Array.isArray(rec.files) && rec.files.length ? rec.files : undefined;
+      /** @type {DelegationRequest} */
+      const childReq = { ...req, prompt: rec.question, expert: childExpert, files: childFiles };
+      const tool = rec.tool === "ask-all" ? "ask-all" : "consensus";
+      const { payload, parts } = tool === "ask-all"
+        ? await runAskAll(childReq, childExpert)
+        : await runConsensus(childReq, childExpert);
+      const sid = persistRun(tool, childReq, childExpert, { ...parts, parentId: rec.id });
+      if (sid) payload.sessionId = sid;
+      payload.parentId = rec.id;
+      return jsonResult(payload);
     }
     if (Object.prototype.hasOwnProperty.call(ASK_PROVIDER, name)) {
       const p = registry.get(ASK_PROVIDER[name]);
@@ -362,7 +544,8 @@ function startStdio() {
       bridge: require("../openrouter/index.js"),
     }),
   ];
-  const srv = buildServer({ providers, getConfig, getConfigError });
+  const sessionsDir = require("../../core/paths.js").resolveSessionsDir();
+  const srv = buildServer({ providers, getConfig, getConfigError, sessionsDir });
 
   if (typeof globalThis.fetch !== "function") {
     console.error("deliberation-mcp requires Node 18+ (global fetch unavailable).");

--- a/server/openrouter/config.js
+++ b/server/openrouter/config.js
@@ -131,13 +131,15 @@ function resolveSessions(raw) {
     if (typeof raw.persist === "boolean") out.persist = raw.persist;
     else warnings.push(`sessions.persist must be a boolean (got ${JSON.stringify(raw.persist)}); using false`);
   }
+  // -1 means UNLIMITED (keep forever / no count cap); otherwise a positive integer.
+  // 0 and other values are invalid -> default + warning.
   if (raw.maxRecords !== undefined) {
-    if (Number.isInteger(raw.maxRecords) && raw.maxRecords > 0) out.maxRecords = raw.maxRecords;
-    else warnings.push(`sessions.maxRecords must be a positive integer (got ${JSON.stringify(raw.maxRecords)}); using ${DEFAULT_SESSIONS_MAX_RECORDS}`);
+    if (Number.isInteger(raw.maxRecords) && (raw.maxRecords === -1 || raw.maxRecords > 0)) out.maxRecords = raw.maxRecords;
+    else warnings.push(`sessions.maxRecords must be -1 (unlimited) or a positive integer (got ${JSON.stringify(raw.maxRecords)}); using ${DEFAULT_SESSIONS_MAX_RECORDS}`);
   }
   if (raw.maxAgeDays !== undefined) {
-    if (Number.isInteger(raw.maxAgeDays) && raw.maxAgeDays > 0) out.maxAgeDays = raw.maxAgeDays;
-    else warnings.push(`sessions.maxAgeDays must be a positive integer (got ${JSON.stringify(raw.maxAgeDays)}); using ${DEFAULT_SESSIONS_MAX_AGE_DAYS}`);
+    if (Number.isInteger(raw.maxAgeDays) && (raw.maxAgeDays === -1 || raw.maxAgeDays > 0)) out.maxAgeDays = raw.maxAgeDays;
+    else warnings.push(`sessions.maxAgeDays must be -1 (unlimited) or a positive integer (got ${JSON.stringify(raw.maxAgeDays)}); using ${DEFAULT_SESSIONS_MAX_AGE_DAYS}`);
   }
   return { sessions: out, warnings };
 }

--- a/server/openrouter/config.js
+++ b/server/openrouter/config.js
@@ -15,6 +15,9 @@ const DEFAULT_API_BASE = "https://openrouter.ai/api/v1";
 const DEFAULT_API_KEY_ENV = "OPENROUTER_API_KEY";
 const DEFAULT_MAX_FANOUT = 3;
 const DEFAULT_ARBITER = "auto";
+// sessions block defaults (opt-in store; default OFF).
+const DEFAULT_SESSIONS_MAX_RECORDS = 200;
+const DEFAULT_SESSIONS_MAX_AGE_DAYS = 30;
 const BUILTIN_ARBITERS = new Set(["codex", "gemini", "grok"]);
 // The only provider a `models` entry may target in v1. codex/gemini/grok are
 // CLI-managed or singleton built-ins and are out of scope for named model records.
@@ -90,6 +93,7 @@ function validateConfig(raw) {
   const invalidModels = enabled ? parsed.invalidModels : [];
 
   const { consensus, warnings } = resolveConsensus(raw.consensus, models);
+  const { sessions, warnings: sessionsWarnings } = resolveSessions(raw.sessions);
 
   return {
     ok: true,
@@ -99,11 +103,43 @@ function validateConfig(raw) {
       providers: resolveProviders(providersRaw),
       openrouter: { enabled, apiKeyEnv, apiBase, allowRawModel, maxFanout, defaultModel, defaults, models, invalidModels },
       consensus,
-      // Defaults-validation warnings ride the same consensusWarnings channel the
-      // bridge already surfaces, so a dropped bad default is visible, not silent.
-      consensusWarnings: [...defaultsWarnings, ...warnings],
+      sessions,
+      // Defaults- and sessions-validation warnings ride the same consensusWarnings
+      // channel the bridge already surfaces, so a dropped/degraded value is
+      // visible, not silent.
+      consensusWarnings: [...defaultsWarnings, ...warnings, ...sessionsWarnings],
     },
   };
+}
+
+// Resolve the optional `sessions` block (opt-in per-session store) with
+// soft-degrade semantics, mirroring resolveConsensus: an invalid value NEVER
+// rejects the config; it degrades to the default and records a warning.
+//   - persist: boolean (non-bool -> false + warning); default false (store OFF).
+//   - maxRecords / maxAgeDays: positive ints (invalid -> default + warning).
+// @param {*} raw  the raw sessions block (untrusted)
+// @returns {{sessions:{persist:boolean, maxRecords:number, maxAgeDays:number}, warnings:string[]}}
+function resolveSessions(raw) {
+  const warnings = [];
+  const out = { persist: false, maxRecords: DEFAULT_SESSIONS_MAX_RECORDS, maxAgeDays: DEFAULT_SESSIONS_MAX_AGE_DAYS };
+  if (raw === undefined) return { sessions: out, warnings };
+  if (!isObject(raw)) {
+    warnings.push(`sessions must be an object (got ${JSON.stringify(raw)}); persistence disabled`);
+    return { sessions: out, warnings };
+  }
+  if (raw.persist !== undefined) {
+    if (typeof raw.persist === "boolean") out.persist = raw.persist;
+    else warnings.push(`sessions.persist must be a boolean (got ${JSON.stringify(raw.persist)}); using false`);
+  }
+  if (raw.maxRecords !== undefined) {
+    if (Number.isInteger(raw.maxRecords) && raw.maxRecords > 0) out.maxRecords = raw.maxRecords;
+    else warnings.push(`sessions.maxRecords must be a positive integer (got ${JSON.stringify(raw.maxRecords)}); using ${DEFAULT_SESSIONS_MAX_RECORDS}`);
+  }
+  if (raw.maxAgeDays !== undefined) {
+    if (Number.isInteger(raw.maxAgeDays) && raw.maxAgeDays > 0) out.maxAgeDays = raw.maxAgeDays;
+    else warnings.push(`sessions.maxAgeDays must be a positive integer (got ${JSON.stringify(raw.maxAgeDays)}); using ${DEFAULT_SESSIONS_MAX_AGE_DAYS}`);
+  }
+  return { sessions: out, warnings };
 }
 
 // Resolve providers.openrouter.defaults. camelCase -> wire mapping happens HERE
@@ -340,7 +376,7 @@ function makeConfigReader(filePath) {
     try {
       text = fs.readFileSync(filePath, "utf8");
     } catch (_) {
-      return { ok: true, error: null, resolved: { version: 1, providers: {}, openrouter: disabledOpenRouter(), consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: true, blindVote: false }, consensusWarnings: [] } };
+      return { ok: true, error: null, resolved: { version: 1, providers: {}, openrouter: disabledOpenRouter(), consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: true, blindVote: false }, sessions: { persist: false, maxRecords: DEFAULT_SESSIONS_MAX_RECORDS, maxAgeDays: DEFAULT_SESSIONS_MAX_AGE_DAYS }, consensusWarnings: [] } };
     }
     let parsed;
     try {
@@ -365,6 +401,6 @@ function makeConfigReader(filePath) {
 }
 
 module.exports = {
-  validateConfig, makeConfigReader, EXPERT_KEYS, RESERVED_ALIAS,
+  validateConfig, makeConfigReader, resolveSessions, EXPERT_KEYS, RESERVED_ALIAS,
   DEFAULT_API_BASE, DEFAULT_API_KEY_ENV,
 };

--- a/test/core-paths.test.js
+++ b/test/core-paths.test.js
@@ -3,7 +3,7 @@ const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
 
-const { resolveConfigPath, resolveGrokCachePath } = require("../core/paths.js");
+const { resolveConfigPath, resolveGrokCachePath, resolveSessionsDir } = require("../core/paths.js");
 
 // --- helpers -----------------------------------------------------------------
 //
@@ -17,6 +17,9 @@ function canonicalConfig(/** @type {string} */ home) {
 }
 function canonicalCache(/** @type {string} */ home) {
   return path.join(home, ".cache", "deliberation", "grok-files.json");
+}
+function canonicalSessions(/** @type {string} */ home) {
+  return path.join(home, ".cache", "deliberation", "sessions");
 }
 
 // --- config: env override ----------------------------------------------------
@@ -172,4 +175,54 @@ test("CC7: win32 relative LOCALAPPDATA is ignored -> ~/AppData/Local fallback", 
     platform: "win32",
   });
   assert.equal(got, path.join(home, "AppData", "Local", "deliberation", "grok-files.json"));
+});
+
+// --- sessions dir: env override + canonical default --------------------------
+
+test("CS1: DELIBERATION_SESSIONS wins verbatim", () => {
+  const override = "/somewhere/custom/sessions";
+  const got = resolveSessionsDir({
+    home: HOME,
+    env: { DELIBERATION_SESSIONS: override },
+    platform: "linux",
+  });
+  assert.equal(got, override);
+});
+
+test("CS2: no override -> canonical XDG cache /sessions", () => {
+  const got = resolveSessionsDir({
+    home: HOME,
+    env: {},
+    platform: "linux",
+  });
+  assert.equal(got, canonicalSessions(HOME));
+});
+
+test("CS3: XDG_CACHE_HOME relocates the sessions dir", () => {
+  const xdg = "/xdg/cache";
+  const got = resolveSessionsDir({
+    home: HOME,
+    env: { XDG_CACHE_HOME: xdg },
+    platform: "linux",
+  });
+  assert.equal(got, path.join(xdg, "deliberation", "sessions"));
+});
+
+test("CS4: win32 uses LOCALAPPDATA (Local) for the sessions dir", () => {
+  const localAppData = "C:\\Users\\tester\\AppData\\Local";
+  const got = resolveSessionsDir({
+    home: "C:\\Users\\tester",
+    env: { LOCALAPPDATA: localAppData },
+    platform: "win32",
+  });
+  assert.equal(got, path.join(localAppData, "deliberation", "sessions"));
+});
+
+test("CS5: empty DELIBERATION_SESSIONS falls through to canonical", () => {
+  const got = resolveSessionsDir({
+    home: HOME,
+    env: { DELIBERATION_SESSIONS: "" },
+    platform: "linux",
+  });
+  assert.equal(got, canonicalSessions(HOME));
 });

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -345,3 +345,32 @@ test("S20: files persist as path REFS only", () => {
   if (!back) return;
   assert.deepEqual(back.files, [{ path: "./notes.md" }]);
 });
+
+test("S20b: non-path file refs (dir/file_id/file_url/mode) survive a round-trip", () => {
+  const dir = tmpDir();
+  const files = [
+    { dir: "src", mode: "inline" },
+    { file_id: "file-abc123" },
+    { file_url: "https://example.com/x.pdf" },
+  ];
+  const id = writeSession(rec({ files }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.deepEqual(back.files, files); // preserved so session-revisit keeps context
+});
+
+test("S18e: tmp reap only matches the writer's exact temp shape", () => {
+  const dir = tmpDir();
+  writeSession(rec({}), { dir });
+  const ours = path.join(dir, "abc.json.tmp.111.222");   // matches <id>.json.tmp.<pid>.<ms>
+  const theirs = path.join(dir, "notes.tmp.backup");      // unrelated ".tmp." file
+  fs.writeFileSync(ours, "x");
+  fs.writeFileSync(theirs, "keep me");
+  const old = Date.now() - 2 * 60 * 60 * 1000;
+  fs.utimesSync(ours, new Date(old), new Date(old));
+  fs.utimesSync(theirs, new Date(old), new Date(old));
+  pruneSessions({ dir, maxAgeDays: 3650, maxRecords: 100 });
+  assert.equal(fs.existsSync(ours), false);  // reaped
+  assert.equal(fs.existsSync(theirs), true); // left alone
+});

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -218,7 +218,8 @@ test("S17: scrubSecrets redacts each key pattern", () => {
   const openrouter = "sk-or-v1-" + "b".repeat(24);
   const xai = "xai-" + "c".repeat(24);
   const google = "AIza" + "D".repeat(35);
-  const bearer = "Bearer tok.en-value_123";
+  const bearerTok = "abc.def-ghi_jkl+mno/pqrST"; // >= 20 chars, base64url-ish
+  const bearer = `Bearer ${bearerTok}`;
 
   assert.equal(scrubSecrets(openai).includes(openai), false);
   assert.ok(scrubSecrets(openai).includes("[REDACTED]"));
@@ -233,8 +234,24 @@ test("S17: scrubSecrets redacts each key pattern", () => {
   assert.ok(scrubSecrets(google).includes("[REDACTED]"));
 
   const scrubbedBearer = scrubSecrets(bearer);
-  assert.equal(scrubbedBearer.includes("tok.en-value_123"), false);
+  assert.equal(scrubbedBearer.includes(bearerTok), false);
   assert.ok(scrubbedBearer.includes("Bearer [REDACTED]"));
+});
+
+test("S17d: scrubSecrets leaves short hyphenated terms and the word 'bearer' intact", () => {
+  // {20,} minimum: these are NOT keys and must survive unchanged.
+  assert.equal(scrubSecrets("sk-folding-cube spinner"), "sk-folding-cube spinner");
+  assert.equal(scrubSecrets("xai-explainability docs"), "xai-explainability docs");
+  // No `i` flag: the English word "bearer" (lowercase, short follow) is untouched.
+  assert.equal(scrubSecrets("the bearer of this responsibility"), "the bearer of this responsibility");
+});
+
+test("S17e: scrubSecrets redacts GitHub and AWS key shapes", () => {
+  const gh = "ghp_" + "a".repeat(36);
+  const aws = "AKIA" + "ABCDEFGHIJKLMNOP"; // AKIA + 16
+  assert.ok(scrubSecrets(gh).includes("[REDACTED]"));
+  assert.equal(scrubSecrets(gh).includes(gh), false);
+  assert.ok(scrubSecrets(`id=${aws} x`).includes("[REDACTED]"));
 });
 
 test("S17b: scrubSecrets does NOT corrupt normal words containing key-like substrings", () => {
@@ -266,6 +283,38 @@ test("S18: secrets are scrubbed on write (question, opinion text, verdict, file 
   const blob = JSON.stringify(back);
   assert.equal(blob.includes(secret), false);
   assert.ok(blob.includes("[REDACTED]"));
+});
+
+test("S18b: secrets in the warnings array are scrubbed on write", () => {
+  const dir = tmpDir();
+  const secret = "sk-" + "w".repeat(30);
+  const id = writeSession(rec({ warnings: [`provider error: invalid key ${secret}`] }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.equal(JSON.stringify(back.warnings).includes(secret), false);
+  assert.ok((back.warnings || [])[0].includes("[REDACTED]"));
+});
+
+test("S18c: pruneSessions reaps an orphaned old .tmp file", () => {
+  const dir = tmpDir();
+  writeSession(rec({}), { dir });
+  // Simulate a crash-orphaned temp from a previous write, aged > 1h.
+  const orphan = path.join(dir, "abc.json.tmp.999.123");
+  fs.writeFileSync(orphan, "partial");
+  const old = Date.now() - 2 * 60 * 60 * 1000;
+  fs.utimesSync(orphan, new Date(old), new Date(old));
+  pruneSessions({ dir, maxAgeDays: 3650, maxRecords: 100 });
+  assert.equal(fs.existsSync(orphan), false);
+});
+
+test("S18d: pruneSessions leaves a FRESH .tmp file alone (in-flight write)", () => {
+  const dir = tmpDir();
+  writeSession(rec({}), { dir });
+  const fresh = path.join(dir, "abc.json.tmp.999.456");
+  fs.writeFileSync(fresh, "in-flight");
+  pruneSessions({ dir, maxAgeDays: 3650, maxRecords: 100 });
+  assert.equal(fs.existsSync(fresh), true); // younger than the 1h reap window
 });
 
 // --- 100 KB cap --------------------------------------------------------------

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -1,0 +1,298 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  writeSession, readSession, listSessions, pruneSessions, annotateSession,
+  scrubSecrets, isSafeId, newSessionId, SCHEMA_VERSION, MAX_TEXT_BYTES,
+} = require("../core/sessions.js");
+
+/** @typedef {import("../core/sessions.js").SessionRecord} SessionRecord */
+
+// Each test gets its own temp sessions dir.
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "delib-sess-"));
+}
+
+/**
+ * Build a minimal valid record. Caller overrides fields as needed.
+ * @param {Partial<SessionRecord>} [over]
+ * @returns {SessionRecord}
+ */
+function rec(over) {
+  /** @type {SessionRecord} */
+  const base = {
+    id: newSessionId(),
+    parentId: null,
+    schemaVersion: SCHEMA_VERSION,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    tool: "consensus",
+    question: "what is 2+2?",
+    expert: null,
+    files: null,
+    opinions: [{ provider: "codex", model: "m", text: "4" }],
+    blindVerdict: null,
+    verdict: "the answer is 4",
+    arbiter: { mode: "server", provider: "grok" },
+    warnings: [],
+    annotations: [],
+  };
+  return { ...base, ...(over || {}) };
+}
+
+// --- round-trip --------------------------------------------------------------
+
+test("S1: write + read round-trip preserves core fields", () => {
+  const dir = tmpDir();
+  const r = rec({});
+  const id = writeSession(r, { dir });
+  assert.equal(id, r.id);
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.equal(back.id, r.id);
+  assert.equal(back.tool, "consensus");
+  assert.equal(back.question, "what is 2+2?");
+  assert.equal(back.verdict, "the answer is 4");
+  assert.equal(back.opinions[0].text, "4");
+  assert.equal(back.schemaVersion, SCHEMA_VERSION);
+});
+
+// --- atomic write ------------------------------------------------------------
+
+test("S2: atomic write leaves no temp file and a valid JSON dest", () => {
+  const dir = tmpDir();
+  const id = writeSession(rec({}), { dir });
+  const names = fs.readdirSync(dir);
+  assert.deepEqual(names, [`${id}.json`]); // exactly the dest, no .tmp leftover
+  const raw = fs.readFileSync(path.join(dir, `${id}.json`), "utf8");
+  assert.doesNotThrow(() => JSON.parse(raw));
+});
+
+// --- file mode 0600 ----------------------------------------------------------
+
+test("S3: written file is mode 0600", { skip: process.platform === "win32" }, () => {
+  const dir = tmpDir();
+  const id = writeSession(rec({}), { dir });
+  const mode = fs.statSync(path.join(dir, `${id}.json`)).mode & 0o777;
+  assert.equal(mode, 0o600);
+});
+
+// --- unsafe id rejected (no traversal) --------------------------------------
+
+test("S4: writeSession rejects an unsafe id (path traversal)", () => {
+  const dir = tmpDir();
+  assert.throws(() => writeSession(rec({ id: "../evil" }), { dir }), /unsafe session id/);
+  assert.throws(() => writeSession(rec({ id: "a/b" }), { dir }), /unsafe session id/);
+});
+
+test("S5: readSession returns null for an unsafe id", () => {
+  const dir = tmpDir();
+  assert.equal(readSession("../evil", { dir }), null);
+  assert.equal(readSession("a/b", { dir }), null);
+  assert.equal(readSession("a.b", { dir }), null);
+});
+
+test("S6: isSafeId guards the anchored shape", () => {
+  assert.equal(isSafeId("abc-123"), true);
+  assert.equal(isSafeId("../x"), false);
+  assert.equal(isSafeId("a/b"), false);
+  assert.equal(isSafeId("a.b"), false);
+  assert.equal(isSafeId(""), false);
+  assert.equal(isSafeId(42), false);
+});
+
+// --- corrupt JSON -> null ----------------------------------------------------
+
+test("S7: readSession returns null on corrupt JSON (never throws)", () => {
+  const dir = tmpDir();
+  const id = "deadbeef";
+  fs.writeFileSync(path.join(dir, `${id}.json`), "{ this is not json");
+  assert.equal(readSession(id, { dir }), null);
+});
+
+test("S8: readSession returns null for an absent file", () => {
+  const dir = tmpDir();
+  assert.equal(readSession("missing", { dir }), null);
+});
+
+// --- listing newest-first ----------------------------------------------------
+
+test("S9: listSessions returns newest-first by mtime", () => {
+  const dir = tmpDir();
+  const a = writeSession(rec({}), { dir });
+  const b = writeSession(rec({}), { dir });
+  const c = writeSession(rec({}), { dir });
+  // Force distinct, deterministic mtimes: a oldest, c newest.
+  fs.utimesSync(path.join(dir, `${a}.json`), new Date(1000), new Date(1000));
+  fs.utimesSync(path.join(dir, `${b}.json`), new Date(2000), new Date(2000));
+  fs.utimesSync(path.join(dir, `${c}.json`), new Date(3000), new Date(3000));
+  const ids = listSessions({ dir }).map((e) => e.id);
+  assert.deepEqual(ids, [c, b, a]);
+});
+
+test("S10: listSessions on a missing dir yields []", () => {
+  const got = listSessions({ dir: path.join(os.tmpdir(), "delib-does-not-exist-xyz") });
+  assert.deepEqual(got, []);
+});
+
+// --- prune by age + by count -------------------------------------------------
+
+test("S11: pruneSessions deletes records older than maxAgeDays", () => {
+  const dir = tmpDir();
+  const fresh = writeSession(rec({}), { dir });
+  const old = writeSession(rec({}), { dir });
+  // Backdate `old` by ~10 days.
+  const tenDaysAgo = Date.now() - 10 * 24 * 60 * 60 * 1000;
+  fs.utimesSync(path.join(dir, `${old}.json`), new Date(tenDaysAgo), new Date(tenDaysAgo));
+  const { removed } = pruneSessions({ dir, maxAgeDays: 1, maxRecords: 100 });
+  assert.equal(removed, 1);
+  assert.equal(readSession(old, { dir }), null);
+  assert.ok(readSession(fresh, { dir }));
+});
+
+test("S12: pruneSessions trims to the newest maxRecords", () => {
+  const dir = tmpDir();
+  const ids = [];
+  for (let i = 0; i < 5; i++) ids.push(writeSession(rec({}), { dir }));
+  // Distinct ascending, RECENT mtimes (seconds apart) so only the count-trim
+  // applies - not the age cutoff. ids[0] oldest, ids[4] newest.
+  const nowMs = Date.now();
+  for (let i = 0; i < ids.length; i++) {
+    const t = new Date(nowMs - (ids.length - i) * 1000);
+    fs.utimesSync(path.join(dir, `${ids[i]}.json`), t, t);
+  }
+  const { removed } = pruneSessions({ dir, maxRecords: 2, maxAgeDays: 3650 });
+  assert.equal(removed, 3);
+  const remaining = listSessions({ dir }).map((e) => e.id).sort();
+  assert.deepEqual(remaining, [ids[3], ids[4]].sort()); // two newest survive
+});
+
+test("S13: pruneSessions is ENOENT-tolerant (missing dir, repeat prune)", () => {
+  assert.doesNotThrow(() => pruneSessions({ dir: path.join(os.tmpdir(), "delib-none-abc") }));
+  const dir = tmpDir();
+  const old = writeSession(rec({}), { dir });
+  const past = Date.now() - 100 * 24 * 60 * 60 * 1000;
+  fs.utimesSync(path.join(dir, `${old}.json`), new Date(past), new Date(past));
+  assert.doesNotThrow(() => pruneSessions({ dir, maxAgeDays: 1 }));
+  // Second prune over the now-empty dir must not throw either.
+  assert.doesNotThrow(() => pruneSessions({ dir, maxAgeDays: 1 }));
+});
+
+// --- writeSession prunes after each write ------------------------------------
+
+test("S14: writeSession prunes to maxRecords after writing", () => {
+  const dir = tmpDir();
+  for (let i = 0; i < 4; i++) writeSession(rec({}), { dir, maxRecords: 2, maxAgeDays: 3650 });
+  assert.ok(listSessions({ dir }).length <= 2);
+});
+
+// --- annotate ----------------------------------------------------------------
+
+test("S15: annotateSession appends an annotation and persists it", () => {
+  const dir = tmpDir();
+  const id = writeSession(rec({}), { dir });
+  const updated = annotateSession(id, "looks good", { dir, at: "2026-06-02T00:00:00.000Z" });
+  assert.ok(updated);
+  if (!updated) return;
+  assert.equal(updated.annotations && updated.annotations.length, 1);
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.equal(back.annotations && back.annotations[0].note, "looks good");
+  assert.equal(back.annotations && back.annotations[0].at, "2026-06-02T00:00:00.000Z");
+});
+
+test("S16: annotateSession returns null for an unknown id", () => {
+  const dir = tmpDir();
+  assert.equal(annotateSession("missing", "x", { dir }), null);
+});
+
+// --- scrubSecrets ------------------------------------------------------------
+
+test("S17: scrubSecrets redacts each key pattern", () => {
+  const openai = "sk-" + "a".repeat(24);
+  const openrouter = "sk-or-v1-" + "b".repeat(24);
+  const xai = "xai-" + "c".repeat(24);
+  const google = "AIza" + "D".repeat(35);
+  const bearer = "Bearer tok.en-value_123";
+
+  assert.equal(scrubSecrets(openai).includes(openai), false);
+  assert.ok(scrubSecrets(openai).includes("[REDACTED]"));
+
+  assert.equal(scrubSecrets(openrouter).includes(openrouter), false);
+  assert.ok(scrubSecrets(openrouter).includes("[REDACTED]"));
+
+  assert.equal(scrubSecrets(xai).includes(xai), false);
+  assert.ok(scrubSecrets(xai).includes("[REDACTED]"));
+
+  assert.equal(scrubSecrets(google).includes(google), false);
+  assert.ok(scrubSecrets(google).includes("[REDACTED]"));
+
+  const scrubbedBearer = scrubSecrets(bearer);
+  assert.equal(scrubbedBearer.includes("tok.en-value_123"), false);
+  assert.ok(scrubbedBearer.includes("Bearer [REDACTED]"));
+});
+
+test("S17b: scrubSecrets does NOT corrupt normal words containing key-like substrings", () => {
+  // "risk-analysis" contains "sk-analysis"; word-boundary anchors must spare it.
+  assert.equal(scrubSecrets("risk-analysis and disk-space"), "risk-analysis and disk-space");
+  assert.equal(scrubSecrets("maxai-thing"), "maxai-thing");
+});
+
+test("S17c: a longer-than-39-char Google key is fully redacted (no tail leak)", () => {
+  const longKey = "AIza" + "D".repeat(40); // 44 chars total, > the canonical 39
+  const out = scrubSecrets(`k=${longKey} end`);
+  assert.equal(out.includes(longKey), false); // whole key gone
+  assert.equal(out.includes("DDDD"), false); // no leaked tail run
+  assert.equal(out, "k=[REDACTED] end");
+});
+
+test("S18: secrets are scrubbed on write (question, opinion text, verdict, file refs)", () => {
+  const dir = tmpDir();
+  const secret = "sk-" + "z".repeat(24);
+  const id = writeSession(rec({
+    question: `key is ${secret}`,
+    opinions: [{ provider: "codex", model: "m", text: `leaked ${secret}` }],
+    verdict: `verdict mentions ${secret}`,
+    files: [{ path: `/tmp/${secret}/notes.md` }],
+  }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  const blob = JSON.stringify(back);
+  assert.equal(blob.includes(secret), false);
+  assert.ok(blob.includes("[REDACTED]"));
+});
+
+// --- 100 KB cap --------------------------------------------------------------
+
+test("S19: opinion + verdict text are capped at ~100 KB on write", () => {
+  const dir = tmpDir();
+  const huge = "x".repeat(MAX_TEXT_BYTES + 5000);
+  const id = writeSession(rec({
+    opinions: [{ provider: "codex", model: "m", text: huge }],
+    verdict: huge,
+  }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  const optText = back.opinions[0].text || "";
+  assert.ok(Buffer.byteLength(optText, "utf8") < MAX_TEXT_BYTES + 200);
+  assert.ok(optText.includes("[truncated"));
+  assert.ok((back.verdict || "").includes("[truncated"));
+});
+
+// --- file refs not bodies ----------------------------------------------------
+
+test("S20: files persist as path REFS only", () => {
+  const dir = tmpDir();
+  const id = writeSession(rec({ files: [{ path: "./notes.md" }] }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.deepEqual(back.files, [{ path: "./notes.md" }]);
+});

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -171,6 +171,25 @@ test("S12: pruneSessions trims to the newest maxRecords", () => {
   assert.deepEqual(remaining, [ids[3], ids[4]].sort()); // two newest survive
 });
 
+test("S12b: pruneSessions maxRecords:-1 keeps every record (unlimited count)", () => {
+  const dir = tmpDir();
+  const ids = [];
+  for (let i = 0; i < 5; i++) ids.push(writeSession(rec({}), { dir, maxRecords: -1, maxAgeDays: 3650 }));
+  const { removed } = pruneSessions({ dir, maxRecords: -1, maxAgeDays: 3650 });
+  assert.equal(removed, 0);
+  assert.equal(listSessions({ dir }).length, 5);
+});
+
+test("S12c: pruneSessions maxAgeDays:-1 keeps a very old record (unlimited age)", () => {
+  const dir = tmpDir();
+  const old = writeSession(rec({}), { dir, maxRecords: -1, maxAgeDays: -1 });
+  const ancient = Date.now() - 1000 * 24 * 60 * 60 * 1000; // ~1000 days
+  fs.utimesSync(path.join(dir, `${old}.json`), new Date(ancient), new Date(ancient));
+  const { removed } = pruneSessions({ dir, maxRecords: -1, maxAgeDays: -1 });
+  assert.equal(removed, 0);
+  assert.ok(readSession(old, { dir }));
+});
+
 test("S13: pruneSessions is ENOENT-tolerant (missing dir, repeat prune)", () => {
   assert.doesNotThrow(() => pruneSessions({ dir: path.join(os.tmpdir(), "delib-none-abc") }));
   const dir = tmpDir();

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -92,3 +92,112 @@ test("M5: ask-all expands OR per-alias and never dispatches askAll:false (issue 
   assert.deepEqual(provs, ["codex", "openrouter:on"]); // off excluded server-side
   assert.equal(provs.includes("openrouter:off"), false);
 });
+
+// --- session store wiring ----------------------------------------------------
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function tmpSessionsDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "delib-mcp-sess-"));
+}
+function sessionsConfig(persist) {
+  return { providers: {}, openrouter: { maxFanout: 3, models: [] }, sessions: { persist, maxRecords: 200, maxAgeDays: 30 } };
+}
+async function callTool(srv, id, name, args) {
+  const res = await srv.handle({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } });
+  return JSON.parse(res.result.content[0].text);
+}
+
+test("S-MCP1: tools/list includes the session tools with per-tool (no-prompt) schemas", async () => {
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => config });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+  const byName = Object.fromEntries(res.result.tools.map((t) => [t.name, t]));
+  for (const n of ["session-get", "session-revisit", "session-annotate"]) {
+    assert.ok(byName[n], `missing tool ${n}`);
+    assert.equal(byName[n].inputSchema.properties.prompt, undefined); // NOT the prompt-required schema
+    assert.ok(byName[n].inputSchema.required.includes("sessionId"));
+  }
+  assert.ok(byName["session-annotate"].inputSchema.required.includes("note"));
+});
+
+test("S-MCP2: consensus with persist on writes a record and returns sessionId", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
+  const payload = await callTool(srv, 2, "consensus", { prompt: "q", expert: "architect" });
+  assert.ok(payload.sessionId, "expected a sessionId");
+  assert.ok(fs.existsSync(path.join(dir, `${payload.sessionId}.json`)));
+});
+
+test("S-MCP3: ask-all with persist on writes a record and returns sessionId", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
+  const payload = await callTool(srv, 3, "ask-all", { prompt: "q" });
+  assert.ok(payload.sessionId);
+  assert.ok(fs.existsSync(path.join(dir, `${payload.sessionId}.json`)));
+});
+
+test("S-MCP4: persist off writes nothing and returns no sessionId", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(false), sessionsDir: dir });
+  const payload = await callTool(srv, 4, "consensus", { prompt: "q" });
+  assert.equal(payload.sessionId, undefined);
+  assert.deepEqual(fs.readdirSync(dir), []);
+});
+
+test("S-MCP5: session-get round-trips a persisted record", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
+  const made = await callTool(srv, 5, "consensus", { prompt: "the question", expert: "architect" });
+  const got = await callTool(srv, 6, "session-get", { sessionId: made.sessionId });
+  assert.equal(got.session.id, made.sessionId);
+  assert.equal(got.session.question, "the question");
+  assert.equal(got.session.tool, "consensus");
+});
+
+test("S-MCP6: session-revisit writes a CHILD record linked by parentId", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
+  const parent = await callTool(srv, 7, "consensus", { prompt: "original q" });
+  const child = await callTool(srv, 8, "session-revisit", { sessionId: parent.sessionId });
+  assert.equal(child.parentId, parent.sessionId);
+  assert.ok(child.sessionId);
+  assert.notEqual(child.sessionId, parent.sessionId);
+  const childRec = await callTool(srv, 9, "session-get", { sessionId: child.sessionId });
+  assert.equal(childRec.session.parentId, parent.sessionId);
+  assert.equal(childRec.session.question, "original q"); // re-ran the original question
+});
+
+test("S-MCP7: session-annotate appends to the audit trail", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
+  const made = await callTool(srv, 10, "consensus", { prompt: "q" });
+  const ann = await callTool(srv, 11, "session-annotate", { sessionId: made.sessionId, note: "reviewed" });
+  assert.equal(ann.session.annotations.length, 1);
+  assert.equal(ann.session.annotations[0].note, "reviewed");
+});
+
+test("S-MCP8: session tools report disabled when persist is off", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(false), sessionsDir: dir });
+  for (const [id, name] of [[12, "session-get"], [13, "session-revisit"], [14, "session-annotate"]]) {
+    const payload = await callTool(srv, id, name, { sessionId: "whatever", note: "x" });
+    assert.match(payload.error, /persistence is disabled/);
+  }
+});
+
+test("S-MCP9: session-get on an unknown id returns a not-found message", async (t) => {
+  const dir = tmpSessionsDir();
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
+  const payload = await callTool(srv, 15, "session-get", { sessionId: "nope" });
+  assert.match(payload.error, /session not found/);
+});

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -472,8 +472,23 @@ test("SESS4: invalid maxRecords/maxAgeDays degrade to defaults + warnings", () =
   const { sessions, warnings } = resolveSessions({ persist: true, maxRecords: 0, maxAgeDays: -3 });
   assert.equal(sessions.maxRecords, 200);
   assert.equal(sessions.maxAgeDays, 30);
-  assert.ok(warnings.some((w) => /maxRecords must be a positive integer/.test(w)));
-  assert.ok(warnings.some((w) => /maxAgeDays must be a positive integer/.test(w)));
+  assert.ok(warnings.some((w) => /maxRecords must be -1 \(unlimited\) or a positive integer/.test(w)));
+  assert.ok(warnings.some((w) => /maxAgeDays must be -1 \(unlimited\) or a positive integer/.test(w)));
+});
+
+test("SESS4b: maxRecords/maxAgeDays accept -1 (unlimited) with no warning", () => {
+  const { sessions, warnings } = resolveSessions({ persist: true, maxRecords: -1, maxAgeDays: -1 });
+  assert.equal(sessions.maxRecords, -1);
+  assert.equal(sessions.maxAgeDays, -1);
+  assert.equal(warnings.length, 0);
+});
+
+test("SESS4c: -2 and other negatives still degrade to defaults + warnings", () => {
+  const { sessions, warnings } = resolveSessions({ maxRecords: -2, maxAgeDays: -5 });
+  assert.equal(sessions.maxRecords, 200);
+  assert.equal(sessions.maxAgeDays, 30);
+  assert.ok(warnings.some((w) => /maxRecords must be -1/.test(w)));
+  assert.ok(warnings.some((w) => /maxAgeDays must be -1/.test(w)));
 });
 
 test("SESS5: a non-object sessions block degrades to default OFF + warning", () => {

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -1,7 +1,7 @@
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { validateConfig, makeConfigReader } = require("../server/openrouter/config.js");
+const { validateConfig, makeConfigReader, resolveSessions } = require("../server/openrouter/config.js");
 
 // Unified v1 on-disk shape: providers carry connection config; models is a named-record
 // map keyed by id; routing holds fan-out; consensus.arbiter is a shorthand string or
@@ -446,4 +446,52 @@ test("CB8: missing config file => disabled openrouter + consensus default auto",
   const r = reader.get();
   assert.equal(r.ok, true);
   assert.deepEqual(r.resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
+});
+
+// --- sessions block ----------------------------------------------------------
+
+test("SESS1: absent sessions block -> default OFF", () => {
+  const { resolved } = validateConfig(base());
+  assert.deepEqual(resolved.sessions, { persist: false, maxRecords: 200, maxAgeDays: 30 });
+});
+
+test("SESS2: a valid sessions block is honored", () => {
+  const cfg = base();
+  cfg.sessions = { persist: true, maxRecords: 50, maxAgeDays: 7 };
+  const { resolved } = validateConfig(cfg);
+  assert.deepEqual(resolved.sessions, { persist: true, maxRecords: 50, maxAgeDays: 7 });
+});
+
+test("SESS3: non-boolean persist degrades to false + warning", () => {
+  const { sessions, warnings } = resolveSessions({ persist: "yes" });
+  assert.equal(sessions.persist, false);
+  assert.ok(warnings.some((w) => /persist must be a boolean/.test(w)));
+});
+
+test("SESS4: invalid maxRecords/maxAgeDays degrade to defaults + warnings", () => {
+  const { sessions, warnings } = resolveSessions({ persist: true, maxRecords: 0, maxAgeDays: -3 });
+  assert.equal(sessions.maxRecords, 200);
+  assert.equal(sessions.maxAgeDays, 30);
+  assert.ok(warnings.some((w) => /maxRecords must be a positive integer/.test(w)));
+  assert.ok(warnings.some((w) => /maxAgeDays must be a positive integer/.test(w)));
+});
+
+test("SESS5: a non-object sessions block degrades to default OFF + warning", () => {
+  const { sessions, warnings } = resolveSessions("nope");
+  assert.deepEqual(sessions, { persist: false, maxRecords: 200, maxAgeDays: 30 });
+  assert.ok(warnings.some((w) => /sessions must be an object/.test(w)));
+});
+
+test("SESS6: sessions warnings ride the consensusWarnings channel", () => {
+  const cfg = base();
+  cfg.sessions = { persist: "maybe" };
+  const { resolved } = validateConfig(cfg);
+  assert.ok(resolved.consensusWarnings.some((w) => /sessions\.persist must be a boolean/.test(w)));
+});
+
+test("SESS7: missing config file -> reader yields default-OFF sessions", () => {
+  const reader = makeConfigReader(path.join(os.tmpdir(), "definitely-absent-cdg-sessions.json"));
+  const r = reader.get();
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.resolved.sessions, { persist: false, maxRecords: 200, maxAgeDays: 30 });
 });


### PR DESCRIPTION
## What

Ships the **statefulness** slice of PLAN_0 item 3: an **opt-in (default OFF)** per-session store plus three session tools. 1a (opinion-schema enrichment), 1b (quorum), and the server-side convergence loop are deferred.

When `sessions.persist` is off (the default), nothing about a user's questions or transcripts is written to disk and the `session-*` tools report "persistence disabled".

## Changes

- **`core/sessions.js`** (new, zero-dep, synchronous, JSDoc-typed in the strict `tsc` include):
  - `writeSession` - atomic temp->rename; temp created with `mode:0o600` **directly** (no world-readable window); prunes after each write; cleans up the temp on a failed rename.
  - `readSession` - `null` on absent **or** corrupt JSON (never throws); anchored `^[A-Za-z0-9-]+$` id guard rejects path traversal.
  - `listSessions` - newest-first by mtime; missing dir -> `[]`.
  - `pruneSessions` - delete older than `maxAgeDays`, then trim to newest `maxRecords`; ENOENT-tolerant (`rmSync force`).
  - `scrubSecrets` - redacts OpenAI/OpenRouter/xAI/Google(`AIza…`)/Bearer key shapes, word-boundary anchored so normal words (`risk-analysis`) aren't corrupted; `~100KB` per-text cap (UTF-8-boundary safe).
  - `annotateSession` - append-only audit note (scrubbed + capped); documented last-writer-wins.
  - Input **files persist as path refs, not bodies.**
- **`core/paths.js`** - `resolveSessionsDir` (`DELIBERATION_SESSIONS` override else `<cache>/deliberation/sessions`).
- **`server/openrouter/config.js`** - `resolveSessions` validation (`persist` bool / `maxRecords` / `maxAgeDays` positive ints; soft-degrade + warnings on the existing `consensusWarnings` channel).
- **`server/mcp/index.js`** - persist `consensus`/`ask-all` runs and return `sessionId` when enabled; new `session-get` / `session-revisit` (re-runs the original question with the **current** providers/config, writes a child linked by `parentId`, carrying the original file refs) / `session-annotate`, each with its **own no-prompt input schema**.
- **`config/config.schema.json`** - `sessions` block.

## Decisions (locked, from /grill-me + plan review)

Opt-in default-off; per-file (no global lock); persist both `consensus` and `ask-all`; revisit = re-run with current config (not snapshot-replay); persist current shape + `schemaVersion: 1`.

## Cross-review

Reviewed by Gemini (code-reviewer persona, advisory). Codex was unavailable (auth/token expiry). Valid findings folded into this branch: word-boundary key regexes, variable-length Google key match, revisit carries original file refs, annotation note cap, `capText` suffix-budget + UTF-8 boundary, failed-rename temp cleanup.

## Test plan

- `npm run typecheck` - clean (strict `checkJs`).
- `node --test test/*.test.js` - **337 pass / 0 fail** (+43 new across core-sessions, core-paths, openrouter-config, mcp-server).
- Manual: enable `sessions.persist`, run a `consensus`, confirm `<cache>/deliberation/sessions/<id>.json` exists (0600, keys scrubbed), `session-get` returns it, `session-revisit` makes a linked child, `session-annotate` appends, default-off path writes nothing.