### PR TITLE
feat: persist consensus-auto runs + route session-revisit (PR2b-4b)

### DIFF
--- a/core/sessions.js
+++ b/core/sessions.js
@@ -20,8 +20,13 @@ const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
 
-/** Current on-disk record shape version. 1a enrichment will bump this. */
-const SCHEMA_VERSION = 1;
+/**
+ * Current on-disk record shape version.
+ * v2: consensus-auto records carry per-opinion verdict/criticalIssues + a loop
+ * summary (converged/confidence/rounds). v1 records remain readable (all v2
+ * additions are optional); readers do not branch on the version today.
+ */
+const SCHEMA_VERSION = 2;
 /** Anchored id guard: rejects `../`, dots, slashes - no path traversal. */
 const ID_RE = /^[A-Za-z0-9-]+$/;
 /** Exact shape of a write temp file (`<id>.json.tmp.<pid>.<ms>`) - reaped if orphaned. */
@@ -33,10 +38,18 @@ const DEFAULT_MAX_RECORDS = 200;
 const DEFAULT_MAX_AGE_DAYS = 30;
 
 /**
+ * @typedef {Object} SessionCriticalIssue
+ * @property {string} category
+ * @property {string} description
+ */
+
+/**
  * @typedef {Object} SessionOpinion
  * @property {string} provider
  * @property {string} [model]
  * @property {string} [text]
+ * @property {(("APPROVE"|"REQUEST_CHANGES"|"REJECT")|null)} [verdict]  consensus-auto review verdict
+ * @property {SessionCriticalIssue[]} [criticalIssues]  consensus-auto tagged issues
  */
 
 /**
@@ -69,7 +82,7 @@ const DEFAULT_MAX_AGE_DAYS = 30;
  * @property {(string|null)} parentId
  * @property {number} schemaVersion
  * @property {string} createdAt  ISO timestamp
- * @property {("consensus"|"ask-all")} tool
+ * @property {("consensus"|"ask-all"|"consensus-auto")} tool
  * @property {string} question
  * @property {(string|null)} [expert]
  * @property {(SessionFileRef[]|null)} [files]
@@ -79,6 +92,9 @@ const DEFAULT_MAX_AGE_DAYS = 30;
  * @property {(SessionArbiter|null)} [arbiter]
  * @property {string[]} [warnings]
  * @property {SessionAnnotation[]} [annotations]
+ * @property {boolean} [converged]  consensus-auto: did the loop converge
+ * @property {string} [confidence]  consensus-auto: final confidence (none|low|medium|high)
+ * @property {number} [rounds]  consensus-auto: number of rounds the loop ran
  */
 
 /**
@@ -139,6 +155,16 @@ function isSafeId(id) {
   return typeof id === "string" && ID_RE.test(id);
 }
 
+/** The closed consensus verdict set. The writer coerces anything else to null. */
+const VERDICTS = ["APPROVE", "REQUEST_CHANGES", "REJECT"];
+/**
+ * @param {unknown} v
+ * @returns {v is ("APPROVE"|"REQUEST_CHANGES"|"REJECT")}
+ */
+function isVerdict(v) {
+  return typeof v === "string" && VERDICTS.indexOf(v) !== -1;
+}
+
 /** @returns {string} a fresh session id ([0-9a-f-], matches the safe-id guard). */
 function newSessionId() {
   return crypto.randomUUID();
@@ -154,13 +180,30 @@ function newSessionId() {
 function sanitizeRecord(record) {
   /** @type {SessionRecord} */
   const out = { ...record };
-  out.question = scrubSecrets(String(record.question == null ? "" : record.question));
+  out.question = capText(scrubSecrets(String(record.question == null ? "" : record.question)));
   if (Array.isArray(record.opinions)) {
-    out.opinions = record.opinions.map((o) => ({
-      provider: o.provider,
-      model: o.model,
-      text: typeof o.text === "string" ? capText(scrubSecrets(o.text)) : undefined,
-    }));
+    out.opinions = record.opinions.map((o) => {
+      /** @type {SessionOpinion} */
+      const so = {
+        provider: o.provider,
+        model: o.model,
+        text: typeof o.text === "string" ? capText(scrubSecrets(o.text)) : undefined,
+      };
+      // consensus-auto opinions carry a structured verdict + tagged issues.
+      // The writer is the trust boundary: do NOT assume the caller honored
+      // parseReview's enum contract. Whitelist the verdict to the closed set
+      // (anything else -> null) so no free-text can ride the unscrubbed verdict
+      // field. Issue descriptions are free provider text -> scrub + cap; the
+      // category tag is bounded but capped defensively against a bloated value.
+      if (o.verdict !== undefined) so.verdict = isVerdict(o.verdict) ? o.verdict : null;
+      if (Array.isArray(o.criticalIssues)) {
+        so.criticalIssues = o.criticalIssues.map((ci) => ({
+          category: capText(String(ci && ci.category != null ? ci.category : "")),
+          description: capText(scrubSecrets(String(ci && ci.description != null ? ci.description : ""))),
+        }));
+      }
+      return so;
+    });
   }
   if (record.verdict != null) out.verdict = capText(scrubSecrets(String(record.verdict)));
   if (record.blindVerdict != null) out.blindVerdict = capText(scrubSecrets(String(record.blindVerdict)));
@@ -185,7 +228,7 @@ function sanitizeRecord(record) {
   // (annotateSession already scrubs on append - this just makes write idempotent).
   if (Array.isArray(record.annotations)) {
     out.annotations = record.annotations.map((a) => ({
-      note: scrubSecrets(String(a && a.note != null ? a.note : "")),
+      note: capText(scrubSecrets(String(a && a.note != null ? a.note : ""))),
       at: a && a.at,
     }));
   }

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -313,14 +313,28 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
     }
     return refs.length ? refs : null;
   }
-  /** @param {any} results @returns {{provider:string, model:string, text:(string|undefined)}[]} */
+  /**
+   * Map raw run results to the persisted opinion shape. Handles both kinds:
+   * fan-out provider results ({provider, model, text}) and consensus-auto review
+   * results ({source, verdict, criticalIssues}). `source` falls back to provider
+   * so a loop opinion keeps its identity; verdict/criticalIssues ride along when
+   * present (sanitizeRecord scrubs the issue descriptions on write).
+   * @param {any} results
+   * @returns {any[]}
+   */
   function opinionsFrom(results) {
     if (!Array.isArray(results)) return [];
-    return results.map((r) => ({
-      provider: r && r.provider,
-      model: r && r.model,
-      text: r && r.isError === false && typeof r.text === "string" ? r.text : undefined,
-    }));
+    return results.map((r) => {
+      /** @type {any} */
+      const o = {
+        provider: r && (r.provider || r.source),
+        model: r && r.model,
+        text: r && r.isError === false && typeof r.text === "string" ? r.text : undefined,
+      };
+      if (r && r.verdict !== undefined) o.verdict = r.verdict;
+      if (r && Array.isArray(r.criticalIssues)) o.criticalIssues = r.criticalIssues;
+      return o;
+    });
   }
   /** @param {any} result @returns {(string|null)} the verdict text, or null */
   function textOf(result) {
@@ -333,16 +347,17 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
   /**
    * Persist a completed run when persistence is on. Best-effort: a write failure
    * never fails the tool call. Returns the new sessionId, or null when off.
-   * @param {("consensus"|"ask-all")} tool
+   * @param {("consensus"|"ask-all"|"consensus-auto")} tool
    * @param {DelegationRequest} req
    * @param {string|undefined} expert
-   * @param {any} parts  // { opinions, blindVerdict?, verdict?, arbiter?, warnings?, parentId? }
+   * @param {any} parts  // { opinions, blindVerdict?, verdict?, arbiter?, warnings?, parentId?, converged?, confidence?, rounds? }
    * @returns {(string|null)}
    */
   function persistRun(tool, req, expert, parts) {
     if (!persistEnabled()) return null;
     const cfg = sessionsCfg();
     const id = sessions.newSessionId();
+    /** @type {any} */
     const record = {
       id,
       parentId: parts.parentId == null ? null : parts.parentId,
@@ -359,6 +374,10 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       warnings: Array.isArray(parts.warnings) ? parts.warnings : [],
       annotations: [],
     };
+    // consensus-auto loop summary (omitted for one-shot tools; JSON drops undefined).
+    if (typeof parts.converged === "boolean") record.converged = parts.converged;
+    if (typeof parts.confidence === "string") record.confidence = parts.confidence;
+    if (typeof parts.rounds === "number") record.rounds = parts.rounds;
     try {
       sessions.writeSession(record, { dir: sessionsDir, maxRecords: cfg.maxRecords, maxAgeDays: cfg.maxAgeDays });
       return id;
@@ -442,7 +461,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
    * this one). Shares runConsensus's panel selection + floor-of-2 exclusion.
    * @param {DelegationRequest} req
    * @param {string|undefined} expert
-   * @returns {Promise<any>}  the tool payload (converged/verdict/opinions/...); never throws
+   * @returns {Promise<{payload:any, parts:(any|null)}>}  payload is the tool result; parts is non-null only on a real run (drives persistence); never throws
    */
   async function runConsensusAuto(req, expert) {
     try {
@@ -465,32 +484,48 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
         warnings.push(host
           ? "consensus-auto runs the loop server-side and needs a concrete arbiter; set consensus.arbiter to a provider or openrouter:<alias> (host mode drives the client-side /consensus instead)"
           : "no usable arbiter provider available");
-        return { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: resolved.mode, provider: null }, warnings, error: host ? "arbiter-is-host" : "no-arbiter" };
+        return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: resolved.mode, provider: null }, warnings, error: host ? "arbiter-is-host" : "no-arbiter" }, parts: null };
       }
 
       // Exclude the arbiter from the peer panel - never let it review its own output.
       // A single distinct peer is a valid minimal panel (peer != arbiter).
       const peers = selected.filter((p) => p.name !== arbiterP.name);
       if (peers.length < 1) {
-        return { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: "server", provider: arbiterP.name }, warnings: warnings.concat(["consensus-auto needs at least one peer distinct from the arbiter"]), error: "insufficient-peers" };
+        return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: "server", provider: arbiterP.name }, warnings: warnings.concat(["consensus-auto needs at least one peer distinct from the arbiter"]), error: "insufficient-peers" }, parts: null };
       }
 
       const maxRounds = Number.isInteger(cc.maxRounds) && cc.maxRounds > 0 ? cc.maxRounds : undefined;
       const out = await runToConvergence(peers, withPersona(req, expert), { arbiter: arbiterP, maxRounds });
       const allWarnings = out.error ? warnings.concat([`loop: ${out.error}`]) : warnings;
-      return {
+      const rounds = Array.isArray(out.rounds) ? out.rounds.length : 0;
+      const arbiter = { mode: "server", provider: arbiterP.name };
+      const payload = {
         converged: out.converged,
         verdict: out.verdict,
         confidence: out.confidence,
-        rounds: Array.isArray(out.rounds) ? out.rounds.length : 0,
+        rounds,
         opinions: out.opinions,
-        arbiter: { mode: "server", provider: arbiterP.name },
+        arbiter,
         warnings: allWarnings,
         error: out.error,
       };
+      // parts drives persistence (only on a real run). blindVerdict is per-round in
+      // the loop, so the final record stores null (the verdict + opinions are the
+      // durable summary; full round history is intentionally not persisted yet).
+      const parts = {
+        opinions: out.opinions,
+        blindVerdict: null,
+        verdict: out.verdict,
+        arbiter,
+        warnings: allWarnings,
+        converged: out.converged,
+        confidence: out.confidence,
+        rounds,
+      };
+      return { payload, parts };
     } catch (e) {
       // Never reject the tool call - degrade to a structured error.
-      return { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: null, warnings: [], error: `internal: ${String((e && /** @type {any} */ (e).message) || e)}` };
+      return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: null, warnings: [], error: `internal: ${String((e && /** @type {any} */ (e).message) || e)}` }, parts: null };
     }
   }
 
@@ -648,11 +683,16 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       return jsonResult(payload);
     }
     if (name === "consensus-auto") {
-      // Server-internal full convergence loop (provider arbiter). Persistence +
-      // session-revisit routing for the multi-round record land with PR2b-4 (v2
-      // record with round history); not persisted here to avoid a lossy v1 record
-      // that would silently downgrade to a one-shot rerun on revisit.
-      return jsonResult(await runConsensusAuto(req, expert));
+      // Server-internal full convergence loop (provider arbiter). Persisted as a v2
+      // record (tool:"consensus-auto" + converged/confidence/rounds + per-opinion
+      // verdict/criticalIssues) so session-revisit re-runs the LOOP, not a one-shot.
+      // parts is null on an error path (no-arbiter/insufficient-peers) - skip the write.
+      const { payload, parts } = await runConsensusAuto(req, expert);
+      if (parts) {
+        const sid = persistRun("consensus-auto", req, expert, parts);
+        if (sid) payload.sessionId = sid;
+      }
+      return jsonResult(payload);
     }
     if (name === "consensus-step") {
       // Client-driven, host-arbitrated loop. State lives in the ephemeral loop
@@ -697,12 +737,19 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
         files: childFiles,
         cwd: typeof args.cwd === "string" ? args.cwd : undefined,
       };
-      const tool = rec.tool === "ask-all" ? "ask-all" : "consensus";
+      // Route by the ORIGINAL tool so a consensus-auto record re-runs the full loop
+      // (not a one-shot consensus). consensus-auto can return parts:null on an error
+      // path; the others always carry parts.
+      const tool = rec.tool === "ask-all" ? "ask-all" : rec.tool === "consensus-auto" ? "consensus-auto" : "consensus";
       const { payload, parts } = tool === "ask-all"
         ? await runAskAll(childReq, childExpert)
-        : await runConsensus(childReq, childExpert);
-      const sid = persistRun(tool, childReq, childExpert, { ...parts, parentId: rec.id });
-      if (sid) payload.sessionId = sid;
+        : tool === "consensus-auto"
+          ? await runConsensusAuto(childReq, childExpert)
+          : await runConsensus(childReq, childExpert);
+      if (parts) {
+        const sid = persistRun(tool, childReq, childExpert, { ...parts, parentId: rec.id });
+        if (sid) payload.sessionId = sid;
+      }
       payload.parentId = rec.id;
       return jsonResult(payload);
     }

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -379,6 +379,94 @@ test("S20b: non-path file refs (dir/file_id/file_url/mode) survive a round-trip"
   assert.deepEqual(back.files, files); // preserved so session-revisit keeps context
 });
 
+// --- v2 record: consensus-auto fields (verdict / criticalIssues / loop summary) ---
+
+test("S21: the writer's SCHEMA_VERSION is 2 (consensus-auto round summary support)", () => {
+  assert.equal(SCHEMA_VERSION, 2);
+});
+
+test("S22: a consensus-auto opinion persists its verdict + criticalIssues losslessly", () => {
+  const dir = tmpDir();
+  const id = writeSession(rec({
+    tool: "consensus-auto",
+    opinions: [{
+      provider: "codex",
+      verdict: "REQUEST_CHANGES",
+      criticalIssues: [{ category: "security", description: "missing auth check" }],
+    }],
+  }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.equal(back.tool, "consensus-auto");
+  assert.equal(back.opinions[0].provider, "codex");
+  assert.equal(back.opinions[0].verdict, "REQUEST_CHANGES");
+  assert.deepEqual(back.opinions[0].criticalIssues, [{ category: "security", description: "missing auth check" }]);
+});
+
+test("S22b: a critical-issue description is secret-scrubbed + capped on write", () => {
+  const dir = tmpDir();
+  const secret = "sk-" + "q".repeat(30);
+  const huge = "y".repeat(MAX_TEXT_BYTES + 4000);
+  const id = writeSession(rec({
+    tool: "consensus-auto",
+    opinions: [{ provider: "grok", verdict: "REJECT", criticalIssues: [
+      { category: "ops", description: `leaked ${secret}` },
+      { category: "correctness", description: huge },
+    ] }],
+  }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  const ci = back.opinions[0].criticalIssues || [];
+  assert.equal(JSON.stringify(ci).includes(secret), false);
+  assert.ok(ci[0].description.includes("[REDACTED]"));
+  assert.ok(ci[1].description.includes("[truncated"));
+});
+
+test("S22c: a non-enum verdict is coerced to null on write (writer is the trust boundary)", () => {
+  const dir = tmpDir();
+  const secret = "sk-" + "v".repeat(30);
+  const id = writeSession(rec({
+    tool: "consensus-auto",
+    // A hand-built record that ignores parseReview's enum contract: the writer
+    // must NOT persist arbitrary free text (incl. a secret) in the verdict field.
+    opinions: [{ provider: "codex", verdict: /** @type {any} */ (`bogus ${secret}`) }],
+  }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.equal(back.opinions[0].verdict, null);
+  assert.equal(JSON.stringify(back).includes(secret), false);
+});
+
+test("S22d: question is capped at ~100 KB on write", () => {
+  const dir = tmpDir();
+  const huge = "q".repeat(MAX_TEXT_BYTES + 5000);
+  const id = writeSession(rec({ question: huge }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.ok(Buffer.byteLength(back.question, "utf8") < MAX_TEXT_BYTES + 200);
+  assert.ok(back.question.includes("[truncated"));
+});
+
+test("S23: converged / confidence / rounds round-trip on a consensus-auto record", () => {
+  const dir = tmpDir();
+  const id = writeSession(rec({
+    tool: "consensus-auto",
+    converged: true,
+    confidence: "high",
+    rounds: 3,
+  }), { dir });
+  const back = readSession(id, { dir });
+  assert.ok(back);
+  if (!back) return;
+  assert.equal(back.converged, true);
+  assert.equal(back.confidence, "high");
+  assert.equal(back.rounds, 3);
+});
+
 test("S18e: tmp reap only matches the writer's exact temp shape", () => {
   const dir = tmpDir();
   writeSession(rec({}), { dir });

--- a/test/mcp-consensus-auto.test.js
+++ b/test/mcp-consensus-auto.test.js
@@ -2,7 +2,19 @@
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const { buildServer } = require("../server/mcp/index.js");
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "delib-ca-"));
+}
+/** A tools/call that returns the parsed JSON payload. */
+async function callTool(srv, name, args, id) {
+  const res = await srv.handle({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } });
+  return JSON.parse(res.result.content[0].text);
+}
 
 /** @param {string} name @param {string} verdictText */
 function voter(name, verdictText) {
@@ -23,6 +35,8 @@ const approve = (n) => voter(n, "**Verdict**: APPROVE");
 const reject = (n) => voter(n, "**Verdict**: REQUEST_CHANGES\n- [ops] needs work");
 
 const cfg = (over) => ({ providers: {}, openrouter: { maxFanout: 3, models: [] }, consensus: { arbiter: "auto", arbiterDefaulted: false, ...(over || {}) } });
+/** cfg with persistence ON (sessions.persist). */
+const cfgPersist = (over) => ({ ...cfg(over), sessions: { persist: true } });
 
 test("CA1: tools/list advertises consensus-auto (advisory)", async () => {
   const srv = buildServer({ providers: [approve("codex")], getConfig: () => cfg() });
@@ -72,4 +86,48 @@ test("CA6: a 2-provider panel (arbiter + 1 distinct peer) converges without self
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.converged, true);
   assert.equal(payload.opinions.length, 1); // exactly one peer reviewed (arbiter excluded)
+});
+
+test("CA7: with persistence ON, a converged run is saved as a tool:consensus-auto v2 record", async () => {
+  const dir = tmpDir();
+  const srv = buildServer({ providers: [approve("codex"), approve("gemini"), approve("grok")], getConfig: () => cfgPersist(), sessionsDir: dir });
+  const payload = await callTool(srv, "consensus-auto", { prompt: "ship it" }, 7);
+  assert.equal(payload.converged, true);
+  assert.ok(payload.sessionId, "a sessionId is returned when persistence is on");
+
+  const got = await callTool(srv, "session-get", { sessionId: payload.sessionId }, 8);
+  assert.equal(got.session.tool, "consensus-auto");
+  assert.equal(got.session.schemaVersion, 2);
+  assert.equal(got.session.converged, true);
+  assert.equal(typeof got.session.confidence, "string");
+  assert.equal(typeof got.session.rounds, "number");
+  // opinions persist their structured verdict (lossless v2 shape).
+  assert.ok(got.session.opinions.length >= 1);
+  assert.equal(got.session.opinions[0].verdict, "APPROVE");
+});
+
+test("CA8: session-revisit on a consensus-auto record re-runs the LOOP + links a child", async () => {
+  const dir = tmpDir();
+  const srv = buildServer({ providers: [approve("codex"), approve("gemini"), approve("grok")], getConfig: () => cfgPersist(), sessionsDir: dir });
+  const first = await callTool(srv, "consensus-auto", { prompt: "ship it" }, 9);
+
+  const revisit = await callTool(srv, "session-revisit", { sessionId: first.sessionId }, 10);
+  // The re-run is the LOOP (converged + rounds), not a one-shot consensus.
+  assert.equal(revisit.converged, true);
+  assert.equal(typeof revisit.rounds, "number");
+  assert.equal(revisit.parentId, first.sessionId);
+  assert.ok(revisit.sessionId && revisit.sessionId !== first.sessionId);
+
+  const child = await callTool(srv, "session-get", { sessionId: revisit.sessionId }, 11);
+  assert.equal(child.session.tool, "consensus-auto");
+  assert.equal(child.session.parentId, first.sessionId);
+});
+
+test("CA9: an error-path run (host arbiter) does NOT persist - no sessionId", async () => {
+  const dir = tmpDir();
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfgPersist({ arbiter: "host" }), sessionsDir: dir });
+  const payload = await callTool(srv, "consensus-auto", { prompt: "x" }, 12);
+  assert.equal(payload.error, "arbiter-is-host");
+  assert.equal(payload.sessionId, undefined);
+  assert.deepEqual(fs.readdirSync(dir), []); // nothing written
 });


### PR DESCRIPTION
feat: persist consensus-auto runs + route session-revisit (PR2b-4b)

The server-side consensus-auto convergence loop now persists a session record
(when sessions.persist is on), and session-revisit re-runs the LOOP for a
consensus-auto record instead of silently downgrading to a one-shot consensus.

core/sessions.js (schema v2):
- SCHEMA_VERSION 1 -> 2. v1 records stay readable; all v2 additions are optional
  and readers do not branch on the version.
- SessionOpinion gains optional verdict (closed enum) + criticalIssues
  ({category, description}[]); SessionRecord.tool gains "consensus-auto" and the
  record gains optional converged/confidence/rounds (the loop summary).
- sanitizeRecord persists the new fields, scrubbing + capping all free provider
  text (criticalIssue descriptions) like any other body.

server/mcp/index.js:
- opinionsFrom unified to map both fan-out results ({provider,model,text}) and
  consensus-auto review results ({source,verdict,criticalIssues}); source falls
  back to provider so a loop opinion keeps its identity.
- persistRun persists converged/confidence/rounds when present (JSON drops undefined).
- runConsensusAuto returns {payload, parts}; parts is null on every error path
  (arbiter-is-host / no-arbiter / insufficient-peers / internal catch), non-null
  only on a real run, so the error paths never write a record.
- call(): consensus-auto persists as tool:"consensus-auto" and returns sessionId.
- session-revisit: 3-way route - a consensus-auto record re-runs runConsensusAuto
  (the full loop), writing a child linked by parentId.

Full per-round history is intentionally NOT persisted yet (the final verdict +
final-round opinions + loop summary are the durable record); the per-round
sanitization that history would require is deferred.

Reviewed via /ask-all Code Reviewer (5 models). Folded the hardening findings,
all in sanitizeRecord (the write-time trust boundary): (1) whitelist opinion.verdict
to the closed enum - coerce anything else to null - so no free text can ride the
one unscrubbed field even if parseReview's contract changes or a hand-built record
ignores it; (2) cap the `question` field with capText (a pre-existing gap - every
other text field was capped, question was not, violating the ~100 KB invariant);
(3) cap criticalIssue.category and (4) annotation note in sanitizeRecord for
write-idempotency. Dismissed: capping `expert` (a bounded persona key handled
outside sanitizeRecord; marginal value).

Tests: +9 (4 session-store: schemaVersion=2, verdict+criticalIssues lossless,
scrub/cap of issue descriptions, loop-summary round-trip; +2 hardening: non-enum
verdict -> null, question cap; +3 MCP integration: consensus-auto persists a v2
record, session-revisit re-runs the loop + links a child, error path writes
nothing). Full suite 437/437 green, typecheck clean.
