### PR TITLE
feat: consensus-loop core state machine (PR2a, SSOT)

### DIFF
--- a/core/consensus-loop.js
+++ b/core/consensus-loop.js
@@ -1,0 +1,304 @@
+"use strict";
+
+/**
+ * core/consensus-loop.js - the single source of truth for the multi-round
+ * consensus convergence loop. PURE host-neutral state machine: every transition
+ * takes a state and returns a NEW state (never mutates), and performs NO I/O.
+ *
+ * Hosts drive it differently but share THIS logic (no duplicate algorithm):
+ *   - Claude Code: a thin client-driven driver calls these transitions one step
+ *     per turn, emitting its blind verdict + adjudication as visible transcript
+ *     messages (preserving accountability). Server wiring + driver land in PR2b.
+ *   - Non-Claude hosts: a `runToConvergence` wrapper (PR2b) drives the SAME
+ *     transitions internally with a provider arbiter.
+ *
+ * `recordBlindVerdict` gates peer reveal (precommit); `submitAdjudication`
+ * refuses a silent dismissal (no reason -> throws); `checkConvergence` is pure
+ * and enforces "cannot self-approve". See docs/multi-growth/PLAN_point1.md.
+ */
+
+const MAX_ROUNDS_DEFAULT = 5;
+/** Closed verdict set a peer/host review can carry. */
+const VERDICTS = Object.freeze(["APPROVE", "REQUEST_CHANGES", "REJECT"]);
+
+/**
+ * @typedef {Object} CriticalIssue
+ * @property {("security"|"correctness"|"scope"|"ambiguity"|"performance"|"ops")} category
+ * @property {string} description
+ */
+
+/**
+ * One voice's review for a round. `isError` voices are excluded from the
+ * convergence bar. `verdict` is null when errored.
+ * @typedef {Object} ReviewResult
+ * @property {string} source
+ * @property {boolean} isError
+ * @property {string} [errorKind]
+ * @property {(("APPROVE"|"REQUEST_CHANGES"|"REJECT")|null)} verdict
+ * @property {CriticalIssue[]} criticalIssues
+ * @property {any} [envelope]
+ * @property {number} [ms]
+ */
+
+/**
+ * An adjudication decision on one critical issue. `dismiss`/`defer` REQUIRE a
+ * reason (enforced - no silent dismissal).
+ * @typedef {Object} Decision
+ * @property {string} source
+ * @property {("security"|"correctness"|"scope"|"ambiguity"|"performance"|"ops")} category
+ * @property {string} description
+ * @property {("accept"|"dismiss"|"defer")} action
+ * @property {string} [reason]
+ */
+
+/**
+ * @typedef {Object} HostVerdict
+ * @property {("APPROVE"|"REQUEST_CHANGES"|"REJECT")} verdict
+ * @property {CriticalIssue[]} [criticalIssues]
+ */
+
+/**
+ * @typedef {Object} RoundRecord
+ * @property {number} round
+ * @property {string} plan
+ * @property {(string|null)} blindVerdict
+ * @property {ReviewResult[]} results
+ * @property {Decision[]} decisions
+ * @property {(HostVerdict|null)} hostVerdict
+ * @property {string} [diffSummary]
+ */
+
+/**
+ * @typedef {Object} LoopState
+ * @property {number} round
+ * @property {number} maxRounds
+ * @property {("await_blind"|"await_peers"|"await_adjudication"|"await_revision"|"converged"|"unresolved")} status
+ * @property {string} currentPlan
+ * @property {(string|null)} [expert]
+ * @property {("host"|"provider")} arbiterMode
+ * @property {(string|null)} [blindVerdict]
+ * @property {ReviewResult[]} [results]
+ * @property {Decision[]} [decisions]
+ * @property {(HostVerdict|null)} [hostVerdict]
+ * @property {RoundRecord[]} history
+ */
+
+/** Throw a clear status-guard error so a driver can recover (expected vs got). */
+function assertStatus(/** @type {LoopState} */ state, /** @type {string} */ expected, /** @type {string} */ op) {
+  if (state.status !== expected) {
+    throw new Error(`${op}: expected status '${expected}', got '${state.status}'`);
+  }
+}
+
+/**
+ * @param {{plan:string, maxRounds?:number, expert?:string, arbiterMode?:("host"|"provider")}} opts
+ * @returns {LoopState}
+ */
+function initConsensusLoop(opts) {
+  const maxRounds = Number.isInteger(opts.maxRounds) && /** @type {number} */ (opts.maxRounds) > 0
+    ? /** @type {number} */ (opts.maxRounds)
+    : MAX_ROUNDS_DEFAULT;
+  return {
+    round: 1,
+    maxRounds,
+    status: "await_blind",
+    currentPlan: opts.plan,
+    expert: opts.expert || null,
+    arbiterMode: opts.arbiterMode || "host",
+    blindVerdict: null,
+    results: [],
+    decisions: [],
+    hostVerdict: null,
+    history: [],
+  };
+}
+
+/**
+ * Build the round's prompts. Pure read. Bounds history: the last 2 rounds appear
+ * verbatim (verdict + diff), older rounds as a one-line summary, to cap growth.
+ * Guarded to `await_blind` so a terminated/mid-round state cannot emit a stale
+ * "next round" prompt.
+ * @param {LoopState} state
+ * @returns {{peerPrompt:string, blindPrompt:string}}
+ */
+function prepareRound(state) {
+  assertStatus(state, "await_blind", "prepareRound");
+  const hist = state.history || [];
+  const recent = hist.slice(-2).map((r) => `Round ${r.round}: ${r.diffSummary || "(revised)"}`);
+  const older = hist.slice(0, -2).map((r) => `Round ${r.round}: revised`);
+  const meta = [...older, ...recent].join("\n");
+  const header = `Round ${state.round} of ${state.maxRounds}.`;
+  const body = [
+    header,
+    meta ? `Prior rounds:\n${meta}` : "",
+    `## Plan under review\n${state.currentPlan}`,
+  ].filter(Boolean).join("\n\n");
+  const peerPrompt = [
+    body,
+    "Review the plan for correctness, security, scope, ambiguity, performance, and ops gaps.",
+    "End with: **Verdict**: APPROVE | REQUEST_CHANGES | REJECT, then categorized critical issues.",
+  ].join("\n\n");
+  const blindPrompt = [
+    body,
+    "Give your own independent verdict BEFORE seeing peer opinions.",
+    "End with: **Verdict**: APPROVE | REQUEST_CHANGES | REJECT, then categorized critical issues.",
+  ].join("\n\n");
+  return { peerPrompt, blindPrompt };
+}
+
+/**
+ * Record the host/arbiter blind pre-commit. Gates peer reveal: peers cannot be
+ * added until this is set.
+ * @param {LoopState} state
+ * @param {string} blindVerdict
+ * @returns {LoopState}
+ */
+function recordBlindVerdict(state, blindVerdict) {
+  assertStatus(state, "await_blind", "recordBlindVerdict");
+  if (!(typeof blindVerdict === "string" && blindVerdict.trim())) {
+    throw new Error("recordBlindVerdict: blindVerdict must be a non-empty string");
+  }
+  return { ...state, blindVerdict, status: "await_peers" };
+}
+
+/**
+ * Attach the round's peer reviews.
+ * @param {LoopState} state
+ * @param {ReviewResult[]} results
+ * @returns {LoopState}
+ */
+function addOpinions(state, results) {
+  assertStatus(state, "await_peers", "addOpinions");
+  // Copy the array AND each element so later caller mutation cannot corrupt
+  // stored state or history (the pure-machine contract).
+  const owned = Array.isArray(results) ? results.map((r) => ({ ...r })) : [];
+  return { ...state, results: owned, status: "await_adjudication" };
+}
+
+/**
+ * Submit the host/arbiter adjudication: the overall `verdict` plus per-issue
+ * decisions. THROWS if any dismiss/defer lacks a reason (no silent dismissal).
+ * Then evaluates convergence and moves to `converged` or `await_revision`.
+ * @param {LoopState} state
+ * @param {{verdict:("APPROVE"|"REQUEST_CHANGES"|"REJECT"), decisions?:Decision[]}} adj
+ * @returns {LoopState}
+ */
+function submitAdjudication(state, adj) {
+  assertStatus(state, "await_adjudication", "submitAdjudication");
+  if (!adj || !VERDICTS.includes(adj.verdict)) {
+    throw new Error(`submitAdjudication: verdict must be one of ${VERDICTS.join("|")}`);
+  }
+  // Copy each decision so later caller mutation cannot corrupt stored state.
+  const decisions = Array.isArray(adj.decisions) ? adj.decisions.map((d) => ({ ...d })) : [];
+  decisions.forEach((d, i) => {
+    if (!d || typeof d !== "object") {
+      throw new Error(`submitAdjudication: decision at index ${i} is not an object`);
+    }
+    if ((d.action === "dismiss" || d.action === "defer") && !(typeof d.reason === "string" && d.reason.trim())) {
+      throw new Error(`submitAdjudication: decision at index ${i} (${d.action}) requires a non-empty reason`);
+    }
+  });
+  const next = { ...state, hostVerdict: { verdict: adj.verdict }, decisions };
+  const { converged } = checkConvergence(next);
+  return { ...next, status: converged ? "converged" : "await_revision" };
+}
+
+/**
+ * PURE convergence check. Converges only when: >=1 responding external (an
+ * errored voice is excluded), every responding external APPROVES, no REJECT,
+ * zero ACCEPTED critical issues, AND the host/arbiter verdict is APPROVE
+ * (cannot self-approve - peers must carry it).
+ *
+ * Contract: a peer's blocking concerns ride a REQUEST_CHANGES/REJECT verdict,
+ * which `everyApprove` catches. `criticalIssues` attached to an APPROVE verdict
+ * are advisory (the peer itself deemed them non-blocking by approving); they do
+ * not block convergence unless the host adjudicates one as `accept`. Any
+ * non-"APPROVE" / null / malformed verdict fails closed (no convergence).
+ * @param {LoopState} state
+ * @returns {{converged:boolean, verdict:("APPROVE"|"REQUEST_CHANGES"), nextAction:("finalize"|"revise")}}
+ */
+function checkConvergence(state) {
+  const results = state.results || [];
+  const responding = results.filter((r) => !r.isError);
+  const everyApprove = responding.length > 0 && responding.every((r) => r.verdict === "APPROVE");
+  const anyReject = responding.some((r) => r.verdict === "REJECT");
+  const acceptedCritical = (state.decisions || []).filter((d) => d.action === "accept").length;
+  const hostApprove = !!(state.hostVerdict && state.hostVerdict.verdict === "APPROVE");
+  const converged = responding.length > 0 && everyApprove && !anyReject && acceptedCritical === 0 && hostApprove;
+  return {
+    converged,
+    verdict: converged ? "APPROVE" : "REQUEST_CHANGES",
+    nextAction: converged ? "finalize" : "revise",
+  };
+}
+
+/**
+ * Apply the revised plan and advance. Records the just-finished round to history.
+ * If already at maxRounds, the loop ends `unresolved` (no further round).
+ * @param {LoopState} state
+ * @param {string} revisedPlan
+ * @param {string} [diffSummary]
+ * @returns {LoopState}
+ */
+function submitRevision(state, revisedPlan, diffSummary) {
+  assertStatus(state, "await_revision", "submitRevision");
+  /** @type {RoundRecord} */
+  const record = {
+    round: state.round,
+    plan: state.currentPlan,
+    blindVerdict: state.blindVerdict || null,
+    results: state.results || [],
+    decisions: state.decisions || [],
+    hostVerdict: state.hostVerdict || null,
+    diffSummary: diffSummary || "(revised)",
+  };
+  const history = [...state.history, record];
+  if (state.round >= state.maxRounds) {
+    return { ...state, history, status: "unresolved" };
+  }
+  return {
+    ...state,
+    history,
+    round: state.round + 1,
+    currentPlan: revisedPlan,
+    status: "await_blind",
+    blindVerdict: null,
+    results: [],
+    decisions: [],
+    hostVerdict: null,
+  };
+}
+
+/**
+ * Produce the final report + confidence label. Confidence by the round the loop
+ * settled in: 1 = high, 2-3 = medium, 4-5 = low; an unresolved loop = none.
+ * @param {Pick<LoopState,"status"|"round"|"history"|"currentPlan">} state
+ * @returns {{finalReport:string, confidence:("high"|"medium"|"low"|"none")}}
+ */
+function finalize(state) {
+  const confidence = state.status === "converged"
+    ? (state.round === 1 ? "high" : state.round <= 3 ? "medium" : "low")
+    : "none";
+  const outcome = state.status === "converged"
+    ? `CONVERGED in ${state.round} round(s) (confidence: ${confidence})`
+    : `UNRESOLVED after ${state.round} round(s)`;
+  const finalReport = [
+    `## Consensus result`,
+    `**Outcome**: ${outcome}`,
+    `**Final plan**:\n${state.currentPlan}`,
+  ].join("\n\n");
+  return { finalReport, confidence };
+}
+
+module.exports = {
+  MAX_ROUNDS_DEFAULT,
+  VERDICTS,
+  initConsensusLoop,
+  prepareRound,
+  recordBlindVerdict,
+  addOpinions,
+  submitAdjudication,
+  checkConvergence,
+  submitRevision,
+  finalize,
+};

--- a/test/core-consensus-loop.test.js
+++ b/test/core-consensus-loop.test.js
@@ -1,0 +1,180 @@
+// test/core-consensus-loop.test.js
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  initConsensusLoop,
+  prepareRound,
+  recordBlindVerdict,
+  addOpinions,
+  submitAdjudication,
+  submitRevision,
+  checkConvergence,
+  finalize,
+  MAX_ROUNDS_DEFAULT,
+} = require("../core/consensus-loop.js");
+
+/**
+ * A successful peer review result.
+ * @param {string} source
+ * @param {("APPROVE"|"REQUEST_CHANGES"|"REJECT")} verdict
+ * @param {any[]} [criticalIssues]
+ */
+function review(source, verdict, criticalIssues = []) {
+  return { source, isError: false, verdict, criticalIssues };
+}
+/** @param {string} source */
+function errored(source) {
+  return { source, isError: true, errorKind: "timeout", verdict: null, criticalIssues: [] };
+}
+
+test("L1: init starts at round 1, await_blind, carries the plan", () => {
+  const s = initConsensusLoop({ plan: "do X", expert: "Plan Reviewer", arbiterMode: "host" });
+  assert.equal(s.round, 1);
+  assert.equal(s.status, "await_blind");
+  assert.equal(s.currentPlan, "do X");
+  assert.equal(s.maxRounds, MAX_ROUNDS_DEFAULT);
+  assert.deepEqual(s.history, []);
+});
+
+test("L2: recordBlindVerdict requires await_blind and advances to await_peers", () => {
+  const s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  const s2 = recordBlindVerdict(s, "blind says request changes");
+  assert.equal(s2.status, "await_peers");
+  assert.equal(s2.blindVerdict, "blind says request changes");
+  // out-of-order: calling addOpinions before blind throws
+  assert.throws(() => addOpinions(s, [review("gpt", "APPROVE")]), /await_peers|status/i);
+});
+
+test("L3: addOpinions advances await_peers -> await_adjudication", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [review("gpt", "APPROVE"), review("gemini", "REQUEST_CHANGES", [{ category: "correctness", description: "x" }])]);
+  assert.equal(s.status, "await_adjudication");
+  assert.equal((s.results || []).length, 2);
+});
+
+test("L4: submitAdjudication THROWS naming the index when a dismiss/defer lacks a reason", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [review("gpt", "REQUEST_CHANGES", [{ category: "ops", description: "no rollback" }])]);
+  assert.throws(
+    () => submitAdjudication(s, { verdict: "REQUEST_CHANGES", decisions: [{ source: "gpt", category: "ops", description: "no rollback", action: "dismiss" }] }),
+    /index 0|reason/i,
+  );
+  // with a reason it does not throw
+  assert.doesNotThrow(() =>
+    submitAdjudication(s, { verdict: "APPROVE", decisions: [{ source: "gpt", category: "ops", description: "no rollback", action: "dismiss", reason: "already covered in step 4" }] }),
+  );
+});
+
+test("L5: converges when every responding peer APPROVES, host APPROVES, and no accepted critical issues", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "approve");
+  s = addOpinions(s, [review("gpt", "APPROVE"), review("gemini", "APPROVE"), errored("grok")]);
+  s = submitAdjudication(s, { verdict: "APPROVE", decisions: [] });
+  assert.equal(s.status, "converged");
+  const c = checkConvergence(s);
+  assert.equal(c.converged, true);
+});
+
+test("L6: a single REQUEST_CHANGES peer blocks convergence -> await_revision", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [review("gpt", "APPROVE"), review("gemini", "REQUEST_CHANGES", [{ category: "scope", description: "unclear" }])]);
+  s = submitAdjudication(s, { verdict: "REQUEST_CHANGES", decisions: [{ source: "gemini", category: "scope", description: "unclear", action: "accept" }] });
+  assert.equal(s.status, "await_revision");
+  assert.equal(checkConvergence(s).converged, false);
+});
+
+test("L7: an accepted critical issue blocks convergence even if all peers APPROVE", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [review("gpt", "APPROVE"), review("gemini", "APPROVE")]);
+  // host's own blind verdict surfaced an accepted issue
+  s = submitAdjudication(s, { verdict: "REQUEST_CHANGES", decisions: [{ source: "claude-blind", category: "security", description: "missing authz", action: "accept" }] });
+  assert.equal(checkConvergence(s).converged, false);
+});
+
+test("L8: cannot self-approve - all peers errored means no convergence", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [errored("gpt"), errored("gemini"), errored("grok")]);
+  s = submitAdjudication(s, { verdict: "APPROVE", decisions: [] });
+  const c = checkConvergence(s);
+  assert.equal(c.converged, false); // >=1 responding external is required
+});
+
+test("L9: submitRevision advances the round + sets the new plan; maxRounds -> unresolved", () => {
+  let s = initConsensusLoop({ plan: "p0", maxRounds: 2, arbiterMode: "host" });
+  // round 1: not converged -> revise
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [review("gpt", "REQUEST_CHANGES", [{ category: "ops", description: "x" }])]);
+  s = submitAdjudication(s, { verdict: "REQUEST_CHANGES", decisions: [{ source: "gpt", category: "ops", description: "x", action: "accept" }] });
+  s = submitRevision(s, "p1", "addressed x");
+  assert.equal(s.round, 2);
+  assert.equal(s.currentPlan, "p1");
+  assert.equal(s.status, "await_blind");
+  assert.equal(s.history.length, 1);
+  // round 2: still not converged + at maxRounds -> unresolved
+  s = recordBlindVerdict(s, "b2");
+  s = addOpinions(s, [review("gpt", "REQUEST_CHANGES", [{ category: "ops", description: "y" }])]);
+  s = submitAdjudication(s, { verdict: "REQUEST_CHANGES", decisions: [{ source: "gpt", category: "ops", description: "y", action: "accept" }] });
+  s = submitRevision(s, "p2", "tried y");
+  assert.equal(s.status, "unresolved");
+});
+
+test("L10: finalize labels confidence by round (1=high, 3=medium, 5=low, unresolved=none)", () => {
+  assert.equal(finalize({ status: "converged", round: 1, history: [], currentPlan: "p" }).confidence, "high");
+  assert.equal(finalize({ status: "converged", round: 3, history: [], currentPlan: "p" }).confidence, "medium");
+  assert.equal(finalize({ status: "converged", round: 5, history: [], currentPlan: "p" }).confidence, "low");
+  assert.equal(finalize({ status: "unresolved", round: 5, history: [], currentPlan: "p" }).confidence, "none");
+});
+
+test("L11: prepareRound returns peer + blind prompts that include the current plan", () => {
+  const s = initConsensusLoop({ plan: "ship the widget", arbiterMode: "host" });
+  const { peerPrompt, blindPrompt } = prepareRound(s);
+  assert.ok(peerPrompt.includes("ship the widget"));
+  assert.ok(blindPrompt.includes("ship the widget"));
+  assert.ok(/round 1/i.test(peerPrompt));
+});
+
+test("L12: full happy path - converge in round 1 yields a final report + high confidence", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "looks good");
+  s = addOpinions(s, [review("gpt", "APPROVE"), review("gemini", "APPROVE")]);
+  s = submitAdjudication(s, { verdict: "APPROVE", decisions: [] });
+  assert.equal(s.status, "converged");
+  const f = finalize(s);
+  assert.equal(f.confidence, "high");
+  assert.ok(typeof f.finalReport === "string" && f.finalReport.length > 0);
+});
+
+test("L13: caller mutation after addOpinions/submitAdjudication cannot corrupt state (immutability)", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  const peers = [review("gpt", "APPROVE")];
+  s = addOpinions(s, peers);
+  peers[0].verdict = "REJECT"; // mutate the caller's array AFTER ingest
+  assert.equal((s.results || [])[0].verdict, "APPROVE"); // stored copy is unaffected
+  /** @type {any[]} */
+  const decisions = [{ source: "gpt", category: "ops", description: "x", action: "accept" }];
+  s = submitAdjudication(s, { verdict: "APPROVE", decisions });
+  decisions[0].action = "dismiss";
+  assert.equal((s.decisions || [])[0].action, "accept");
+});
+
+test("L14: recordBlindVerdict rejects an empty/non-string verdict", () => {
+  const s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  assert.throws(() => recordBlindVerdict(s, ""), /non-empty/);
+  assert.throws(() => recordBlindVerdict(s, /** @type {any} */ (null)), /non-empty/);
+});
+
+test("L15: prepareRound throws on a terminated state (guarded to await_blind)", () => {
+  let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
+  s = recordBlindVerdict(s, "b");
+  s = addOpinions(s, [review("gpt", "APPROVE")]);
+  s = submitAdjudication(s, { verdict: "APPROVE", decisions: [] });
+  assert.equal(s.status, "converged");
+  assert.throws(() => prepareRound(s), /await_blind|status/i);
+});


### PR DESCRIPTION
Second step of the consensus-engine chain (plan: `docs/multi-growth/PLAN_point1.md`). The **single source of truth** for the multi-round consensus loop, as a **pure host-neutral state machine** — transitions return new state, no I/O.

Architecture locked by `/ask-all` Architect (5/5): core owns the loop; Claude drives it client-side (transcript-visible blind precommit) and non-Claude hosts call a wrapper — both over **this one** rules layer (no duplicate algorithm). **This PR is the pure core only**; the server `consensus-step` tool + thin Claude driver + `runToConvergence` wrapper land in **PR2b**.

## `core/consensus-loop.js`
`initConsensusLoop` / `prepareRound` / `recordBlindVerdict` / `addOpinions` / `submitAdjudication` / `checkConvergence` / `submitRevision` / `finalize`.

- **status**: `await_blind → await_peers → await_adjudication → (converged | await_revision) → submitRevision → await_blind | unresolved`.
- **Accountability preserved in core**: `recordBlindVerdict` gates peer reveal (precommit); `submitAdjudication` **throws** on a dismiss/defer without a reason (no silent dismissal); `checkConvergence` is **pure** and enforces **cannot-self-approve** (≥1 responding external, every responding APPROVE, no REJECT, zero accepted critical issues, host verdict APPROVE).
- `finalize`: confidence by round (1=high, 2-3=medium, 4-5=low; unresolved=none).

## Review
`/ask-all` Code Reviewer (5 models). Folded real fixes: deep-copy `results`/`decisions` on ingest (immutability), `prepareRound` guarded to `await_blind`, null-decision guard, non-empty `blindVerdict` guard, documented the APPROVE-with-issues convergence contract. **Dismissed 4 false positives** that were artifacts of the paraphrased snippet sent to the panel (verified against real code + green tests): `submitRevision` uses `state.*`; `maxRounds` is `Number.isInteger && >0` validated; `decisions:undefined` is guarded; a non-`APPROVE`/null verdict fails **closed** (no false convergence).

## Tests
15 cases (init / blind-gate / out-of-order / no-silent-dismissal / converge / request-changes / accepted-blocks / all-errored cannot-self-approve / revision+maxRounds→unresolved / confidence / prompts / happy-path / immutability / blind-empty / prepareRound-guard). **Full suite 378/378 green, typecheck clean.**