### PR TITLE
feat: in-memory loop store for consensus-step (PR2b-3a)

### DIFF
--- a/core/loop-store.js
+++ b/core/loop-store.js
@@ -1,0 +1,88 @@
+"use strict";
+
+/**
+ * core/loop-store.js - an in-memory, sliding-TTL store for in-flight consensus
+ * LoopState, keyed by sessionId. Used by the server `consensus-step` tool so a
+ * Claude-driven multi-round loop survives across stateless MCP tool calls
+ * WITHOUT requiring `sessions.persist` (which governs only the durable audit
+ * record). State is intentionally ephemeral: a server restart drops it and the
+ * driver restarts the loop (see PLAN_point1.md).
+ *
+ * Zero deps. The clock is injectable (`opts.now`) so the TTL/eviction logic is
+ * deterministically testable.
+ */
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 min
+const DEFAULT_MAX_ENTRIES = 100;
+
+/**
+ * @param {{ttlMs?:number, maxEntries?:number, now?:() => number}} [opts]
+ * @returns {{
+ *   put:(id:string, state:any)=>void,
+ *   get:(id:string)=>any,
+ *   delete:(id:string)=>boolean,
+ *   sweep:()=>number,
+ *   size:()=>number,
+ * }}
+ */
+function makeLoopStore(opts) {
+  const o = opts || {};
+  const ttlMs = Number.isFinite(o.ttlMs) && /** @type {number} */ (o.ttlMs) > 0 ? /** @type {number} */ (o.ttlMs) : DEFAULT_TTL_MS;
+  const maxEntries = Number.isInteger(o.maxEntries) && /** @type {number} */ (o.maxEntries) > 0 ? /** @type {number} */ (o.maxEntries) : DEFAULT_MAX_ENTRIES;
+  const now = typeof o.now === "function" ? o.now : Date.now;
+
+  /** @type {Map<string, {state:any, touchedAt:number, seq:number}>} */
+  const map = new Map();
+  // Monotonic access counter for TRUE LRU eviction, independent of wall-clock
+  // resolution (Date.now() ms-granularity collisions would otherwise break the
+  // tie-break) and immune to a pathological/non-finite injected clock.
+  let seq = 0;
+
+  /** @param {number} t */
+  function isExpired(/** @type {{touchedAt:number}} */ entry, t) {
+    return t - entry.touchedAt > ttlMs;
+  }
+
+  /** Evict the single least-recently-used entry (lowest seq) after a put pushes over cap. */
+  function evictOldest() {
+    /** @type {string|null} */
+    let lruId = null;
+    let lruSeq = Infinity;
+    for (const [id, entry] of map) {
+      if (entry.seq < lruSeq) { lruSeq = entry.seq; lruId = id; }
+    }
+    if (lruId !== null) map.delete(lruId);
+  }
+
+  return {
+    put(id, state) {
+      map.set(id, { state, touchedAt: now(), seq: ++seq });
+      while (map.size > maxEntries) evictOldest();
+    },
+    get(id) {
+      const entry = map.get(id);
+      if (!entry) return null;
+      const t = now();
+      if (isExpired(entry, t)) { map.delete(id); return null; }
+      entry.touchedAt = t; // sliding TTL: access keeps an active loop alive
+      entry.seq = ++seq;   // mark as most-recently-used for LRU eviction
+      return entry.state;
+    },
+    delete(id) {
+      return map.delete(id);
+    },
+    sweep() {
+      const t = now();
+      let removed = 0;
+      for (const [id, entry] of map) {
+        if (isExpired(entry, t)) { map.delete(id); removed++; }
+      }
+      return removed;
+    },
+    size() {
+      return map.size;
+    },
+  };
+}
+
+module.exports = { makeLoopStore, DEFAULT_TTL_MS, DEFAULT_MAX_ENTRIES };

--- a/test/core-loop-store.test.js
+++ b/test/core-loop-store.test.js
@@ -1,0 +1,110 @@
+// test/core-loop-store.test.js
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { makeLoopStore } = require("../core/loop-store.js");
+
+/** A controllable clock. */
+function clock(start = 1000) {
+  let t = start;
+  /** @type {any} */
+  const now = () => t;
+  now.advance = (/** @type {number} */ ms) => { t += ms; };
+  return now;
+}
+
+test("LS1: put then get round-trips the state", () => {
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now: clock() });
+  s.put("a", { round: 1 });
+  assert.deepEqual(s.get("a"), { round: 1 });
+});
+
+test("LS2: get returns null for an unknown id", () => {
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now: clock() });
+  assert.equal(s.get("missing"), null);
+});
+
+test("LS3: an entry past its TTL is expired (get returns null and drops it)", () => {
+  const now = clock();
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now });
+  s.put("a", { round: 1 });
+  now.advance(1001);
+  assert.equal(s.get("a"), null);
+  assert.equal(s.size(), 0); // dropped on access
+});
+
+test("LS4: get refreshes the TTL (sliding expiry keeps an active loop alive)", () => {
+  const now = clock();
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now });
+  s.put("a", { round: 1 });
+  now.advance(600);
+  assert.deepEqual(s.get("a"), { round: 1 }); // touch at t=1600
+  now.advance(600); // t=2200, but last touch was 1600 -> not yet expired (1600+1000=2600)
+  assert.deepEqual(s.get("a"), { round: 1 });
+});
+
+test("LS5: size cap evicts the least-recently-touched entry", () => {
+  const now = clock();
+  const s = makeLoopStore({ ttlMs: 100000, maxEntries: 2, now });
+  s.put("a", { v: 1 }); now.advance(10);
+  s.put("b", { v: 2 }); now.advance(10);
+  s.get("a"); now.advance(10);          // touch a -> b is now the oldest
+  s.put("c", { v: 3 });                  // over cap -> evict b (least recently touched)
+  assert.equal(s.size(), 2);
+  assert.equal(s.get("b"), null);
+  assert.deepEqual(s.get("a"), { v: 1 });
+  assert.deepEqual(s.get("c"), { v: 3 });
+});
+
+test("LS6: delete removes an entry", () => {
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now: clock() });
+  s.put("a", { round: 1 });
+  assert.equal(s.delete("a"), true);
+  assert.equal(s.get("a"), null);
+  assert.equal(s.delete("a"), false);
+});
+
+test("LS7: sweep drops expired entries and keeps fresh ones", () => {
+  const now = clock();
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now });
+  s.put("old", { v: 1 });
+  now.advance(500);
+  s.put("fresh", { v: 2 }); // touched at 1500
+  now.advance(600);          // t=2100; old last-touched 1000 (expired), fresh 1500 (alive)
+  const removed = s.sweep();
+  assert.equal(removed, 1);
+  assert.equal(s.get("old"), null);
+  assert.deepEqual(s.get("fresh"), { v: 2 });
+});
+
+test("LS8: put refreshes touch + overwrites state", () => {
+  const now = clock();
+  const s = makeLoopStore({ ttlMs: 1000, maxEntries: 10, now });
+  s.put("a", { round: 1 });
+  now.advance(900);
+  s.put("a", { round: 2 }); // overwrite + refresh touch to t=1900
+  now.advance(900);          // t=2800; last touch 1900 -> alive
+  assert.deepEqual(s.get("a"), { round: 2 });
+});
+
+test("LS9: defaults are sane when opts omitted/null (no throw)", () => {
+  assert.doesNotThrow(() => {
+    const s = makeLoopStore();
+    s.put("a", { round: 1 });
+    assert.deepEqual(s.get("a"), { round: 1 });
+  });
+  assert.doesNotThrow(() => makeLoopStore(/** @type {any} */ (null)));
+});
+
+test("LS10: eviction is TRUE LRU under a frozen clock (seq, not timestamp ties)", () => {
+  // Clock never advances -> all touchedAt equal. Eviction must still respect
+  // access recency via the monotonic seq counter.
+  const s = makeLoopStore({ ttlMs: 100000, maxEntries: 2, now: () => 5000 });
+  s.put("a", { v: 1 });
+  s.put("b", { v: 2 });
+  s.get("a");            // a is now most-recently-used despite equal timestamps
+  s.put("c", { v: 3 });  // over cap -> evict b (least-recently-used)
+  assert.equal(s.get("b"), null);
+  assert.deepEqual(s.get("a"), { v: 1 });
+  assert.deepEqual(s.get("c"), { v: 3 });
+});


### PR DESCRIPTION
PR2b step 3a (plan: `docs/multi-growth/PLAN_point1.md`). Sliding-TTL, size-capped in-memory store keyed by `sessionId` that holds in-flight consensus `LoopState` across stateless MCP tool calls — so a Claude-driven multi-round loop survives call-to-call **without** `sessions.persist` (which governs only the durable audit record). Ephemeral by design: a restart drops it and the driver restarts the loop. Consumed by the server `consensus-step` tool next.

## `core/loop-store.js`
- `makeLoopStore({ttlMs=30min, maxEntries=100, now=Date.now})` → `{put,get,delete,sweep,size}`. Injectable clock.
- **Sliding TTL** (get refreshes; lazy drop on get + eager `sweep()`).
- **True-LRU eviction via a monotonic seq counter** — not `touchedAt` — so `Date.now()` ms-granularity ties can't evict a recently-used entry, and a pathological injected clock can't stall eviction.

## Review
`/ask-all` Code Reviewer (5 models, 4 APPROVE). Folded the one REQUEST CHANGES + 2 converging recs: **monotonic-seq LRU** (was timestamp tie-break — deepseek's blocker) + `makeLoopStore(null)` guard. Dismissed deep-copy-on-get (contract: `LoopState` replaced wholesale each step).

## Tests
10 cases incl. **LS10** frozen-clock true-LRU (proves the seq fix). **Full suite 411/411 green, typecheck clean.**