### PR TITLE
feat: parseReview - verdict + categorized issues parser (PR2b-1)

### DIFF
--- a/core/provider.js
+++ b/core/provider.js
@@ -237,11 +237,93 @@ function validateOpinion(o) {
   return { valid, wellFormed, warnings };
 }
 
+/** The closed 6-category taxonomy a consensus review tags critical issues with. */
+const REVIEW_CATEGORIES = deepFreeze(["security", "correctness", "scope", "ambiguity", "performance", "ops"]);
+const REVIEW_FALLBACK_CATEGORY = "ambiguity";
+
+/**
+ * @typedef {Object} ReviewCriticalIssue
+ * @property {("security"|"correctness"|"scope"|"ambiguity"|"performance"|"ops")} category
+ * @property {string} description
+ */
+
+/**
+ * @typedef {Object} ParsedReview
+ * @property {(("APPROVE"|"REQUEST_CHANGES"|"REJECT")|null)} verdict
+ * @property {ReviewCriticalIssue[]} criticalIssues
+ */
+
+// Anchored verdict matcher: the token must sit adjacent to the word "verdict"
+// (only non-alphanumerics between), and is matched on WORD BOUNDARIES. This
+// rejects substring traps ("DISAPPROVE"/"APPROVED" never match "APPROVE";
+// "verdict: do not REJECT" finds no adjacent token -> null) and loose prose
+// ("verdict as APPROVE" has the alpha word "as" between -> no match), so an
+// echoed instruction line cannot hijack the verdict.
+const VERDICT_RE = /\bverdict\b[^A-Za-z0-9]*\b(APPROVE|REJECT|REQUEST[_\s]CHANGES)\b/i;
+const BULLET_RE = /^([-*+•]|`?\[)/;
+const BRACKET_CAT_RE = /\[\s*([A-Za-z_]+)\s*\]/g;
+
+/**
+ * Parse a consensus REVIEW reply into a verdict + categorized critical issues.
+ * Best-effort and NEVER throws. Line-based (no regex backtracking on large input).
+ *
+ * - verdict: the FIRST line whose `verdict` keyword is immediately followed by a
+ *   bounded APPROVE/REJECT/REQUEST_CHANGES token wins (the reviewer's own verdict;
+ *   later quoted/template mentions are ignored). No adjacent token -> null.
+ * - criticalIssues: taken only from bullet/bracket lines; among multiple `[tag]`
+ *   brackets the FIRST that is a known category wins (so `- [P0] [security] ...`
+ *   categorizes as security), else the first bracket degrades to `ambiguity`. A
+ *   bullet with a category but NO description is dropped (not actionable for
+ *   convergence).
+ *
+ * Distinct from `parseOpinion` (advisory recommendation envelope) - this drives
+ * the consensus loop's convergence rule.
+ * @param {string} text
+ * @returns {ParsedReview}
+ */
+function parseReview(text) {
+  const raw = safeString(text);
+  const lines = raw.split(/\r?\n/);
+  /** @type {ParsedReview["verdict"]} */
+  let verdict = null;
+  /** @type {ReviewCriticalIssue[]} */
+  const criticalIssues = [];
+
+  for (const line of lines) {
+    if (verdict === null) {
+      const vm = line.match(VERDICT_RE);
+      if (vm) verdict = /** @type {ParsedReview["verdict"]} */ (vm[1].replace(/\s+/g, "_").toUpperCase());
+    }
+    const trimmed = line.trim();
+    if (!BULLET_RE.test(trimmed)) continue;
+    // Pick the first bracketed token that is a known category; else the first
+    // bracket at all (degraded to ambiguity). matchAll is reset each line.
+    let chosen = null;
+    for (const mm of trimmed.matchAll(BRACKET_CAT_RE)) {
+      if (REVIEW_CATEGORIES.includes(mm[1].toLowerCase())) { chosen = mm; break; }
+      if (chosen === null) chosen = mm; // remember the first bracket as fallback
+    }
+    if (!chosen) continue;
+    const cat = chosen[1].toLowerCase();
+    const category = /** @type {ReviewCriticalIssue["category"]} */ (
+      REVIEW_CATEGORIES.includes(cat) ? cat : REVIEW_FALLBACK_CATEGORY
+    );
+    const description = trimmed
+      .slice((chosen.index || 0) + chosen[0].length)
+      .replace(/^[`\s:.\-]+/, "")
+      .trim();
+    if (description) criticalIssues.push({ category, description });
+  }
+  return { verdict, criticalIssues };
+}
+
 module.exports = {
   toErrorResult,
   OPINION_SCHEMA,
   OPINION_INSTRUCTIONS,
   CONFIDENCE_ENUM,
+  REVIEW_CATEGORIES,
   validateOpinion,
   parseOpinion,
+  parseReview,
 };

--- a/test/core-review-parse.test.js
+++ b/test/core-review-parse.test.js
@@ -1,0 +1,100 @@
+// test/core-review-parse.test.js
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { parseReview, REVIEW_CATEGORIES } = require("../core/provider.js");
+
+test("RP1: parses a bold APPROVE verdict with no issues", () => {
+  const r = parseReview("Looks solid.\n\n**Verdict**: APPROVE");
+  assert.equal(r.verdict, "APPROVE");
+  assert.deepEqual(r.criticalIssues, []);
+});
+
+test("RP2: 'REQUEST CHANGES' (space form) normalizes to REQUEST_CHANGES", () => {
+  assert.equal(parseReview("Verdict: REQUEST CHANGES").verdict, "REQUEST_CHANGES");
+  assert.equal(parseReview("**Verdict:** REQUEST_CHANGES").verdict, "REQUEST_CHANGES");
+});
+
+test("RP3: verdict match is case-insensitive", () => {
+  assert.equal(parseReview("verdict: reject").verdict, "REJECT");
+  assert.equal(parseReview("VERDICT: approve").verdict, "APPROVE");
+});
+
+test("RP4: extracts categorized critical issues (bracket + backtick forms)", () => {
+  const text = [
+    "**Verdict**: REQUEST_CHANGES",
+    "**Critical issues**:",
+    "- [security] no authz on the endpoint",
+    "- `[ops]` missing rollback step",
+  ].join("\n");
+  const r = parseReview(text);
+  assert.equal(r.verdict, "REQUEST_CHANGES");
+  assert.equal(r.criticalIssues.length, 2);
+  assert.deepEqual(r.criticalIssues[0], { category: "security", description: "no authz on the endpoint" });
+  assert.deepEqual(r.criticalIssues[1], { category: "ops", description: "missing rollback step" });
+});
+
+test("RP5: an unknown/missing category falls back to 'ambiguity'", () => {
+  const r = parseReview("- [bogus] something vague");
+  assert.equal(r.criticalIssues.length, 1);
+  assert.equal(r.criticalIssues[0].category, "ambiguity");
+  assert.equal(r.criticalIssues[0].description, "something vague");
+});
+
+test("RP6: no verdict line -> verdict null, never throws", () => {
+  assert.doesNotThrow(() => parseReview("just some prose with no verdict"));
+  assert.equal(parseReview("just some prose with no verdict").verdict, null);
+});
+
+test("RP7: hostile/non-string input -> {verdict:null, criticalIssues:[]} no throw", () => {
+  for (const bad of [null, undefined, 42, {}, []]) {
+    /** @type {any} */
+    let r;
+    assert.doesNotThrow(() => { r = parseReview(/** @type {any} */ (bad)); });
+    assert.equal(r.verdict, null);
+    assert.deepEqual(r.criticalIssues, []);
+  }
+});
+
+test("RP8: verdict embedded in a sentence is still found", () => {
+  assert.equal(parseReview("My **Verdict:** APPROVE - ship it").verdict, "APPROVE");
+});
+
+test("RP9: the FIRST verdict line wins (the reviewer's own), not a quoted one later", () => {
+  const text = "**Verdict**: REJECT\n...\nthe template says Verdict: APPROVE";
+  assert.equal(parseReview(text).verdict, "REJECT");
+});
+
+test("RP10: a non-issue bracket like [note] in prose is only taken on a bullet line", () => {
+  // Bracketed token mid-paragraph (not a leading bullet) must NOT become an issue.
+  const r = parseReview("This plan [mostly] works.\n\n**Verdict**: APPROVE");
+  assert.deepEqual(r.criticalIssues, []);
+  assert.equal(r.verdict, "APPROVE");
+});
+
+test("RP12: substring traps do NOT set a verdict ('DISAPPROVE', 'do not REJECT')", () => {
+  assert.equal(parseReview("Verdict: DISAPPROVE").verdict, null);
+  assert.equal(parseReview("My verdict: do not REJECT this").verdict, null);
+  assert.equal(parseReview("Verdict: APPROVED").verdict, null); // bounded - 'APPROVED' != 'APPROVE'
+});
+
+test("RP13: a loose/echoed 'verdict' mention with a non-adjacent token is ignored", () => {
+  // The instruction phrasing puts the alpha word 'as'/'or' between keyword and token.
+  assert.equal(parseReview("Provide your verdict as APPROVE or REJECT below.").verdict, null);
+});
+
+test("RP14: among multiple brackets the first KNOWN category wins (priority tag dropped)", () => {
+  const r = parseReview("- [P0] [security] buffer overflow on input");
+  assert.equal(r.criticalIssues.length, 1);
+  assert.equal(r.criticalIssues[0].category, "security");
+  assert.equal(r.criticalIssues[0].description, "buffer overflow on input");
+});
+
+test("RP15: a category-only bullet with no description is dropped", () => {
+  assert.deepEqual(parseReview("- [security]").criticalIssues, []);
+});
+
+test("RP11: REVIEW_CATEGORIES is the frozen 6-set", () => {
+  assert.deepEqual([...REVIEW_CATEGORIES].sort(), ["ambiguity", "correctness", "ops", "performance", "scope", "security"]);
+  assert.equal(Object.isFrozen(REVIEW_CATEGORIES), true);
+});


### PR DESCRIPTION
PR2b step 1 of the consensus-engine chain (plan: `docs/multi-growth/PLAN_point1.md`). The shared parser that turns a provider's free-text review reply into the `{verdict, criticalIssues}` shape the convergence loop consumes — needed by both the server `consensus-step` tool and the `runToConvergence` wrapper (next PR2b step).

## `core/provider.js`
- **`parseReview(text)`** -> `{ verdict: APPROVE|REQUEST_CHANGES|REJECT|null, criticalIssues: [{category, description}] }`. Pure, **never throws**, line-based (no regex backtracking on large input).
  - **verdict**: matched on **word boundaries, anchored adjacent to the `verdict` keyword**. Rejects substring traps (`DISAPPROVE`/`APPROVED` never match APPROVE; `"do not REJECT"` -> null) and echoed/loose mentions (`"verdict as APPROVE"` -> null). First real verdict line wins.
  - **issues**: bullet/bracket lines only; among multiple `[tag]` brackets the **first known category** wins (`- [P0] [security] ...` -> security), else the first bracket degrades to `ambiguity`; a category-only bullet with no description is dropped (not actionable).
- **`REVIEW_CATEGORIES`** (frozen 6-set) exported.

Pure primitive only — no live behavior change; consumed by the loop drivers next.

## Review
`/ask-all` Code Reviewer (5 models, REQUEST CHANGES) → folded the real fixes: **anchored word-boundary verdict regex** (was substring `.includes()`, which inverted verdicts on `DISAPPROVE` / `"do not REJECT"` — the unanimous critical), echo-resistant anchoring, first-known-category among multiple brackets, `•` escape. Documented the intentional empty-description drop + first-verdict-wins (it parses a *reply*, not the prompt).

## Tests
15 cases incl. the new guards (`DISAPPROVE`/`do-not-REJECT`/`APPROVED` → null, echoed mention → null, multi-bracket priority, empty-desc drop). **Full suite 393/393 green, typecheck clean.**