### PR TITLE
feat: runToConvergence - non-Claude consensus loop driver (PR2b-2)

### DIFF
--- a/core/orchestrate.js
+++ b/core/orchestrate.js
@@ -4,6 +4,9 @@
 /** @typedef {import("./types.js").DelegationResult} DelegationResult */
 /** @typedef {import("./types.js").DelegationSuccess} DelegationSuccess */
 
+const { parseReview } = require("./provider.js");
+const loop = require("./consensus-loop.js");
+
 /**
  * Fan out ONE request to N providers concurrently. The whole serialization fix:
  * the host harness sees a single tool call, so it cannot stagger the providers.
@@ -120,4 +123,136 @@ async function consensus(providers, req, opts = {}) {
   }
 }
 
-module.exports = { askAll, askOne, consensus, buildArbiterPrompt };
+/**
+ * Build the per-round adjudication prompt for the provider arbiter. Embeds each
+ * peer's verdict + issues verbatim (so the arbiter - and a deterministic test
+ * stub - can see dissent), and asks for a single overall verdict.
+ * @param {{currentPlan:string}} state
+ * @param {Array<{source:string, isError:boolean, verdict:(string|null), criticalIssues:{category:string,description:string}[]}>} results
+ * @returns {string}
+ */
+function buildAdjudicationPrompt(state, results) {
+  const peerBlocks = results.map((r) => {
+    if (r.isError) return `Peer ${r.source}: ERRORED`;
+    const issues = (r.criticalIssues || []).map((i) => `  - [${i.category}] ${i.description}`).join("\n");
+    return `Peer ${r.source}: ${r.verdict || "UNKNOWN"}${issues ? "\n" + issues : ""}`;
+  }).join("\n");
+  return [
+    "ADJUDICATE the peer reviews below and give ONE overall verdict.",
+    `## Plan\n${state.currentPlan}`,
+    `## Peer reviews\n${peerBlocks}`,
+    "End with **Verdict**: APPROVE | REQUEST_CHANGES | REJECT.",
+  ].join("\n\n");
+}
+
+/**
+ * Build the per-round revision prompt for the provider arbiter.
+ * @param {{currentPlan:string}} state
+ * @param {Array<{source:string, isError:boolean, verdict:(string|null), criticalIssues:{category:string,description:string}[]}>} results
+ * @returns {string}
+ */
+function buildRevisionPrompt(state, results) {
+  const feedback = results
+    .filter((r) => !r.isError && r.verdict !== "APPROVE")
+    .flatMap((r) => (r.criticalIssues || []).map((i) => `- [${i.category}] ${i.description}`))
+    .join("\n");
+  return [
+    "REVISE THE PLAN to address the critical issues below. Return ONLY the revised plan.",
+    `## Current plan\n${state.currentPlan}`,
+    `## Must-fix issues\n${feedback || "(reviewers gave no specific issues; tighten the weakest part)"}`,
+  ].join("\n\n");
+}
+
+/** Resolve a provider reply to non-empty text, or null. */
+function okText(/** @type {any} */ res) {
+  return res && res.isError === false && typeof res.text === "string" && res.text.trim() ? res.text : null;
+}
+
+/**
+ * Drive the full multi-round consensus loop to convergence using a PROVIDER
+ * arbiter - the non-Claude host path. Shares the exact core/consensus-loop.js
+ * state machine the Claude command drives client-side (single source of truth);
+ * here the arbiter's blind/adjudication/revision steps are provider calls and
+ * the blind pass runs in PARALLEL with the peer fan-out (no interactive stall).
+ * Failure-isolated and never rejects: a failed blind pass degrades to a
+ * sentinel, a failed adjudication holds the verdict at REQUEST_CHANGES, a failed
+ * revision keeps the current plan.
+ * @param {Provider[]} providers  peer panel
+ * @param {DelegationRequest} req  `prompt` is the initial plan
+ * @param {{arbiter?:Provider, maxRounds?:number}} [opts]
+ * @returns {Promise<{converged:boolean, verdict:(string|null), confidence:string, finalReport?:string, rounds:any[], opinions:any[], error?:string}>}
+ */
+async function runToConvergence(providers, req, opts = {}) {
+  const arbiter = opts.arbiter;
+  if (!arbiter) return { converged: false, verdict: null, confidence: "none", rounds: [], opinions: [], error: "no-arbiter" };
+
+  let state = loop.initConsensusLoop({
+    plan: typeof req.prompt === "string" ? req.prompt : "",
+    maxRounds: opts.maxRounds,
+    expert: req.expert,
+    arbiterMode: "provider",
+  });
+  /** @type {any[]} */
+  let lastResults = [];
+
+  // Top-level guard: a synchronous throw from a malformed provider (e.g. askAll's
+  // map building) or any state-machine transition must NOT reject - the loop is
+  // failure-isolated. Return a structured error with whatever we have so far.
+  try {
+    while (state.status !== "converged" && state.status !== "unresolved") {
+      const { peerPrompt, blindPrompt } = loop.prepareRound(state);
+      // Blind pass runs concurrently with the peer fan-out; isolate its failure.
+      const [blindRes, peerResults] = await Promise.all([
+        Promise.resolve().then(() => arbiter.ask({ ...req, prompt: blindPrompt })).then((r) => r, () => null),
+        askAll(providers, { ...req, prompt: peerPrompt }),
+      ]);
+      state = loop.recordBlindVerdict(state, okText(blindRes) || "(blind pass unavailable)");
+
+      lastResults = peerResults.map((r) =>
+        r.isError
+          ? { source: r.provider, isError: true, errorKind: r.errorKind, verdict: null, criticalIssues: [] }
+          // parseReview spread FIRST so the explicit structural fields always win.
+          : { ...parseReview(typeof r.text === "string" ? r.text : ""), source: r.provider, isError: false, ms: r.ms }
+      );
+      state = loop.addOpinions(state, lastResults);
+
+      /** @type {"APPROVE"|"REQUEST_CHANGES"|"REJECT"} */
+      let verdict = "REQUEST_CHANGES";
+      try {
+        const adj = await arbiter.ask({ ...req, prompt: buildAdjudicationPrompt(state, lastResults) });
+        const t = okText(adj);
+        if (t) { const p = parseReview(t); if (p.verdict) verdict = p.verdict; }
+      } catch { /* arbiter adjudication failed -> hold at REQUEST_CHANGES */ }
+      state = loop.submitAdjudication(state, { verdict, decisions: [] });
+      if (state.status === "converged") break;
+
+      let revised = state.currentPlan;
+      try {
+        const rev = await arbiter.ask({ ...req, prompt: buildRevisionPrompt(state, lastResults) });
+        revised = okText(rev) || state.currentPlan;
+      } catch { /* keep the current plan */ }
+      state = loop.submitRevision(state, revised, "arbiter revision");
+    }
+  } catch (e) {
+    return {
+      converged: false,
+      verdict: null,
+      confidence: "none",
+      rounds: state.history,
+      opinions: lastResults,
+      error: `loop-failed: ${String((e && /** @type {any} */ (e).message) || e)}`,
+    };
+  }
+
+  const { finalReport, confidence } = loop.finalize(state);
+  return {
+    converged: state.status === "converged",
+    verdict: state.hostVerdict ? state.hostVerdict.verdict : null,
+    confidence,
+    finalReport,
+    rounds: state.history,
+    opinions: lastResults,
+  };
+}
+
+module.exports = { askAll, askOne, consensus, buildArbiterPrompt, runToConvergence };

--- a/test/core-run-to-convergence.test.js
+++ b/test/core-run-to-convergence.test.js
@@ -1,0 +1,133 @@
+// test/core-run-to-convergence.test.js
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { runToConvergence } = require("../core/orchestrate.js");
+
+/**
+ * Stub provider. `reply(prompt) -> string` returns the review text; throws/errors
+ * are simulated by `errors:true`.
+ * @param {string} name
+ * @param {(prompt:string)=>string} reply
+ * @param {{errors?:boolean}} [opts]
+ */
+function stub(name, reply, opts = {}) {
+  return {
+    name,
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    health: async () => ({ ok: true }),
+    /** @param {{prompt:string}} req @returns {Promise<any>} */
+    ask: async (req) => {
+      const ms = 1;
+      if (opts.errors) return { provider: name, model: "stub", isError: true, errorKind: "timeout", retryable: true, ms };
+      return { provider: name, model: "stub", isError: false, text: reply(req.prompt), ms };
+    },
+  };
+}
+
+/** Peer that APPROVES once the plan has been revised, else REQUEST_CHANGES. @param {string} name */
+function revisionSensitivePeer(name) {
+  return stub(name, (p) => (p.includes("REVISED") ? "**Verdict**: APPROVE" : "**Verdict**: REQUEST_CHANGES\n- [scope] needs detail"));
+}
+
+/** Arbiter: blind -> APPROVE; adjudicate -> APPROVE unless a peer dissented; revise -> "REVISED plan". */
+function smartArbiter(name = "arbiter") {
+  return stub(name, (p) => {
+    // Detect a peer dissent on a "Peer X: VERDICT" line (not the instruction line
+    // that merely lists the allowed tokens).
+    if (p.includes("ADJUDICATE")) return /:\s+(REQUEST_CHANGES|REJECT)\b/.test(p) ? "**Verdict**: REQUEST_CHANGES" : "**Verdict**: APPROVE";
+    if (p.includes("REVISE")) return "REVISED plan addressing the feedback";
+    return "**Verdict**: APPROVE"; // blind
+  });
+}
+
+const REQ = { prompt: "ship the widget" };
+
+test("RC1: all peers + arbiter APPROVE -> converged round 1, high confidence", async () => {
+  const peers = [stub("gpt", () => "**Verdict**: APPROVE"), stub("gemini", () => "**Verdict**: APPROVE")];
+  const out = await runToConvergence(peers, REQ, { arbiter: smartArbiter() });
+  assert.equal(out.converged, true);
+  assert.equal(out.verdict, "APPROVE");
+  assert.equal(out.confidence, "high");
+  assert.equal(out.rounds.length, 0); // converged in round 1, no revision recorded
+});
+
+test("RC2: dissent then revise -> converges in round 2", async () => {
+  const peers = [revisionSensitivePeer("gpt"), revisionSensitivePeer("gemini")];
+  const out = await runToConvergence(peers, REQ, { arbiter: smartArbiter(), maxRounds: 5 });
+  assert.equal(out.converged, true);
+  assert.equal(out.verdict, "APPROVE");
+  assert.equal(out.confidence, "medium"); // round 2
+  assert.equal(out.rounds.length, 1); // one revision happened
+});
+
+test("RC3: persistent dissent -> unresolved at maxRounds", async () => {
+  const peers = [stub("gpt", () => "**Verdict**: REQUEST_CHANGES\n- [ops] no rollback")];
+  // arbiter that never approves (always sees the dissent) + revision that never satisfies
+  const arb = stub("arb", (p) => (p.includes("ADJUDICATE") ? "**Verdict**: REQUEST_CHANGES" : p.includes("REVISE") ? "still not enough" : "**Verdict**: REQUEST_CHANGES"));
+  const out = await runToConvergence(peers, REQ, { arbiter: arb, maxRounds: 2 });
+  assert.equal(out.converged, false);
+  assert.equal(out.confidence, "none");
+  assert.equal(out.rounds.length, 2); // both rounds recorded
+});
+
+test("RC4: an errored peer is excluded; remaining APPROVE -> converges", async () => {
+  const peers = [stub("gpt", () => "**Verdict**: APPROVE"), stub("grok", () => "", { errors: true })];
+  const out = await runToConvergence(peers, REQ, { arbiter: smartArbiter() });
+  assert.equal(out.converged, true);
+  // the errored peer surfaces as isError in the opinions
+  assert.ok(out.opinions.some((o) => o.isError && o.source === "grok"));
+});
+
+test("RC5: a failing blind arbiter pass is isolated (run still completes)", async () => {
+  // arbiter errors ONLY on the blind pass; adjudication/revision still work.
+  let calls = 0;
+  const arb = {
+    name: "arb",
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    health: async () => ({ ok: true }),
+    /** @param {{prompt:string}} req @returns {Promise<any>} */
+    ask: async (req) => {
+      calls++;
+      if (!req.prompt.includes("ADJUDICATE") && !req.prompt.includes("REVISE")) {
+        return { provider: "arb", model: "s", isError: true, errorKind: "timeout", retryable: true, ms: 1 }; // blind fails
+      }
+      return { provider: "arb", model: "s", isError: false, text: "**Verdict**: APPROVE", ms: 1 };
+    },
+  };
+  const peers = [stub("gpt", () => "**Verdict**: APPROVE")];
+  /** @type {any} */
+  let out;
+  await assert.doesNotReject(async () => { out = await runToConvergence(peers, REQ, { arbiter: arb }); });
+  assert.equal(out.converged, true);
+  assert.ok(calls > 0);
+});
+
+test("RC6: no arbiter -> graceful error, no throw", async () => {
+  const out = await runToConvergence([stub("gpt", () => "**Verdict**: APPROVE")], REQ, {});
+  assert.equal(out.converged, false);
+  assert.equal(out.error, "no-arbiter");
+});
+
+test("RC7: a peer whose ask() throws SYNCHRONOUSLY does not reject the run", async () => {
+  const syncThrower = {
+    name: "boom",
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    health: async () => ({ ok: true }),
+    ask: () => { throw new Error("sync peer throw"); }, // throws before returning a promise
+  };
+  /** @type {any} */
+  let out;
+  await assert.doesNotReject(async () => { out = await runToConvergence([syncThrower], REQ, { arbiter: smartArbiter() }); });
+  assert.equal(out.converged, false);
+  assert.ok(typeof out.error === "string" || out.opinions.length >= 0);
+});
+
+test("RC8: omitted maxRounds still terminates (defaults to 5) -> unresolved on persistent dissent", async () => {
+  const peers = [stub("gpt", () => "**Verdict**: REQUEST_CHANGES\n- [ops] x")];
+  const arb = stub("arb", (p) => (p.includes("ADJUDICATE") ? "**Verdict**: REQUEST_CHANGES" : p.includes("REVISE") ? "nope" : "**Verdict**: REQUEST_CHANGES"));
+  const out = await runToConvergence(peers, REQ, { arbiter: arb }); // no maxRounds
+  assert.equal(out.converged, false);
+  assert.equal(out.confidence, "none");
+  assert.equal(out.rounds.length, 5); // defaulted to 5 and terminated
+});


### PR DESCRIPTION
PR2b step 2 (plan: `docs/multi-growth/PLAN_point1.md`). Drives the full multi-round consensus loop to convergence with a **provider arbiter** — the non-Claude host path. Reuses the **same** `core/consensus-loop.js` state machine the Claude command drives client-side (single source of truth, no duplicated algorithm).

## `core/orchestrate.js`
- **`runToConvergence(providers, req, {arbiter, maxRounds})`** — per round: blind arbiter pass **in parallel** with the peer fan-out (`askAll`); `parseReview()` → `ReviewResult` per peer; arbiter adjudicates one verdict; if not converged, arbiter revises the plan → `submitRevision`. Returns `{converged, verdict, confidence, finalReport, rounds, opinions, error?}`.
- `buildAdjudicationPrompt`/`buildRevisionPrompt` embed peer verdicts+issues.
- **Failure-isolated, never rejects**: top-level try/catch → structured error; blind failure → sentinel; adjudication failure → holds REQUEST_CHANGES; revision failure → keeps current plan.

## Review
`/ask-all` Code Reviewer (5 models). Folded the real fixes: **top-level try/catch** (guarantees never-reject vs a synchronous provider throw through `askAll`, or any state-machine throw), `parseReview`-spread-first so explicit fields always win, `typeof`-string guard on `r.text`. **Dismissed 3 paraphrase-level false positives** (verified vs merged code + proven by new tests): `maxRounds` already defaults via `initConsensusLoop` (**RC8** omits it and terminates at 5); `submitAdjudication` can't throw here (verdict ∈ 3-enum, `decisions:[]`); it never yields a terminal state mid-round.

## Tests
8 cases incl. the new guards (**RC7** sync peer throw does not reject; **RC8** omitted maxRounds terminates). **Full suite 401/401 green, typecheck clean.**