### PR TITLE
ci: drop redundant master-push validate, add PR concurrency

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,9 +7,15 @@ name: Validate
 
 on:
   pull_request:
-  push:
-    branches: [master]
   workflow_dispatch:
+
+# All changes land on master via PR squash-merge, and master's ruleset requires
+# this "validate" check - so the pull_request run already gates every merge. A
+# post-merge push:[master] run would only re-test the identical tree, so it is
+# omitted. workflow_dispatch stays as a manual fallback.
+concurrency:
+  group: validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

`validate.yml` ran **twice per merge**: once on the PR (the required `validate` check), then again on the `master` push of the squash-merged commit - re-testing the identical tree (npm ci + typecheck + tests + version-sync).

- Remove `push: [master]` trigger (keep `pull_request` + `workflow_dispatch`).
- Add a `concurrency` group that cancels superseded PR runs.
- Release workflows untouched.

## Why safe

`master` is protected; the ruleset requires the `validate` check, which is produced by the `pull_request` event and gates every merge. All changes land via PR squash-merge (direct pushes blocked), so the post-merge run only re-tested an already-validated tree. The release PR (`chore(release): vX.Y.Z`) still validates on its PR event - that is where the version-sync check verifies the bumped files. `workflow_dispatch` remains as a manual fallback.

The self-skipping jobs in `automated-release.yml` / `tag-release.yml` are intentionally left alone: job-level `if:` is evaluated before a runner is provisioned, so they cost zero billed minutes.

## Net effect

Removes ~2 redundant full validate runs per release cycle (feature-merge push + release-merge push) and auto-cancels stale PR runs.

## Risks

- **Admin bypass / policy drift (low):** if branch protection is later relaxed to allow direct pushes to `master`, those commits skip validation. Mitigated by `workflow_dispatch` and the current ruleset.
- **npm cache warmth (minor):** default-branch cache is now seeded by PR runs instead of the master-push run. Negligible - devDeps only, lockfile-keyed, 7-day retention.

## Verification

- [ ] This PR shows exactly one `Validate` run (pull_request) and it is the required check.
- [ ] Push a second commit here → first run cancels (`cancel-in-progress`).
- [ ] After merge → no `Validate` run on the master push.
- [ ] Next release: `chore(release):` PR runs `Validate`, merge tags+publishes, no duplicate validate.

Reviewed via 5-model /ask-all (Codex, Gemini, Grok, deepseek-v4-pro, qwen3-7-max) - unanimous, high confidence.