### PR TITLE
docs: sync public docs to the shipped consensus engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,18 @@ Fan-out and single-provider:
   independent answers and returns a single synthesized verdict. An optional
   server-side blind pre-vote (`consensus.blindVote` in config) returns a
   `blindVerdict` alongside the `verdict`.
+- `consensus-auto` - run the FULL multi-round convergence loop server-side with a
+  provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to
+  `consensus.maxRounds`, default 5) and get the converged verdict in one call. Use
+  this when you want the whole loop without driving it step by step. Set a concrete
+  `consensus.arbiter` (a provider or `openrouter:<alias>`); `host` mode is for the
+  client-driven path below.
+- `consensus-step` - drive the loop yourself as the arbiter, one action per call:
+  `init` (returns a `sessionId` + blind prompt) -> `record_blind` (your pre-commit
+  verdict) -> `dispatch_peers` (the server fans out to the panel) ->
+  `submit_adjudication` (your verdict + per-issue accept/dismiss/defer, each dismiss
+  needs a reason) -> `submit_revision` (your revised plan), looping until converged
+  or the round cap. State is held server-side by `sessionId` (ephemeral).
 - `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
   provider for a single-shot second opinion.
 
@@ -40,11 +52,12 @@ tools to apply one persona to every delegate):
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
 Session tools (only useful when `sessions.persist` is enabled in config; they report
-"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
+"persistence disabled" otherwise). When on, `consensus`/`ask-all`/`consensus-auto` return a `sessionId`:
 
 - `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
 - `session-revisit { sessionId }` - re-run the recorded question with the current
-  providers/config and save a linked child record.
+  providers/config and save a linked child record. A `consensus-auto` record re-runs the
+  full loop, not a one-shot pass.
 - `session-annotate { sessionId, note }` - append a note to a run's audit trail.
 
 Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,14 @@ No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok,
   `toErrorResult` + the opinion schema/envelope (`types.js` / `provider.js`): `OPINION_SCHEMA`
   (`recommendation` + `confidence` enum + optional `dissent_points`/`assumptions`/`tradeoffs`
   `string[]`), `parseOpinion(text) -> OpinionEnvelope` (best-effort, never throws; `structured` =
-  parse provenance), advisory `validateOpinion` (`{valid, wellFormed, warnings}`), and
-  `OPINION_INSTRUCTIONS`. The envelope normalizes provider replies for the consensus engine; it is
-  wired into the adapters + loop in a follow-up (the advisory `ask-*` path is unchanged for now).
-  `registry.js` (`selectForAskAll` /
-  `selectForConsensus`); `orchestrate.js` (`askAll` / `askOne` / `consensus`); `providers/*.js`
+  parse provenance), advisory `validateOpinion` (`{valid, wellFormed, warnings}`), `OPINION_INSTRUCTIONS`,
+  and `parseReview(text) -> {verdict, criticalIssues}` (anchored verdict regex + the closed 6-category
+  taxonomy) used by the convergence loop. `registry.js` (`selectForAskAll` /
+  `selectForConsensus`); `orchestrate.js` (`askAll` / `askOne` / `consensus` / `runToConvergence` -
+  the non-Claude server-side loop driver); `consensus-loop.js` (the PURE convergence state machine -
+  the SSOT for round counting, the convergence rule, the configurable max-rounds cap, history, and the
+  confidence label); `loop-store.js` (ephemeral sliding-TTL + LRU `Map` holding `LoopState` across the
+  stateless `consensus-step` calls; independent of `sessions.persist`); `providers/*.js`
   adapters (`codex.js` spawns the Codex CLI; `antigravity.js` / `grok.js` /
   `openai-compatible.js` wrap their bridge via an injectable `opts.bridge`); `paths.js`
   (config + cache path resolver, `DELIBERATION_CONFIG` override).
@@ -48,6 +51,26 @@ No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok,
 - **Typecheck gate** - `tsconfig.json` strict `checkJs` over `core/**` + `server/mcp/**/*.js`
   (excludes `server/mcp/dist`). `npm run check` = `typecheck` + `node --test test/*.test.js`,
   enforced in CI by `.github/workflows/validate.yml`.
+
+### Consensus engine (single source of truth)
+
+The multi-round convergence loop lives in `core/consensus-loop.js` as a pure state machine
+(`init -> await_blind -> await_peers -> await_adjudication -> converged|await_revision -> ...`),
+shared by two drivers so there is ONE rules layer, not a Claude copy and a non-Claude copy:
+
+- **`consensus-auto`** (MCP tool) - runs the whole loop server-side in one call with a CONCRETE
+  provider arbiter (`core/orchestrate.js runToConvergence`). For non-Claude hosts that want the loop
+  without driving it.
+- **`consensus-step`** (MCP tool) - the host model (Claude) is the arbiter and drives ONE action per
+  call (`init / record_blind / dispatch_peers / submit_adjudication / submit_revision`); `LoopState`
+  is held server-side in the ephemeral `loop-store` by `sessionId`. The live `/consensus` slash command
+  (`commands/consensus.md`) is a THIN DRIVER over this tool - the loop mechanics are in the engine, not
+  the prose.
+
+The cap is `consensus.maxRounds` (config, default 5, clamped to 50). The one-shot `consensus` tool
+(single arbiter pass) is unchanged and independent of the loop. `consensus-auto` runs persist as a
+schema-v2 session record (when `sessions.persist` is on); `session-revisit` re-runs the LOOP for such
+a record, not a one-shot pass.
 
 ### Orchestration Flow
 
@@ -93,7 +116,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
 | `config/config.schema.json` | JSON Schema (in `config/`) | Validates `config.json` in editors (VS Code built-in JSON support, no extension); `.vscode/` wires it for in-repo example configs |
-| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote`), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
+| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote` + `maxRounds`: the loop cap, default 5, clamped to 50), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off; consensus-auto records are schema v2). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 
@@ -137,7 +160,8 @@ Grok reads attached files via `files[]` and resolves them under `roots[]` (top-l
 3. **Dual mode** - Any expert can advise or implement based on task
 4. **Synthesize, don't passthrough** - Claude interprets expert output, applies judgment
 5. **Proactive triggers** - Claude checks for delegation triggers on every message
-6. **Opt-in session store** - `consensus`/`ask-all` runs persist only when `sessions.persist` is on (default off); per-file JSON at `<XDG cache>/deliberation/sessions/` (override `DELIBERATION_SESSIONS`), secrets scrubbed, retention by count + age (`-1` = unlimited). Tools: `session-get`/`session-revisit`/`session-annotate`. Details in [TECHNICAL.md § Session persistence](TECHNICAL.md#session-persistence).
+6. **Opt-in session store** - `consensus`/`ask-all`/`consensus-auto` runs persist only when `sessions.persist` is on (default off); per-file JSON at `<XDG cache>/deliberation/sessions/` (override `DELIBERATION_SESSIONS`), secrets scrubbed, retention by count + age (`-1` = unlimited). Record schema v2 (consensus-auto carries per-opinion verdict/criticalIssues + converged/confidence/rounds). Tools: `session-get`/`session-revisit`/`session-annotate`. Details in [TECHNICAL.md § Session persistence](TECHNICAL.md#session-persistence).
+7. **Consensus engine SSOT** - one pure state machine (`core/consensus-loop.js`) behind two drivers (`consensus-auto` server-side, `consensus-step` host-driven); the live `/consensus` is a thin driver over `consensus-step`. See [Consensus engine](#consensus-engine-single-source-of-truth).
 
 ## Commit Conventions & Releases
 

--- a/POWER.md
+++ b/POWER.md
@@ -34,6 +34,18 @@ Fan-out and single-provider:
   independent answers and returns a single synthesized verdict. An optional
   server-side blind pre-vote (`consensus.blindVote` in config) returns a
   `blindVerdict` alongside the `verdict`.
+- `consensus-auto` - run the FULL multi-round convergence loop server-side with a
+  provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to
+  `consensus.maxRounds`, default 5) and get the converged verdict in one call. Use
+  this when you want the whole loop without driving it step by step. Set a concrete
+  `consensus.arbiter` (a provider or `openrouter:<alias>`); `host` mode is for the
+  client-driven path below.
+- `consensus-step` - drive the loop yourself as the arbiter, one action per call:
+  `init` (returns a `sessionId` + blind prompt) -> `record_blind` (your pre-commit
+  verdict) -> `dispatch_peers` (the server fans out to the panel) ->
+  `submit_adjudication` (your verdict + per-issue accept/dismiss/defer, each dismiss
+  needs a reason) -> `submit_revision` (your revised plan), looping until converged
+  or the round cap. State is held server-side by `sessionId` (ephemeral).
 - `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
   provider for a single-shot second opinion.
 
@@ -49,11 +61,12 @@ tools to apply one persona to every delegate):
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
 Session tools (only useful when `sessions.persist` is enabled in config; they report
-"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
+"persistence disabled" otherwise). When on, `consensus`/`ask-all`/`consensus-auto` return a `sessionId`:
 
 - `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
 - `session-revisit { sessionId }` - re-run the recorded question with the current
-  providers/config and save a linked child record.
+  providers/config and save a linked child record. A `consensus-auto` record re-runs the
+  full loop, not a one-shot pass.
 - `session-annotate { sessionId, note }` - append a note to a run's audit trail.
 
 Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Per-host config location and the key it expects:
 
 Provider prerequisites are the same as the plugin (see [Requirements](#requirements)): the Codex CLI for GPT, `agy` for Gemini, `XAI_API_KEY` for Grok, and `OPENROUTER_API_KEY` plus `~/.config/deliberation/config.json` for OpenRouter (Windows: `%APPDATA%\deliberation\config.json`; override the config path with `DELIBERATION_CONFIG`).
 
-Tools exposed: `ask-all`, `consensus`, `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, and the seven experts (`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`, `security-analyst`, `researcher`, `debugger`).
+Tools exposed: `ask-all`, `consensus`, `consensus-auto` (full convergence loop server-side), `consensus-step` (drive the loop yourself, one action per call), `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, the seven experts (`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`, `security-analyst`, `researcher`, `debugger`), and the session tools (`session-get` / `session-revisit` / `session-annotate`).
 
 The package also ships a `deliberation-setup` bin. Run it once with `npx -y --package @antonbabenko/deliberation-mcp deliberation-setup` to write a starter `~/.config/deliberation/config.json` (it never overwrites an existing one). The plain `npx -y @antonbabenko/deliberation-mcp` form runs the default bin (the server), which is what your MCP host launches. For host rule wiring, see [`AGENTS.md`](AGENTS.md) and the per-host snippets in [`examples/`](examples/).
 
@@ -214,31 +214,27 @@ Or invoke the slash commands directly - see Commands above.
 
 The four guards:
 
-- **Blind verdict.** Claude posts its own verdict (APPROVE / REQUEST CHANGES / REJECT) in a message sent *before* the one that calls the panel. The pre-commitment sits in the transcript, so Claude cannot reshape its opinion after seeing the others.
-- **Peer review.** Stage 2: each external model rates the OTHER models' answers blind, with identity stripped best-effort. Not-viable votes become candidate critical issues for the arbiter to weigh. Pattern adapted from [karpathy/llm-council](https://github.com/karpathy/llm-council).
+- **Blind verdict.** Claude posts its own verdict (APPROVE / REQUEST CHANGES / REJECT) in a message sent *before* the one that calls the panel. The pre-commitment sits in the transcript, so Claude cannot reshape its opinion after seeing the others. The engine enforces this: the panel is not revealed until the blind verdict is recorded.
+- **Peer review.** Each external model reviews the plan independently and returns a verdict plus categorized critical issues; Claude weighs them as the arbiter. The models vote, Claude adjudicates.
 - **No self-approval.** A round converges only when every responding external approves and at least one external actually answered. Claude's own approval never carries a round by itself. A provider that errors (an unconfigured Grok returning `missing-auth`, for example) drops out of the count instead of jamming the loop.
-- **No silent dismissal.** Every critical issue that gets dismissed or deferred ships with a one-line reason in the final report, including the times Claude walks back one of its own blind objections.
+- **No silent dismissal.** Every critical issue that gets dismissed or deferred ships with a one-line reason in the final report, including the times Claude walks back one of its own blind objections. The engine rejects an adjudication that dismisses an issue without a reason.
 
 The `/ask-*` commands carry a lighter version of the same rule. The external model only advises: Claude reads the output, applies its own judgment, and owns the synthesized answer. When the models agree, that is input, not a verdict.
 
 <details>
 <summary>Deep dive: how a single /consensus round actually runs</summary>
 
-Each `/consensus` round runs three stages:
+`/consensus` is a thin driver over the core convergence engine (`core/consensus-loop.js`); the loop mechanics - round counting, the convergence rule, the configurable max-rounds cap, history, and the confidence label - live in the engine, not the command. Each round:
 
-1. **Stage 1 - parallel verdicts.** Claude commits a blind verdict first; GPT, Gemini, and Grok review the plan in parallel and emit APPROVE / REQUEST CHANGES / REJECT plus a list of critical issues.
-2. **Stage 2 - blind cross-review (conditional).** Each external reviewer rates the OTHER reviewers' anonymized answers as viable or not-viable, with a one-line reason and a category. Reviewer identity is stripped best-effort (preamble plus self-references). House styles may still leak, so reviewers are instructed to score substance, not style. Not-viable votes become candidate critical issues for Stage 3.
-3. **Stage 3 - arbiter adjudication.** Claude reconciles Stage 1 verdicts, Stage 2 candidate issues, and its own blind verdict. For each issue it picks accept, dismiss (with reason), or defer. Then it revises the plan for the next round.
+1. **Blind verdict.** Claude commits its own verdict (transcript-visible) BEFORE the panel is revealed; the engine gates the reveal on it.
+2. **Panel review.** GPT, Gemini, Grok (and any configured OpenRouter delegates) review the plan in parallel and emit APPROVE / REQUEST CHANGES / REJECT plus categorized critical issues. The server parses each verdict.
+3. **Arbiter adjudication + revision.** Claude reconciles the panel verdicts and its own blind verdict; for each critical issue it picks accept, dismiss (reason required), or defer, then revises the plan for the next round.
 
-The loop stops when all responding externals approve, zero critical issues remain accepted, and Claude adjudicates APPROVE. Hard cap at 5 rounds.
+The loop converges when at least one responding external approves, none reject, zero critical issues remain accepted, and Claude adjudicates APPROVE - so Claude cannot self-approve. It otherwise stops at `consensus.maxRounds` (default 5, configurable) as `unresolved`. The confidence label reflects how fast it settled (round 1 = high, 2-3 = medium, 4-5 = low).
 
-**Stage 2 trigger.** Round 1 always. Round 2 onwards, Stage 2 fires only when Stage 1 has divergence OR the previous Stage 2 surfaced an arbiter-accepted not-viable issue (a one-round lookback that catches rubber-stamp convergence after a divergent round).
+The same engine backs two non-interactive entry points for other hosts: `consensus-auto` (runs the whole loop server-side in one call with a provider arbiter) and `consensus-step` (drive it yourself, one action per call). See [TECHNICAL.md](TECHNICAL.md#consensus-flow-details) for the taxonomy and the engine contract.
 
-**Stage 2 activation boundary.** Stage 2 is skipped on `sandbox: workspace-write` runs (Claude is writing code, not reviewing prose). Plan reviews that merely contain embedded diff text as prose still run Stage 2.
-
-**Cost ceiling.** Stage 2 adds at most about 60% to the call count in the worst case (5 rounds, Stage 2 firing every round). Typical convergence (2 to 3 rounds with partial Stage 2 fires) adds 25 to 50%.
-
-Scoring vocabulary and operator-visible debug details live in [TECHNICAL.md](TECHNICAL.md#consensus-flow-details).
+> An earlier revision ran an extra "Stage 2" anonymized peer cross-review (each model scoring the others' answers blind, adapted from [karpathy/llm-council](https://github.com/karpathy/llm-council)). The engine-driven rewrite removed it to keep one source of truth; it may return as an engine feature.
 
 </details>
 
@@ -301,7 +297,7 @@ Minimal example:
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true },
+  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true, "maxRounds": 5 },
   "sessions": { "persist": false, "maxRecords": 200, "maxAgeDays": 30 }
 }
 ```
@@ -321,8 +317,9 @@ is emitted when more than 3 models participate). `consensus.arbiter` picks who s
 a shorthand string (`"auto"` / `"host"` / `"codex"` / `"gemini"` / `"grok"`) or
 `{ "model": "<id>" }` naming a record (even an out-of-panel one). `consensus.blindVote`
 (boolean, default `false`) runs the arbiter cold in parallel with the panel to reduce
-anchoring - concrete-arbiter / non-host mode only. Implementation tasks always route to
-Codex or Gemini - never OpenRouter.
+anchoring - concrete-arbiter / non-host mode only. `consensus.maxRounds` (integer, default
+`5`, clamped to `50`) caps the multi-round convergence loop used by the `consensus-auto` /
+`consensus-step` tools. Implementation tasks always route to Codex or Gemini - never OpenRouter.
 
 For the full schema, the `$schema` / VS Code validation story, apiBase override matrix
 (Ollama, vLLM, LM Studio, HuggingFace), file-attachment caps, session model persistence,

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -63,9 +63,16 @@ Claude: "I found 3 issues..." (synthesizes, applies judgment)
 
 ## Consensus flow details
 
-The README's `## How /consensus and /ask-* keep models honest` section covers the 3-stage flow narrative inside a `<details>` block. The two reference pieces below live here so the README stays narrative:
+`/consensus` is a thin driver over the `consensus-step` tool; the multi-round loop lives in
+the core state machine (`core/consensus-loop.js`). Each round: Claude commits a blind verdict,
+the server fans out to the panel (`dispatch_peers`) and parses each voice's verdict + critical
+issues, Claude adjudicates (accept/dismiss/defer, every dismiss carries a reason), then revises
+the plan. The loop converges only when at least one responding peer APPROVES, none REJECT, zero
+accepted critical issues remain, and Claude's adjudicated verdict is APPROVE - so Claude cannot
+self-approve. The cap is `consensus.maxRounds` (default 5).
 
-**Stage 2 scoring vocabulary** (the closed taxonomy `/consensus` uses for all critical-issue categories):
+**Critical-issue taxonomy** (the closed set every critical issue is tagged with, parsed by
+`parseReview` in `core/provider.js`):
 
 - `security` - auth, secrets, injection, data exposure, privilege boundary
 - `correctness` - wrong behaviour, broken invariant, missing case, race condition
@@ -74,7 +81,12 @@ The README's `## How /consensus and /ask-* keep models honest` section covers th
 - `performance` - latency, throughput, resource use, scaling limit
 - `ops` - rollback, observability, deploy, migration, on-call surface
 
-**Operator-visible debug.** The final `/consensus` report logs a Stage 2 shuffle mapping per round so you can audit which model rated which anonymized answer. The mapping lives in the final report only - reviewers never see it during Stage 2.
+**Stage 2 (anonymized peer cross-review) is not part of the current loop.** Earlier revisions ran
+a command-layer Stage 2 (each reviewer scored the others' anonymized answers, with a shuffle
+mapping in the report). The engine-driven rewrite removed it: the core loop has no Stage 2 model,
+and keeping it in command prose re-introduced the duplication the rewrite eliminated. If anonymized
+cross-review proves valuable it returns as an engine feature (a new `consensus-step` action), not as
+prose.
 
 ## Provider bridges
 
@@ -505,6 +517,20 @@ Constraints and behavior:
 Behavior source of truth: `consensus()` in `core/orchestrate.js` and the `blindVote`
 validation in `server/openrouter/config.js`.
 
+### consensus.maxRounds
+
+`consensus.maxRounds` is an optional positive integer (default `5`) that caps the
+server-side convergence loop used by the `consensus-auto` and `consensus-step` tools.
+The loop ends `unresolved` once it hits the cap without converging.
+
+- **Range.** `1`..`50`. A value above `50` is clamped to `50` with a warning; a
+  non-integer or non-positive value is dropped (the default `5` applies) with a warning -
+  it never hard-fails the config.
+- **Scope.** It governs only the multi-round loop tools. The one-shot `consensus` tool is
+  a single arbiter pass and is unaffected.
+- Validation lives in `resolveConsensus` (`server/openrouter/config.js`); the cap is
+  enforced in `core/consensus-loop.js`.
+
 ### camelCase config keys, wire mapping
 
 Config keys are camelCase: `reasoningEffort`, `temperature`, `timeout`. The bridge sends
@@ -679,21 +705,31 @@ surfaces.
   `-1` = unlimited). Orphaned `<id>.json.tmp.<pid>.<ts>` fragments older than an hour
   are also reaped.
 
-### Record shape (`schemaVersion: 1`)
+### Record shape (`schemaVersion: 2`)
 
 ```
-{ id, parentId|null, schemaVersion: 1, createdAt: <ISO>,
-  tool: "consensus"|"ask-all", question, expert|null,
+{ id, parentId|null, schemaVersion: 2, createdAt: <ISO>,
+  tool: "consensus"|"ask-all"|"consensus-auto", question, expert|null,
   files: [{ path|dir|file_id|file_url, mode? }]|null,   // attachment REFS, never bodies
-  opinions: [{ provider, model, text }],
+  opinions: [{ provider, model, text,
+               verdict?, criticalIssues? }],            // verdict/criticalIssues on consensus-auto opinions
   blindVerdict|null, verdict|null,
-  arbiter: { mode, provider }|null, warnings: [], annotations: [{ note, at }] }
+  arbiter: { mode, provider }|null, warnings: [], annotations: [{ note, at }],
+  converged?, confidence?, rounds? }                    // consensus-auto loop summary
 ```
+
+v2 is additive: v1 records (no `verdict`/`criticalIssues`/loop-summary fields) still read
+back fine - `readSession` returns the object as-is and callers treat the v2 fields as
+optional. The `verdict`/`criticalIssues` and `converged`/`confidence`/`rounds` fields are
+populated only for `consensus-auto` runs (the multi-round loop); one-shot `consensus` and
+`ask-all` records omit them.
 
 Before writing, `scrubSecrets` redacts common key shapes (OpenAI `sk-`, OpenRouter
 `sk-or-`, xAI `xai-`, GitHub `gh[pousr]_`, AWS `AKIA`, Google `AIza`, and `Bearer`
-tokens) in the question, opinion/verdict text, `warnings`, annotation notes, and the
-file `path`/`dir` strings; each opinion/verdict is capped at ~100 KB. Scrubbing is
+tokens) in the question, opinion/verdict text, each critical-issue description, `warnings`,
+annotation notes, and the file `path`/`dir` strings; the question and each opinion/verdict
+are capped at ~100 KB, and an opinion `verdict` is whitelisted to the closed enum (anything
+else is coerced to `null`) so no free text rides the unscrubbed verdict field. Scrubbing is
 best-effort - user transcript text may still carry secrets in unrecognized shapes.
 
 ### Tools
@@ -704,11 +740,11 @@ Each takes its own input schema (no `prompt`), and reports
 | Tool | Input | Effect |
 |------|-------|--------|
 | `session-get` | `{ sessionId }` | Return the record, or a not-found message. Read-only. |
-| `session-revisit` | `{ sessionId, cwd? }` | Re-run the record's original question (and its file refs) with the CURRENT providers/config, write a CHILD record (`parentId` = original id), return the new `sessionId` + result. Re-run, not snapshot-replay. |
+| `session-revisit` | `{ sessionId, cwd? }` | Re-run the record's original question (and its file refs) with the CURRENT providers/config, write a CHILD record (`parentId` = original id), return the new `sessionId` + result. Re-run, not snapshot-replay. A `consensus-auto` record re-runs the full multi-round LOOP, not a one-shot pass. |
 | `session-annotate` | `{ sessionId, note }` | Append `{ note, at }` to the record's audit trail and rewrite the file. |
 
-When `persist` is on, `consensus` and `ask-all` also include a top-level `sessionId`
-in their result.
+When `persist` is on, `consensus`, `ask-all`, and `consensus-auto` also include a top-level
+`sessionId` in their result.
 
 ## Customizing expert prompts
 

--- a/plugins/deliberation/skills/deliberation/SKILL.md
+++ b/plugins/deliberation/skills/deliberation/SKILL.md
@@ -31,6 +31,18 @@ Fan-out and single-provider:
   independent answers and returns a single synthesized verdict. An optional
   server-side blind pre-vote (`consensus.blindVote` in config) returns a
   `blindVerdict` alongside the `verdict`.
+- `consensus-auto` - run the FULL multi-round convergence loop server-side with a
+  provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to
+  `consensus.maxRounds`, default 5) and get the converged verdict in one call. Use
+  this when you want the whole loop without driving it step by step. Set a concrete
+  `consensus.arbiter` (a provider or `openrouter:<alias>`); `host` mode is for the
+  client-driven path below.
+- `consensus-step` - drive the loop yourself as the arbiter, one action per call:
+  `init` (returns a `sessionId` + blind prompt) -> `record_blind` (your pre-commit
+  verdict) -> `dispatch_peers` (the server fans out to the panel) ->
+  `submit_adjudication` (your verdict + per-issue accept/dismiss/defer, each dismiss
+  needs a reason) -> `submit_revision` (your revised plan), looping until converged
+  or the round cap. State is held server-side by `sessionId` (ephemeral).
 - `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one
   provider for a single-shot second opinion.
 
@@ -46,11 +58,12 @@ tools to apply one persona to every delegate):
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
 Session tools (only useful when `sessions.persist` is enabled in config; they report
-"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
+"persistence disabled" otherwise). When on, `consensus`/`ask-all`/`consensus-auto` return a `sessionId`:
 
 - `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
 - `session-revisit { sessionId }` - re-run the recorded question with the current
-  providers/config and save a linked child record.
+  providers/config and save a linked child record. A `consensus-auto` record re-runs the
+  full loop, not a one-shot pass.
 - `session-annotate { sessionId, note }` - append a note to a run's audit trail.
 
 Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code


### PR DESCRIPTION
docs: sync public docs to the shipped consensus engine

The consensus engine chain (point 1) shipped end to end (PRs #90-#108) but the
public docs still described the pre-engine state. Bring them to reality.

CLAUDE.md:
- core/ layout now lists consensus-loop.js (the pure state-machine SSOT), loop-store.js,
  runToConvergence, and parseReview; dropped the stale "wired in a follow-up" clause.
- New "Consensus engine (single source of truth)" subsection: one state machine behind two
  drivers (consensus-auto server-side, consensus-step host-driven); /consensus is a thin driver.
- Config table: consensus gains maxRounds (default 5, clamped 50); sessions records are v2.
- New design decision: consensus engine SSOT.

AGENTS.md / POWER.md / SKILL.md (the last two regenerated by scripts/sync-hosts.js):
- Added consensus-auto and consensus-step to the tool list; noted consensus-auto returns a
  sessionId and that session-revisit re-runs the loop for such a record.

README.md:
- "How /consensus keeps models honest": reframed the peer-review guard and rewrote the deep-dive
  to the engine-driven loop (blind -> panel review -> adjudicate+revise; convergence rule;
  configurable cap; confidence label). Stage 2 is documented as removed/deferred, not current.
- Config: consensus.maxRounds in the example + prose. "Tools exposed" lists consensus-auto,
  consensus-step, and the session tools.

TECHNICAL.md:
- New consensus.maxRounds section (range 1-50, clamp, validation source).
- Record shape bumped to schemaVersion 2 (tool "consensus-auto"; per-opinion verdict/criticalIssues;
  converged/confidence/rounds; v1 still reads). Session tools/persist note covers consensus-auto.
- "Consensus flow details" rewritten to the engine loop; the closed taxonomy stays (parsed by
  parseReview); Stage 2 marked not-part-of-the-current-loop (deferred to a future engine action).

Docs-only + regenerated host artifacts; no code change.
