### PR TITLE
feat: consensus-auto MCP tool - server-side convergence loop (PR2b-3b)

### DIFF
--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -5,7 +5,7 @@
 /** @typedef {import("../../core/types.js").DelegationRequest} DelegationRequest */
 
 const { makeRegistry, pinAlias } = require("../../core/registry.js");
-const { askAll, askOne, consensus } = require("../../core/orchestrate.js");
+const { askAll, askOne, consensus, runToConvergence } = require("../../core/orchestrate.js");
 const { PROMPTS } = require("../../core/prompts/index.js");
 
 const ADVISORY = { readOnlyHint: true };
@@ -72,6 +72,7 @@ function toolList() {
   const tools = [
     { name: "ask-all", description: "Fan out one question to GPT, Gemini, Grok, and any configured OpenRouter models in parallel for independent second opinions, then return all results (advisory, no cross-contamination). Pass `expert` to apply a persona to every delegate.", inputSchema: inputSchema(), annotations: ADVISORY },
     { name: "consensus", description: "Fan out one question to all enabled providers, then run a single arbiter pass that cross-reviews the independent opinions and returns one synthesized verdict (advisory). Pass `expert` to apply a persona to the fan-out and arbiter.", inputSchema: inputSchema(), annotations: ADVISORY },
+    { name: "consensus-auto", description: "Run the FULL multi-round consensus convergence loop server-side with a provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to 5 rounds) and return the converged verdict. For non-Claude hosts that want the loop in one call. Advisory; pass `expert` to apply a persona. Configure the arbiter via consensus.arbiter.", inputSchema: inputSchema(), annotations: ADVISORY },
   ];
   for (const t of Object.keys(ASK_PROVIDER)) {
     tools.push({ name: t, description: `Single-provider second opinion via ${ASK_PROVIDER[t]} (advisory, single-shot). Pass \`expert\` to apply one of the expert personas.`, inputSchema: inputSchema(), annotations: ADVISORY });
@@ -406,6 +407,66 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
   }
 
   /**
+   * Run the full multi-round convergence loop server-side via runToConvergence.
+   * Needs a CONCRETE provider arbiter (the loop is provider-driven here); if the
+   * config resolves to host/none, fall back to a selected provider as the driver
+   * with a warning (the host-driven client loop is the consensus-step path, not
+   * this one). Shares runConsensus's panel selection + floor-of-2 exclusion.
+   * @param {DelegationRequest} req
+   * @param {string|undefined} expert
+   * @returns {Promise<any>}  the tool payload (converged/verdict/opinions/...); never throws
+   */
+  async function runConsensusAuto(req, expert) {
+    try {
+      const cfg = getConfig() || {};
+      const { providers: selected } = registry.selectForConsensus({ config: cfg, expert: expert || "" });
+      const cc = cfg.consensus || {};
+      const arbiterSpec = cc.arbiterDefaulted ? (isClaudeHost() ? "host" : "auto") : (cc.arbiter || "auto");
+      /** @type {string[]} */
+      const warnings = Array.isArray(cfg.consensusWarnings) ? cfg.consensusWarnings.slice() : [];
+      const cfgErr = typeof getConfigError === "function" ? getConfigError() : null;
+      if (cfgErr) warnings.push(`config not loaded: ${cfgErr}`);
+      const resolved = await resolveArbiter(arbiterSpec, selected, registry, getConfig);
+      if (resolved.warning) warnings.push(resolved.warning);
+
+      const arbiterP = resolved.provider;
+      if (!arbiterP) {
+        // consensus-auto needs a CONCRETE provider arbiter (the loop runs server-side).
+        // host mode is the client-driven /consensus path; do NOT silently pick a peer.
+        const host = resolved.mode === "host";
+        warnings.push(host
+          ? "consensus-auto runs the loop server-side and needs a concrete arbiter; set consensus.arbiter to a provider or openrouter:<alias> (host mode drives the client-side /consensus instead)"
+          : "no usable arbiter provider available");
+        return { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: resolved.mode, provider: null }, warnings, error: host ? "arbiter-is-host" : "no-arbiter" };
+      }
+
+      // Exclude the arbiter from the peer panel - never let it review its own output.
+      // A single distinct peer is a valid minimal panel (peer != arbiter).
+      const peers = selected.filter((p) => p.name !== arbiterP.name);
+      if (peers.length < 1) {
+        return { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: "server", provider: arbiterP.name }, warnings: warnings.concat(["consensus-auto needs at least one peer distinct from the arbiter"]), error: "insufficient-peers" };
+      }
+
+      const maxRounds = Number.isInteger(cc.maxRounds) && cc.maxRounds > 0 ? cc.maxRounds : undefined;
+      const out = await runToConvergence(peers, withPersona(req, expert), { arbiter: arbiterP, maxRounds });
+      const allWarnings = out.error ? warnings.concat([`loop: ${out.error}`]) : warnings;
+      return {
+        converged: out.converged,
+        verdict: out.verdict,
+        confidence: out.confidence,
+        rounds: Array.isArray(out.rounds) ? out.rounds.length : 0,
+        opinions: out.opinions,
+        arbiter: { mode: "server", provider: arbiterP.name },
+        warnings: allWarnings,
+        error: out.error,
+      };
+    } catch (e) {
+      // Never reject the tool call - degrade to a structured error.
+      return { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: null, warnings: [], error: `internal: ${String((e && /** @type {any} */ (e).message) || e)}` };
+    }
+  }
+
+  /**
    * @param {string} name
    * @param {any} args  // untrusted JSON-RPC tool arguments
    */
@@ -443,6 +504,13 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       const sid = persistRun("consensus", req, expert, parts);
       if (sid) payload.sessionId = sid;
       return jsonResult(payload);
+    }
+    if (name === "consensus-auto") {
+      // Server-internal full convergence loop (provider arbiter). Persistence +
+      // session-revisit routing for the multi-round record land with PR2b-4 (v2
+      // record with round history); not persisted here to avoid a lossy v1 record
+      // that would silently downgrade to a one-shot rerun on revisit.
+      return jsonResult(await runConsensusAuto(req, expert));
     }
     if (name === "session-get") {
       if (!persistEnabled()) return disabledMsg();

--- a/test/mcp-consensus-auto.test.js
+++ b/test/mcp-consensus-auto.test.js
@@ -1,0 +1,75 @@
+// test/mcp-consensus-auto.test.js
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { buildServer } = require("../server/mcp/index.js");
+
+/** @param {string} name @param {string} verdictText */
+function voter(name, verdictText) {
+  return {
+    name,
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    async health() { return { ok: true }; },
+    /** @param {{prompt:string}} req @returns {Promise<any>} */
+    async ask(req) {
+      // The arbiter's revision step asks to REVISE; return a plan body so the loop progresses.
+      if (req.prompt.includes("REVISE THE PLAN")) return { provider: name, model: "m", isError: false, text: "REVISED plan", ms: 1 };
+      // Adjudication + blind + peer review all just emit the configured verdict.
+      return { provider: name, model: "m", isError: false, text: verdictText, ms: 1 };
+    },
+  };
+}
+const approve = (n) => voter(n, "**Verdict**: APPROVE");
+const reject = (n) => voter(n, "**Verdict**: REQUEST_CHANGES\n- [ops] needs work");
+
+const cfg = (over) => ({ providers: {}, openrouter: { maxFanout: 3, models: [] }, consensus: { arbiter: "auto", arbiterDefaulted: false, ...(over || {}) } });
+
+test("CA1: tools/list advertises consensus-auto (advisory)", async () => {
+  const srv = buildServer({ providers: [approve("codex")], getConfig: () => cfg() });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+  const t = res.result.tools.find((x) => x.name === "consensus-auto");
+  assert.ok(t);
+  assert.equal(t.annotations.readOnlyHint, true);
+});
+
+test("CA2: all-APPROVE panel converges with a verdict", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("gemini"), approve("grok")], getConfig: () => cfg() });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "ship it", expert: "architect" } } });
+  const payload = JSON.parse(res.result.content[0].text);
+  assert.equal(payload.converged, true);
+  assert.equal(payload.verdict, "APPROVE");
+  assert.equal(payload.arbiter.mode, "server");
+});
+
+test("CA3: persistent dissent ends unresolved at the configured maxRounds", async () => {
+  const srv = buildServer({ providers: [reject("codex"), reject("gemini"), reject("grok")], getConfig: () => cfg({ maxRounds: 2 }) });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "ship it" } } });
+  const payload = JSON.parse(res.result.content[0].text);
+  assert.equal(payload.converged, false);
+  assert.equal(payload.rounds, 2);
+});
+
+test("CA4: never throws on an empty panel - returns a structured error", async () => {
+  const srv = buildServer({ providers: [], getConfig: () => cfg() });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "x" } } });
+  const payload = JSON.parse(res.result.content[0].text);
+  assert.equal(payload.converged, false);
+  assert.ok(typeof payload.error === "string");
+});
+
+test("CA5: host-mode arbiter -> explicit arbiter-is-host error (no silent peer hijack)", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg({ arbiter: "host" }) });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "x" } } });
+  const payload = JSON.parse(res.result.content[0].text);
+  assert.equal(payload.converged, false);
+  assert.equal(payload.error, "arbiter-is-host");
+  assert.equal(payload.arbiter.provider, null);
+});
+
+test("CA6: a 2-provider panel (arbiter + 1 distinct peer) converges without self-arbitration", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg() });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "x" } } });
+  const payload = JSON.parse(res.result.content[0].text);
+  assert.equal(payload.converged, true);
+  assert.equal(payload.opinions.length, 1); // exactly one peer reviewed (arbiter excluded)
+});


### PR DESCRIPTION
PR2b step 3b (plan: `docs/multi-growth/PLAN_point1.md`). New **`consensus-auto`** MCP tool: runs the full multi-round consensus loop **server-side** via `runToConvergence` with a provider arbiter, returning the converged verdict in one call — the non-Claude host path. **Additive**; the one-shot `consensus` tool is unchanged.

## `server/mcp/index.js`
- Register `consensus-auto` (advisory) in `toolList`.
- `runConsensusAuto`: selects the panel, resolves a **concrete** arbiter, **excludes it from peers** (never self-reviews), runs `runToConvergence`, returns `{converged, verdict, confidence, rounds, opinions, arbiter, warnings, error?}`.

## Review
`/ask-all` Code Reviewer (5 models, REQUEST CHANGES). Folded the real fixes:
1. **top-level try/catch** — the tool never rejects (selection/arbiter/persona throws → structured error).
2. **no arbiter self-arbitration** — dropped the `peers=selected` fallback; exclude the arbiter, require ≥1 distinct peer else `insufficient-peers`.
3. **no silent host hijack** — `mode:host`/no-provider → explicit `arbiter-is-host`/`no-arbiter` error directing to set `consensus.arbiter`.
4. **removed lossy v1 persistence** — persistence + revisit routing for the multi-round record move to **PR2b-4** (v2 record + round history), avoiding a silent one-shot downgrade on revisit.

Dismissed (with reason): `out.error`+`converged:false` (branch on `converged`); `maxRounds` config-surfacing (plumbing real+tested; schema deferred to PR2b-4).

## Tests
6 cases incl. **CA5** host-arbiter error + **CA6** 2-provider panel converges with exactly 1 peer (no self-arbitration). **Full suite 417/417 green, typecheck clean.**