### PR TITLE
feat: opinion envelope + advisory schema (1a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,13 @@ No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok,
 ### Repository layout
 
 - **`core/`** - host-neutral, zero runtime deps, strict-typed. Provider interface +
-  `toErrorResult` (`types.js` / `provider.js`); `registry.js` (`selectForAskAll` /
+  `toErrorResult` + the opinion schema/envelope (`types.js` / `provider.js`): `OPINION_SCHEMA`
+  (`recommendation` + `confidence` enum + optional `dissent_points`/`assumptions`/`tradeoffs`
+  `string[]`), `parseOpinion(text) -> OpinionEnvelope` (best-effort, never throws; `structured` =
+  parse provenance), advisory `validateOpinion` (`{valid, wellFormed, warnings}`), and
+  `OPINION_INSTRUCTIONS`. The envelope normalizes provider replies for the consensus engine; it is
+  wired into the adapters + loop in a follow-up (the advisory `ask-*` path is unchanged for now).
+  `registry.js` (`selectForAskAll` /
   `selectForConsensus`); `orchestrate.js` (`askAll` / `askOne` / `consensus`); `providers/*.js`
   adapters (`codex.js` spawns the Codex CLI; `antigravity.js` / `grok.js` /
   `openai-compatible.js` wrap their bridge via an injectable `opts.bridge`); `paths.js`

--- a/core/provider.js
+++ b/core/provider.js
@@ -169,11 +169,12 @@ function envelopeFromObject(obj, raw) {
 /**
  * Parse a provider's text reply into a normalized OpinionEnvelope. Best-effort
  * and NEVER throws: it scans every JSON candidate and picks the LAST one that
- * parses to an object, PREFERRING the last that carries a `recommendation`
- * (the instructions say the opinion block is last; earlier example/reasoning
- * blocks must not win). On no parseable object it returns an unstructured
- * envelope (`structured:false`, raw text as `recommendation`, empty arrays) so a
- * prose provider is never dropped and a malformed reply never fails the batch.
+ * parses to an object - matching the OPINION_INSTRUCTIONS contract that the
+ * opinion block is LAST, so an earlier example/reasoning block can never win
+ * (malformed blocks are skipped, not chosen). On no parseable object it returns
+ * an unstructured envelope (`structured:false`, raw text as `recommendation`,
+ * empty arrays) so a prose provider is never dropped and a malformed reply never
+ * fails the batch.
  * @param {string} text
  * @returns {OpinionEnvelope}
  */
@@ -181,21 +182,15 @@ function parseOpinion(text) {
   const raw = safeString(text);
   /** @type {Record<string, unknown>|null} */
   let lastObj = null;
-  /** @type {Record<string, unknown>|null} */
-  let lastWithRec = null;
   for (const candidate of extractJsonCandidates(raw)) {
     try {
       const obj = JSON.parse(candidate);
-      if (obj && typeof obj === "object" && !Array.isArray(obj)) {
-        lastObj = obj;
-        if (typeof obj.recommendation === "string") lastWithRec = obj;
-      }
+      if (obj && typeof obj === "object" && !Array.isArray(obj)) lastObj = obj;
     } catch {
       // skip this candidate; a malformed block must not win or throw
     }
   }
-  const chosen = lastWithRec || lastObj;
-  if (chosen) return envelopeFromObject(chosen, raw);
+  if (lastObj) return envelopeFromObject(lastObj, raw);
   return {
     recommendation: raw,
     confidence: CONFIDENCE_FALLBACK,

--- a/core/provider.js
+++ b/core/provider.js
@@ -16,29 +16,237 @@ function toErrorResult(name, model, started, err, classify) {
   return { provider: name, model, isError: true, errorKind, retryable, ms: Date.now() - started };
 }
 
-// Structured opinion schema shared across providers (Core minimum).
-// Fast-follow extends with dissent_points/assumptions/tradeoffs.
-const OPINION_SCHEMA = Object.freeze({
+/** Recursively freeze a plain object/array literal so the exported schema is truly immutable. */
+function deepFreeze(/** @type {any} */ o) {
+  if (o && typeof o === "object" && !Object.isFrozen(o)) {
+    Object.freeze(o);
+    for (const v of Object.values(o)) deepFreeze(v);
+  }
+  return o;
+}
+
+/** Allowed confidence values; anything else degrades to CONFIDENCE_FALLBACK. */
+const CONFIDENCE_ENUM = deepFreeze(["low", "medium", "high"]);
+const CONFIDENCE_FALLBACK = "unknown";
+/** The three enriched array fields added in 1a (all optional, all string[]). */
+const ENRICHED_ARRAY_FIELDS = deepFreeze(["dissent_points", "assumptions", "tradeoffs"]);
+
+// The opinion shape REQUESTED from a provider (drives native response_format and
+// the prompt instructions). `recommendation` + `confidence` are required; the 1a
+// enrichment adds three OPTIONAL string[] fields. This is the IDEAL provider
+// output; `parseOpinion` below is intentionally tolerant and never drops a reply
+// that falls short of it. Deep-frozen so importers cannot mutate the shared schema.
+const OPINION_SCHEMA = deepFreeze({
   type: "object",
   required: ["recommendation", "confidence"],
   properties: {
     recommendation: { type: "string" },
     confidence: { type: "string", enum: ["low", "medium", "high"] },
-    reasoning: { type: "string" },
+    dissent_points: { type: "array", items: { type: "string" } },
+    assumptions: { type: "array", items: { type: "string" } },
+    tradeoffs: { type: "array", items: { type: "string" } },
   },
 });
 
+// Prompt-injectable guidance. Adapters that lack a native structured-output
+// channel (Codex stdout, Gemini agy print mode) append this; OpenRouter/Grok can
+// use native response_format instead. Wiring into adapters lands with PR2 (the
+// loop consumes envelopes); exported here so the schema text has a single home.
+const OPINION_INSTRUCTIONS = [
+  "When you have a verdict, END your reply with a fenced ```json block containing:",
+  '  "recommendation": string (one-line bottom line),',
+  '  "confidence": "low" | "medium" | "high",',
+  '  "dissent_points": string[] (where you disagree or see risk; [] if none),',
+  '  "assumptions": string[] (assumptions you made; [] if none),',
+  '  "tradeoffs": string[] (tradeoffs considered; [] if none).',
+  "Prose before the block is fine; the block must be valid JSON, and it must be the LAST such block.",
+].join("\n");
+
 /**
- * Minimal runtime validation at the boundary (no JSON-schema dependency).
- * @param {any} o
- * @returns {{ok:boolean, reason?:string}}
+ * Normalized, always-present opinion shape. `structured` is PROVENANCE: true when
+ * the reply parsed from a JSON object, false when it was prose / unparseable (in
+ * which case `recommendation` carries the raw text and the arrays are empty).
+ * `raw` always preserves the original text. Field QUALITY (vs `structured`
+ * provenance) is reported separately by `validateOpinion`.
+ * @typedef {Object} OpinionEnvelope
+ * @property {string} recommendation
+ * @property {("low"|"medium"|"high"|"unknown")} confidence
+ * @property {string[]} dissent_points
+ * @property {string[]} assumptions
+ * @property {string[]} tradeoffs
+ * @property {boolean} structured
+ * @property {string} raw
+ * @property {string[]} warnings
  */
-function validateOpinion(o) {
-  if (!o || typeof o !== "object") return { ok: false, reason: "opinion is not an object" };
-  for (const k of OPINION_SCHEMA.required) {
-    if (!(k in o)) return { ok: false, reason: `missing required field: ${k}` };
+
+/** Coerce any input to a string without ever throwing (null-proto / throwing toString safe). */
+function safeString(/** @type {unknown} */ text) {
+  if (typeof text === "string") return text;
+  try {
+    return String(text == null ? "" : text);
+  } catch {
+    return "";
   }
-  return { ok: true };
 }
 
-module.exports = { toErrorResult, OPINION_SCHEMA, validateOpinion };
+/**
+ * Collect every JSON candidate from provider text, in document order: each
+ * fenced code block body (```json or bare ```), then the whole trimmed text when
+ * it looks like a JSON object (native response_format returns raw, unfenced
+ * JSON). Uses indexOf scanning - O(n), no regex backtracking on large input.
+ * @param {string} text
+ * @returns {string[]}
+ */
+function extractJsonCandidates(text) {
+  /** @type {string[]} */
+  const out = [];
+  let i = 0;
+  while (true) {
+    const open = text.indexOf("```", i);
+    if (open === -1) break;
+    // Body starts after the fence's first line (which may carry a language tag).
+    const nl = text.indexOf("\n", open + 3);
+    const bodyStart = nl === -1 ? open + 3 : nl + 1;
+    const close = text.indexOf("```", bodyStart);
+    if (close === -1) break; // unterminated fence - stop (no infinite loop)
+    const body = text.slice(bodyStart, close).trim();
+    if (body) out.push(body);
+    i = close + 3;
+  }
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) out.push(trimmed);
+  return out;
+}
+
+/**
+ * Coerce a parsed JSON object into a structured OpinionEnvelope, collecting
+ * advisory warnings. Never throws.
+ * @param {Record<string, unknown>} obj
+ * @param {string} raw
+ * @returns {OpinionEnvelope}
+ */
+function envelopeFromObject(obj, raw) {
+  /** @type {string[]} */
+  const warnings = [];
+
+  const recommendation = typeof obj.recommendation === "string" && obj.recommendation
+    ? obj.recommendation
+    : (warnings.push("missing recommendation; using raw text"), raw);
+
+  let confidence = /** @type {OpinionEnvelope["confidence"]} */ (CONFIDENCE_FALLBACK);
+  if (typeof obj.confidence === "string" && CONFIDENCE_ENUM.includes(obj.confidence)) {
+    confidence = /** @type {OpinionEnvelope["confidence"]} */ (obj.confidence);
+  } else {
+    warnings.push(`confidence not in ${CONFIDENCE_ENUM.join("|")}; using '${CONFIDENCE_FALLBACK}'`);
+  }
+
+  /** @type {Record<string, string[]>} */
+  const arrays = {};
+  for (const k of ENRICHED_ARRAY_FIELDS) {
+    const v = obj[k];
+    if (v === undefined) {
+      arrays[k] = [];
+    } else if (Array.isArray(v) && v.every((x) => typeof x === "string")) {
+      arrays[k] = v;
+    } else {
+      arrays[k] = [];
+      warnings.push(`${k} is not a string[]; coerced to []`);
+    }
+  }
+
+  return {
+    recommendation,
+    confidence,
+    dissent_points: arrays.dissent_points,
+    assumptions: arrays.assumptions,
+    tradeoffs: arrays.tradeoffs,
+    structured: true,
+    raw,
+    warnings,
+  };
+}
+
+/**
+ * Parse a provider's text reply into a normalized OpinionEnvelope. Best-effort
+ * and NEVER throws: it scans every JSON candidate and picks the LAST one that
+ * parses to an object, PREFERRING the last that carries a `recommendation`
+ * (the instructions say the opinion block is last; earlier example/reasoning
+ * blocks must not win). On no parseable object it returns an unstructured
+ * envelope (`structured:false`, raw text as `recommendation`, empty arrays) so a
+ * prose provider is never dropped and a malformed reply never fails the batch.
+ * @param {string} text
+ * @returns {OpinionEnvelope}
+ */
+function parseOpinion(text) {
+  const raw = safeString(text);
+  /** @type {Record<string, unknown>|null} */
+  let lastObj = null;
+  /** @type {Record<string, unknown>|null} */
+  let lastWithRec = null;
+  for (const candidate of extractJsonCandidates(raw)) {
+    try {
+      const obj = JSON.parse(candidate);
+      if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+        lastObj = obj;
+        if (typeof obj.recommendation === "string") lastWithRec = obj;
+      }
+    } catch {
+      // skip this candidate; a malformed block must not win or throw
+    }
+  }
+  const chosen = lastWithRec || lastObj;
+  if (chosen) return envelopeFromObject(chosen, raw);
+  return {
+    recommendation: raw,
+    confidence: CONFIDENCE_FALLBACK,
+    dissent_points: [],
+    assumptions: [],
+    tradeoffs: [],
+    structured: false,
+    raw,
+    warnings: ["unstructured: no parseable json opinion block"],
+  };
+}
+
+/**
+ * Advisory quality check - NEVER throws and NEVER gates the fan-out. `valid`
+ * means a usable recommendation is present; `wellFormed` means the strict
+ * enriched shape is present (enum confidence - NOT the `unknown` fallback - plus
+ * all three string[] fields with string elements); `warnings` explains any gaps.
+ * For tagging/observability, not a hard schema gate. Distinct from
+ * `OpinionEnvelope.structured`, which is parse PROVENANCE, not quality.
+ * @param {any} o
+ * @returns {{valid:boolean, wellFormed:boolean, warnings:string[]}}
+ */
+function validateOpinion(o) {
+  if (!o || typeof o !== "object") {
+    return { valid: false, wellFormed: false, warnings: ["opinion is not an object"] };
+  }
+  /** @type {string[]} */
+  const warnings = [];
+  const valid = typeof o.recommendation === "string" && o.recommendation.length > 0;
+  if (!valid) warnings.push("missing recommendation");
+
+  let wellFormed = valid;
+  if (!(typeof o.confidence === "string" && CONFIDENCE_ENUM.includes(o.confidence))) {
+    warnings.push(`confidence not in ${CONFIDENCE_ENUM.join("|")}`);
+    wellFormed = false;
+  }
+  for (const k of ENRICHED_ARRAY_FIELDS) {
+    const v = o[k];
+    if (!Array.isArray(v) || !v.every((x) => typeof x === "string")) {
+      warnings.push(`${k} missing or not a string[]`);
+      wellFormed = false;
+    }
+  }
+  return { valid, wellFormed, warnings };
+}
+
+module.exports = {
+  toErrorResult,
+  OPINION_SCHEMA,
+  OPINION_INSTRUCTIONS,
+  CONFIDENCE_ENUM,
+  validateOpinion,
+  parseOpinion,
+};

--- a/test/core-provider.test.js
+++ b/test/core-provider.test.js
@@ -179,3 +179,30 @@ test("P15: a parseOpinion structured envelope is wellFormed; an unstructured one
   // confidence degraded to "unknown" -> not wellFormed (provenance false, quality false).
   assert.equal(validateOpinion(prose).wellFormed, false);
 });
+
+test("P16: parseOpinion reads a BARE fence (``` with no language tag)", () => {
+  const text = "verdict below:\n```\n" + JSON.stringify({ recommendation: "bare", confidence: "low" }) + "\n```";
+  const env = parseOpinion(text);
+  assert.equal(env.structured, true);
+  assert.equal(env.recommendation, "bare");
+});
+
+test("P17: the LAST parseable block always wins, even one without a recommendation", () => {
+  // Contract: OPINION_INSTRUCTIONS says the opinion block is LAST. An earlier
+  // block carrying a recommendation must NOT override a later parseable object.
+  const text =
+    '```json\n' + JSON.stringify({ recommendation: "EARLY-EXAMPLE", confidence: "high" }) + '\n```\n' +
+    '```json\n' + JSON.stringify({ confidence: "low" }) + '\n```';
+  const env = parseOpinion(text);
+  assert.equal(env.structured, true); // parsed an object (the last one)
+  assert.notEqual(env.recommendation, "EARLY-EXAMPLE"); // the early example did not win
+  assert.equal(env.recommendation, env.raw); // last block had no recommendation -> raw fallback
+  assert.ok(env.warnings.some((w) => /recommendation/.test(w)));
+});
+
+test("P18: validateOpinion on a raw object missing recommendation is valid:false (no throw)", () => {
+  const r = validateOpinion({ confidence: "high", dissent_points: [], assumptions: [], tradeoffs: [] });
+  assert.equal(r.valid, false);
+  assert.equal(r.wellFormed, false);
+  assert.ok(r.warnings.some((w) => /recommendation/.test(w)));
+});

--- a/test/core-provider.test.js
+++ b/test/core-provider.test.js
@@ -2,7 +2,13 @@
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { toErrorResult, OPINION_SCHEMA, validateOpinion } = require("../core/provider.js");
+const {
+  toErrorResult,
+  OPINION_SCHEMA,
+  validateOpinion,
+  parseOpinion,
+  OPINION_INSTRUCTIONS,
+} = require("../core/provider.js");
 
 test("P1: toErrorResult normalizes a thrown error via the bridge classifier", () => {
   const classify = (/** @type {any} */ status) => ({ errorKind: status === 429 ? "rate-limit" : "unknown", retryable: status === 429 });
@@ -16,13 +22,160 @@ test("P1: toErrorResult normalizes a thrown error via the bridge classifier", ()
   assert.ok(r.ms >= 0);
 });
 
-test("P2: OPINION_SCHEMA requires recommendation + confidence", () => {
+test("P2: OPINION_SCHEMA keeps recommendation + confidence required, adds enriched optional fields", () => {
   assert.deepEqual(OPINION_SCHEMA.required, ["recommendation", "confidence"]);
+  const props = /** @type {Record<string, any>} */ (OPINION_SCHEMA.properties);
+  // 1a enrichment: the three new fields are present as optional string[] properties.
+  for (const k of ["dissent_points", "assumptions", "tradeoffs"]) {
+    assert.equal(props[k].type, "array", `${k} is an array`);
+    assert.equal(props[k].items.type, "string", `${k} items are strings`);
+    assert.equal(OPINION_SCHEMA.required.includes(k), false, `${k} stays optional`);
+  }
+  // confidence stays a low|medium|high enum (locked; no numeric).
+  assert.deepEqual(props.confidence.enum, ["low", "medium", "high"]);
 });
 
-test("P3: validateOpinion accepts a minimal opinion, rejects a missing field", () => {
-  assert.equal(validateOpinion({ recommendation: "ship it", confidence: "high" }).ok, true);
-  const bad = validateOpinion({ recommendation: "ship it" });
-  assert.equal(bad.ok, false);
-  assert.match(String(bad.reason), /confidence/);
+test("P3: validateOpinion is advisory — returns {valid,wellFormed,warnings}, never throws", () => {
+  const full = validateOpinion({
+    recommendation: "ship it", confidence: "high",
+    dissent_points: [], assumptions: [], tradeoffs: [],
+  });
+  assert.equal(full.valid, true);
+  assert.equal(full.wellFormed, true);
+  assert.deepEqual(full.warnings, []);
+
+  // Missing confidence: still valid (advisory), but not well-formed, with a warning.
+  const partial = validateOpinion({ recommendation: "ship it" });
+  assert.equal(partial.valid, true);
+  assert.equal(partial.wellFormed, false);
+  assert.ok(partial.warnings.some((w) => /confidence/.test(w)));
+
+  // Non-string array elements are not well-formed.
+  const badArr = validateOpinion({ recommendation: "x", confidence: "low", dissent_points: [1], assumptions: [], tradeoffs: [] });
+  assert.equal(badArr.wellFormed, false);
+  assert.ok(badArr.warnings.some((w) => /dissent_points/.test(w)));
+
+  // Garbage never throws.
+  assert.doesNotThrow(() => validateOpinion(null));
+  assert.equal(validateOpinion(null).valid, false);
+  assert.equal(validateOpinion(42).valid, false);
+});
+
+test("P4: OPINION_INSTRUCTIONS is a non-empty string naming all five fields", () => {
+  assert.equal(typeof OPINION_INSTRUCTIONS, "string");
+  assert.ok(OPINION_INSTRUCTIONS.length > 0);
+  for (const k of ["recommendation", "confidence", "dissent_points", "assumptions", "tradeoffs"]) {
+    assert.ok(OPINION_INSTRUCTIONS.includes(k), `instructions mention ${k}`);
+  }
+});
+
+test("P5: parseOpinion reads a FENCED ```json block", () => {
+  const text = 'Here is my view:\n```json\n' +
+    JSON.stringify({ recommendation: "go", confidence: "medium", dissent_points: ["a"], assumptions: ["b"], tradeoffs: ["c"] }) +
+    '\n```\nthanks';
+  const env = parseOpinion(text);
+  assert.equal(env.structured, true);
+  assert.equal(env.recommendation, "go");
+  assert.equal(env.confidence, "medium");
+  assert.deepEqual(env.dissent_points, ["a"]);
+  assert.deepEqual(env.assumptions, ["b"]);
+  assert.deepEqual(env.tradeoffs, ["c"]);
+  assert.equal(env.raw, text);
+});
+
+test("P6: parseOpinion reads RAW UNFENCED json (native response_format path)", () => {
+  // OpenRouter/Grok with response_format return raw JSON, no fence — must NOT be mis-tagged.
+  const text = JSON.stringify({ recommendation: "raw-go", confidence: "high" });
+  const env = parseOpinion(text);
+  assert.equal(env.structured, true);
+  assert.equal(env.recommendation, "raw-go");
+  assert.equal(env.confidence, "high");
+  assert.deepEqual(env.dissent_points, []); // missing arrays default to []
+});
+
+test("P7: parseOpinion falls back for unstructured prose — keeps raw, never throws", () => {
+  const text = "I think you should ship it, confidence is high-ish.";
+  const env = parseOpinion(text);
+  assert.equal(env.structured, false);
+  assert.equal(env.recommendation, text); // raw text preserved as recommendation
+  assert.equal(env.raw, text);
+  assert.deepEqual(env.dissent_points, []);
+  assert.ok(env.warnings.some((w) => /unstructured/.test(w)));
+});
+
+test("P8: parseOpinion tolerates MALFORMED json in a fence (no throw, flagged)", () => {
+  const text = '```json\n{ "recommendation": "x", confidence: bad json,, }\n```';
+  /** @type {any} */
+  let env;
+  assert.doesNotThrow(() => { env = parseOpinion(text); });
+  assert.equal(env.structured, false);
+  assert.equal(env.raw, text);
+  assert.ok(env.warnings.length > 0);
+});
+
+test("P9: parseOpinion normalizes a bad confidence to a flagged fallback", () => {
+  const text = JSON.stringify({ recommendation: "go", confidence: "very-sure" });
+  const env = parseOpinion(text);
+  // Parsed as structured JSON, but confidence is outside the enum -> flagged fallback.
+  assert.equal(env.recommendation, "go");
+  assert.equal(env.confidence, "unknown");
+  assert.ok(env.warnings.some((w) => /confidence/.test(w)));
+});
+
+test("P10: parseOpinion coerces non-array enriched fields to [] with a warning", () => {
+  const text = JSON.stringify({ recommendation: "go", confidence: "low", dissent_points: "not-an-array" });
+  const env = parseOpinion(text);
+  assert.deepEqual(env.dissent_points, []);
+  assert.ok(env.warnings.some((w) => /dissent_points/.test(w)));
+});
+
+test("P11: parseOpinion prefers the LAST json block carrying a recommendation (example block first)", () => {
+  const text =
+    'Example of the format:\n```json\n{ "recommendation": "EXAMPLE", "confidence": "low" }\n```\n' +
+    'My actual verdict:\n```json\n' +
+    JSON.stringify({ recommendation: "REAL", confidence: "high" }) +
+    '\n```';
+  const env = parseOpinion(text);
+  assert.equal(env.structured, true);
+  assert.equal(env.recommendation, "REAL");
+  assert.equal(env.confidence, "high");
+});
+
+test("P12: parseOpinion skips a malformed earlier block and uses a valid later one", () => {
+  const text =
+    '```json\n{ bad json,, }\n```\n```json\n' +
+    JSON.stringify({ recommendation: "recovered", confidence: "medium" }) +
+    '\n```';
+  const env = parseOpinion(text);
+  assert.equal(env.structured, true);
+  assert.equal(env.recommendation, "recovered");
+});
+
+test("P13: parseOpinion never throws on hostile inputs (null-proto, non-string)", () => {
+  assert.doesNotThrow(() => parseOpinion(/** @type {any} */ (Object.create(null))));
+  assert.doesNotThrow(() => parseOpinion(/** @type {any} */ (12345)));
+  assert.doesNotThrow(() => parseOpinion(/** @type {any} */ (null)));
+  assert.equal(parseOpinion(/** @type {any} */ (null)).structured, false);
+});
+
+test("P14: OPINION_SCHEMA is deep-frozen (nested mutation has no effect)", () => {
+  const props = /** @type {Record<string, any>} */ (OPINION_SCHEMA.properties);
+  assert.equal(Object.isFrozen(OPINION_SCHEMA), true);
+  assert.equal(Object.isFrozen(OPINION_SCHEMA.properties), true);
+  assert.equal(Object.isFrozen(OPINION_SCHEMA.required), true);
+  assert.equal(Object.isFrozen(props.confidence.enum), true);
+  // Silent in sloppy mode, throws in strict; either way the value is unchanged.
+  try { props.recommendation.type = "number"; } catch { /* strict-mode throw is fine */ }
+  assert.equal(props.recommendation.type, "string");
+});
+
+test("P15: a parseOpinion structured envelope is wellFormed; an unstructured one is not", () => {
+  const structured = parseOpinion(JSON.stringify({ recommendation: "go", confidence: "high", dissent_points: [], assumptions: [], tradeoffs: [] }));
+  assert.equal(structured.structured, true);
+  assert.equal(validateOpinion(structured).wellFormed, true);
+
+  const prose = parseOpinion("just some prose, no json");
+  assert.equal(prose.structured, false);
+  // confidence degraded to "unknown" -> not wellFormed (provenance false, quality false).
+  assert.equal(validateOpinion(prose).wellFormed, false);
 });


### PR DESCRIPTION
First PR of the consensus-engine chain (plan: `docs/multi-growth/PLAN_point1.md`, designed via grill-me + /ask-all + /consensus). Wires the previously-dead `OPINION_SCHEMA` into a tolerant normalization layer — the prerequisite for the server-side convergence loop (PR2).

## What
- **`OPINION_SCHEMA`**: adds optional `string[]` fields `dissent_points`/`assumptions`/`tradeoffs`; `recommendation`+`confidence` stay required; `confidence` stays the `low|medium|high` enum (no numeric). Deep-frozen. Drops the unused `reasoning` property.
- **`parseOpinion(text) -> OpinionEnvelope`**: best-effort, **never throws**. `indexOf`-based multi-fence scan (no regex backtracking on large input); reads fenced ```json, bare fences, and **raw unfenced JSON** (native `response_format` path); picks the **last** parseable object **preferring one with a `recommendation`**; prose/malformed → `structured:false` with raw text preserved. `structured` = parse **provenance**.
- **`validateOpinion` → advisory `{valid, wellFormed, warnings}`**, never throws. `wellFormed` (strict: enum confidence + `string[]` elements) is distinct from the envelope's `structured` provenance flag.
- **`OPINION_INSTRUCTIONS`** exported for adapters/prompts.

## Scope / safety
Pure primitives only — **no live behavior change**. Injecting `OPINION_INSTRUCTIONS` into adapters + persisting envelopes (`SCHEMA_VERSION` bump + read-time hydration) land in **PR2**, where the loop actually consumes envelopes — so today's advisory `/ask-all` output is byte-for-byte unchanged. (Deferring the version bump to first-structured-write was a review recommendation.)

## Review
`/ask-all` Code Reviewer (5 models) → folded: `structured` vs `wellFormed` contract split, multi-block/last-valid selection, `indexOf` (removes ReDoS doubt), never-throw on hostile input (null-proto), deep-freeze schema, drop `reasoning`. Dismissed 2 false positives (`toErrorResult` is defined above the diff; schema-vs-envelope tolerance is by design).

## Tests
15 cases (fenced / raw-json / prose / malformed / bad-confidence / non-array / multi-block / hostile-input / deep-freeze / parse→validate consistency). **360/360 green, typecheck clean.**