### PR TITLE
feat!: unify consensus tools into one + drop schema versioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,16 +21,15 @@ Fan-out and single-provider:
 
 - `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
   models in parallel, get every answer back independently (no cross-talk).
-- `consensus` - fan out, then run one arbiter pass that cross-reviews the
-  independent answers and returns a single synthesized verdict. An optional
-  server-side blind pre-vote (`consensus.blindVote` in config) returns a
-  `blindVerdict` alongside the `verdict`.
-- `consensus-auto` - run the FULL multi-round convergence loop server-side with a
-  provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to
-  `consensus.maxRounds`, default 5) and get the converged verdict in one call. Use
-  this when you want the whole loop without driving it step by step. Set a concrete
-  `consensus.arbiter` (a provider or `openrouter:<alias>`); `host` mode is for the
-  client-driven path below.
+- `consensus` - run the FULL multi-round convergence loop server-side with a provider
+  arbiter (blind pass + peer fan-out -> adjudicate -> revise) and get the converged
+  verdict in one call. Depth is `consensus.maxRounds` (config, default 5); pass
+  `maxRounds` to override. Pass `synthesizeAlways:true` for a SINGLE arbiter synthesis
+  pass instead of the loop (best for open questions): it returns a free-text `synthesis`
+  (the enum `verdict` and `converged`/`confidence` are null, `rounds` is 1). Set a concrete
+  `consensus.arbiter` (a provider or `openrouter:<alias>`) for the server-side pass; in
+  `host` mode the tool returns the opinions for YOU to synthesize. An optional blind
+  pre-vote (`consensus.blindVote`) is available on the synthesize path.
 - `consensus-step` - drive the loop yourself as the arbiter, one action per call:
   `init` (returns a `sessionId` + blind prompt) -> `record_blind` (your pre-commit
   verdict) -> `dispatch_peers` (the server fans out to the panel) ->
@@ -52,12 +51,12 @@ tools to apply one persona to every delegate):
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
 Session tools (only useful when `sessions.persist` is enabled in config; they report
-"persistence disabled" otherwise). When on, `consensus`/`ask-all`/`consensus-auto` return a `sessionId`:
+"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
 
 - `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
 - `session-revisit { sessionId }` - re-run the recorded question with the current
-  providers/config and save a linked child record. A `consensus-auto` record re-runs the
-  full loop, not a one-shot pass.
+  providers/config and save a linked child record. A `consensus` record replays its
+  mode (the loop, or a synthesize pass).
 - `session-annotate { sessionId, note }` - append a note to a run's audit trail.
 
 Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,19 +58,21 @@ The multi-round convergence loop lives in `core/consensus-loop.js` as a pure sta
 (`init -> await_blind -> await_peers -> await_adjudication -> converged|await_revision -> ...`),
 shared by two drivers so there is ONE rules layer, not a Claude copy and a non-Claude copy:
 
-- **`consensus-auto`** (MCP tool) - runs the whole loop server-side in one call with a CONCRETE
-  provider arbiter (`core/orchestrate.js runToConvergence`). For non-Claude hosts that want the loop
-  without driving it.
+- **`consensus`** (MCP tool) - runs the whole loop server-side in one call with a CONCRETE
+  provider arbiter (`core/orchestrate.js runToConvergence`). `maxRounds` overrides the config cap;
+  `synthesizeAlways:true` runs a SINGLE arbiter synthesis pass instead of the loop (free-text
+  `synthesis`, for open questions) - one unified tool, one return envelope (split `verdict`/`synthesis`,
+  loop-only fields nullable). For non-Claude hosts that want the loop without driving it.
 - **`consensus-step`** (MCP tool) - the host model (Claude) is the arbiter and drives ONE action per
   call (`init / record_blind / dispatch_peers / submit_adjudication / submit_revision`); `LoopState`
   is held server-side in the ephemeral `loop-store` by `sessionId`. The live `/consensus` slash command
   (`commands/consensus.md`) is a THIN DRIVER over this tool - the loop mechanics are in the engine, not
-  the prose.
+  the prose. This is the transcript-visible host-arbiter path; the `consensus` tool is the
+  provider-arbiter path.
 
-The cap is `consensus.maxRounds` (config, default 5, clamped to 50). The one-shot `consensus` tool
-(single arbiter pass) is unchanged and independent of the loop. `consensus-auto` runs persist as a
-schema-v2 session record (when `sessions.persist` is on); `session-revisit` re-runs the LOOP for such
-a record, not a one-shot pass.
+The cap is `consensus.maxRounds` (config, default 5, clamped to 50; a per-call `maxRounds` overrides it).
+`consensus` runs persist a session record (when `sessions.persist` is on, with the mode flag);
+`session-revisit` replays the recorded mode (loop or synthesize), not a one-shot pass.
 
 ### Orchestration Flow
 
@@ -116,7 +118,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
 | `config/config.schema.json` | JSON Schema (in `config/`) | Validates `config.json` in editors (VS Code built-in JSON support, no extension); `.vscode/` wires it for in-repo example configs |
-| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote` + `maxRounds`: the loop cap, default 5, clamped to 50), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off; consensus-auto records are schema v2). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
+| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote` + `maxRounds`: the loop cap, default 5, clamped to 50), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off; single `schemaVersion:1` stamp). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 
@@ -160,8 +162,8 @@ Grok reads attached files via `files[]` and resolves them under `roots[]` (top-l
 3. **Dual mode** - Any expert can advise or implement based on task
 4. **Synthesize, don't passthrough** - Claude interprets expert output, applies judgment
 5. **Proactive triggers** - Claude checks for delegation triggers on every message
-6. **Opt-in session store** - `consensus`/`ask-all`/`consensus-auto` runs persist only when `sessions.persist` is on (default off); per-file JSON at `<XDG cache>/deliberation/sessions/` (override `DELIBERATION_SESSIONS`), secrets scrubbed, retention by count + age (`-1` = unlimited). Record schema v2 (consensus-auto carries per-opinion verdict/criticalIssues + converged/confidence/rounds). Tools: `session-get`/`session-revisit`/`session-annotate`. Details in [TECHNICAL.md § Session persistence](TECHNICAL.md#session-persistence).
-7. **Consensus engine SSOT** - one pure state machine (`core/consensus-loop.js`) behind two drivers (`consensus-auto` server-side, `consensus-step` host-driven); the live `/consensus` is a thin driver over `consensus-step`. See [Consensus engine](#consensus-engine-single-source-of-truth).
+6. **Opt-in session store** - `consensus`/`ask-all` runs persist only when `sessions.persist` is on (default off); per-file JSON at `<XDG cache>/deliberation/sessions/` (override `DELIBERATION_SESSIONS`), secrets scrubbed, retention by count + age (`-1` = unlimited). Single `schemaVersion:1` (no dual-version support; loop runs carry per-opinion verdict/criticalIssues + converged/confidence/rounds, synthesize runs carry `synthesis`). Tools: `session-get`/`session-revisit`/`session-annotate`. Details in [TECHNICAL.md § Session persistence](TECHNICAL.md#session-persistence).
+7. **Consensus engine SSOT** - one pure state machine (`core/consensus-loop.js`) behind two drivers (`consensus` server-side, `consensus-step` host-driven); the live `/consensus` is a thin driver over `consensus-step`. See [Consensus engine](#consensus-engine-single-source-of-truth).
 
 ## Commit Conventions & Releases
 

--- a/POWER.md
+++ b/POWER.md
@@ -30,16 +30,15 @@ Fan-out and single-provider:
 
 - `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
   models in parallel, get every answer back independently (no cross-talk).
-- `consensus` - fan out, then run one arbiter pass that cross-reviews the
-  independent answers and returns a single synthesized verdict. An optional
-  server-side blind pre-vote (`consensus.blindVote` in config) returns a
-  `blindVerdict` alongside the `verdict`.
-- `consensus-auto` - run the FULL multi-round convergence loop server-side with a
-  provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to
-  `consensus.maxRounds`, default 5) and get the converged verdict in one call. Use
-  this when you want the whole loop without driving it step by step. Set a concrete
-  `consensus.arbiter` (a provider or `openrouter:<alias>`); `host` mode is for the
-  client-driven path below.
+- `consensus` - run the FULL multi-round convergence loop server-side with a provider
+  arbiter (blind pass + peer fan-out -> adjudicate -> revise) and get the converged
+  verdict in one call. Depth is `consensus.maxRounds` (config, default 5); pass
+  `maxRounds` to override. Pass `synthesizeAlways:true` for a SINGLE arbiter synthesis
+  pass instead of the loop (best for open questions): it returns a free-text `synthesis`
+  (the enum `verdict` and `converged`/`confidence` are null, `rounds` is 1). Set a concrete
+  `consensus.arbiter` (a provider or `openrouter:<alias>`) for the server-side pass; in
+  `host` mode the tool returns the opinions for YOU to synthesize. An optional blind
+  pre-vote (`consensus.blindVote`) is available on the synthesize path.
 - `consensus-step` - drive the loop yourself as the arbiter, one action per call:
   `init` (returns a `sessionId` + blind prompt) -> `record_blind` (your pre-commit
   verdict) -> `dispatch_peers` (the server fans out to the panel) ->
@@ -61,12 +60,12 @@ tools to apply one persona to every delegate):
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
 Session tools (only useful when `sessions.persist` is enabled in config; they report
-"persistence disabled" otherwise). When on, `consensus`/`ask-all`/`consensus-auto` return a `sessionId`:
+"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
 
 - `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
 - `session-revisit { sessionId }` - re-run the recorded question with the current
-  providers/config and save a linked child record. A `consensus-auto` record re-runs the
-  full loop, not a one-shot pass.
+  providers/config and save a linked child record. A `consensus` record replays its
+  mode (the loop, or a synthesize pass).
 - `session-annotate { sessionId, note }` - append a note to a run's audit trail.
 
 Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deliberation
 
-Get a second opinion in Claude Code from GPT, Gemini, and Grok - plus 300+ more models through OpenRouter, including Qwen, Kimi, and DeepSeek. Seven domain experts (Architect, Code Reviewer, Security Analyst, and four more) review your plans, find bugs, and debate edge cases until they agree.
+Get a second opinion in Claude Code from GPT, Gemini, and Grok - plus 400+ more models through OpenRouter, including Qwen, Kimi, and DeepSeek. Seven domain experts (Architect, Code Reviewer, Security Analyst, and four more) review your plans, find bugs, and debate edge cases until they agree.
 
 [![Four chairs at the table: Claude, GPT, Gemini, Grok - one verdict you can ship](assets/agents.png)<br>One model is a guess. Three that agree is a plan. → read the blog post](https://builder.aws.com/content/3DtBiR4ua0qy7ybZMPzPmQ2SDMj/one-model-is-a-guess-three-that-agree-is-a-plan)
 
@@ -115,7 +115,7 @@ Per-host config location and the key it expects:
 
 Provider prerequisites are the same as the plugin (see [Requirements](#requirements)): the Codex CLI for GPT, `agy` for Gemini, `XAI_API_KEY` for Grok, and `OPENROUTER_API_KEY` plus `~/.config/deliberation/config.json` for OpenRouter (Windows: `%APPDATA%\deliberation\config.json`; override the config path with `DELIBERATION_CONFIG`).
 
-Tools exposed: `ask-all`, `consensus`, `consensus-auto` (full convergence loop server-side), `consensus-step` (drive the loop yourself, one action per call), `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, the seven experts (`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`, `security-analyst`, `researcher`, `debugger`), and the session tools (`session-get` / `session-revisit` / `session-annotate`).
+Tools exposed: `ask-all`, `consensus` (the full convergence loop in one call, or a single synthesis pass with `synthesizeAlways:true`), `consensus-step` (drive the loop yourself, one action per call), `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter`, the seven experts (`architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`, `security-analyst`, `researcher`, `debugger`), and the session tools (`session-get` / `session-revisit` / `session-annotate`).
 
 The package also ships a `deliberation-setup` bin. Run it once with `npx -y --package @antonbabenko/deliberation-mcp deliberation-setup` to write a starter `~/.config/deliberation/config.json` (it never overwrites an existing one). The plain `npx -y @antonbabenko/deliberation-mcp` form runs the default bin (the server), which is what your MCP host launches. For host rule wiring, see [`AGENTS.md`](AGENTS.md) and the per-host snippets in [`examples/`](examples/).
 
@@ -232,7 +232,7 @@ The `/ask-*` commands carry a lighter version of the same rule. The external mod
 
 The loop converges when at least one responding external approves, none reject, zero critical issues remain accepted, and Claude adjudicates APPROVE - so Claude cannot self-approve. It otherwise stops at `consensus.maxRounds` (default 5, configurable) as `unresolved`. The confidence label reflects how fast it settled (round 1 = high, 2-3 = medium, 4-5 = low).
 
-The same engine backs two non-interactive entry points for other hosts: `consensus-auto` (runs the whole loop server-side in one call with a provider arbiter) and `consensus-step` (drive it yourself, one action per call). See [TECHNICAL.md](TECHNICAL.md#consensus-flow-details) for the taxonomy and the engine contract.
+The same engine backs the entry points other hosts use: the `consensus` tool (runs the whole loop server-side in one call with a provider arbiter, or a single synthesis pass with `synthesizeAlways:true`) and `consensus-step` (drive it yourself, one action per call). See [TECHNICAL.md](TECHNICAL.md#consensus-flow-details) for the taxonomy and the engine contract.
 
 > An earlier revision ran an extra "Stage 2" anonymized peer cross-review (each model scoring the others' answers blind, adapted from [karpathy/llm-council](https://github.com/karpathy/llm-council)). The engine-driven rewrite removed it to keep one source of truth; it may return as an engine feature.
 
@@ -318,8 +318,8 @@ a shorthand string (`"auto"` / `"host"` / `"codex"` / `"gemini"` / `"grok"`) or
 `{ "model": "<id>" }` naming a record (even an out-of-panel one). `consensus.blindVote`
 (boolean, default `false`) runs the arbiter cold in parallel with the panel to reduce
 anchoring - concrete-arbiter / non-host mode only. `consensus.maxRounds` (integer, default
-`5`, clamped to `50`) caps the multi-round convergence loop used by the `consensus-auto` /
-`consensus-step` tools. Implementation tasks always route to Codex or Gemini - never OpenRouter.
+`5`, clamped to `50`) caps the multi-round convergence loop used by the `consensus` /
+`consensus-step` tools (a per-call `maxRounds` overrides it). Implementation tasks always route to Codex or Gemini - never OpenRouter.
 
 For the full schema, the `$schema` / VS Code validation story, apiBase override matrix
 (Ollama, vLLM, LM Studio, HuggingFace), file-attachment caps, session model persistence,

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -520,7 +520,7 @@ validation in `server/openrouter/config.js`.
 ### consensus.maxRounds
 
 `consensus.maxRounds` is an optional positive integer (default `5`) that caps the
-server-side convergence loop used by the `consensus-auto` and `consensus-step` tools.
+server-side convergence loop used by the `consensus` and `consensus-step` tools (a per-call `maxRounds` overrides it).
 The loop ends `unresolved` once it hits the cap without converging.
 
 - **Range.** `1`..`50`. A value above `50` is clamped to `50` with a warning; a
@@ -705,24 +705,26 @@ surfaces.
   `-1` = unlimited). Orphaned `<id>.json.tmp.<pid>.<ts>` fragments older than an hour
   are also reaped.
 
-### Record shape (`schemaVersion: 2`)
+### Record shape (`schemaVersion: 1`)
 
 ```
-{ id, parentId|null, schemaVersion: 2, createdAt: <ISO>,
-  tool: "consensus"|"ask-all"|"consensus-auto", question, expert|null,
+{ id, parentId|null, schemaVersion: 1, createdAt: <ISO>,
+  tool: "consensus"|"ask-all", question, expert|null,
   files: [{ path|dir|file_id|file_url, mode? }]|null,   // attachment REFS, never bodies
   opinions: [{ provider, model, text,
-               verdict?, criticalIssues? }],            // verdict/criticalIssues on consensus-auto opinions
-  blindVerdict|null, verdict|null,
+               verdict?, criticalIssues? }],            // verdict/criticalIssues on consensus LOOP opinions
+  blindVerdict|null, verdict|null,                      // verdict = loop enum (null in synthesize mode)
+  synthesis?|null, synthesizeAlways?,                   // synthesis = free-text (synthesize runs)
   arbiter: { mode, provider }|null, warnings: [], annotations: [{ note, at }],
-  converged?, confidence?, rounds? }                    // consensus-auto loop summary
+  converged?, confidence?, rounds? }                    // consensus LOOP summary
 ```
 
-v2 is additive: v1 records (no `verdict`/`criticalIssues`/loop-summary fields) still read
-back fine - `readSession` returns the object as-is and callers treat the v2 fields as
-optional. The `verdict`/`criticalIssues` and `converged`/`confidence`/`rounds` fields are
-populated only for `consensus-auto` runs (the multi-round loop); one-shot `consensus` and
-`ask-all` records omit them.
+A single stamp - no dual-version support (pre-1.0, no users). `readSession` returns the
+object as-is and nothing branches on `schemaVersion`. The loop fields
+(`verdict`/`criticalIssues`/`converged`/`confidence`/`rounds`) are populated only for a
+`consensus` LOOP run; a `synthesizeAlways` run carries `synthesis` instead; `ask-all` omits
+all of them. (`tool` is `"consensus"` for both consensus modes; `synthesizeAlways` records
+the mode so `session-revisit` replays it.)
 
 Before writing, `scrubSecrets` redacts common key shapes (OpenAI `sk-`, OpenRouter
 `sk-or-`, xAI `xai-`, GitHub `gh[pousr]_`, AWS `AKIA`, Google `AIza`, and `Bearer`
@@ -740,11 +742,11 @@ Each takes its own input schema (no `prompt`), and reports
 | Tool | Input | Effect |
 |------|-------|--------|
 | `session-get` | `{ sessionId }` | Return the record, or a not-found message. Read-only. |
-| `session-revisit` | `{ sessionId, cwd? }` | Re-run the record's original question (and its file refs) with the CURRENT providers/config, write a CHILD record (`parentId` = original id), return the new `sessionId` + result. Re-run, not snapshot-replay. A `consensus-auto` record re-runs the full multi-round LOOP, not a one-shot pass. |
+| `session-revisit` | `{ sessionId, cwd? }` | Re-run the record's original question (and its file refs) with the CURRENT providers/config, write a CHILD record (`parentId` = original id), return the new `sessionId` + result. Re-run, not snapshot-replay. A `consensus` record replays its mode - the full multi-round LOOP, or the single synthesis pass. (Records written before the tool merge are unsupported - pre-1.0, no users.) |
 | `session-annotate` | `{ sessionId, note }` | Append `{ note, at }` to the record's audit trail and rewrite the file. |
 
-When `persist` is on, `consensus`, `ask-all`, and `consensus-auto` also include a top-level
-`sessionId` in their result.
+When `persist` is on, `consensus` and `ask-all` also include a top-level `sessionId` in
+their result.
 
 ## Customizing expert prompts
 

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -42,7 +42,8 @@
   },
   "consensus": {
     "arbiter": "auto",
-    "blindVote": false
+    "blindVote": false,
+    "maxRounds": 5
   },
   "sessions": {
     "persist": false,

--- a/core/sessions.js
+++ b/core/sessions.js
@@ -21,12 +21,14 @@ const path = require("node:path");
 const crypto = require("node:crypto");
 
 /**
- * Current on-disk record shape version.
- * v2: consensus-auto records carry per-opinion verdict/criticalIssues + a loop
- * summary (converged/confidence/rounds). v1 records remain readable (all v2
- * additions are optional); readers do not branch on the version today.
+ * Current on-disk record shape version. A single stamp written on every record;
+ * nothing reads or branches on it today (it is a cheap migration signal for the
+ * future). Pre-1.0 with no users, so there is only ONE shape - no compatibility
+ * path. Loop runs (the `consensus` tool) carry extra optional fields
+ * (per-opinion verdict/criticalIssues, synthesis, converged/confidence/rounds)
+ * that one-shot/ask-all runs simply omit.
  */
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 1;
 /** Anchored id guard: rejects `../`, dots, slashes - no path traversal. */
 const ID_RE = /^[A-Za-z0-9-]+$/;
 /** Exact shape of a write temp file (`<id>.json.tmp.<pid>.<ms>`) - reaped if orphaned. */
@@ -48,8 +50,8 @@ const DEFAULT_MAX_AGE_DAYS = 30;
  * @property {string} provider
  * @property {string} [model]
  * @property {string} [text]
- * @property {(("APPROVE"|"REQUEST_CHANGES"|"REJECT")|null)} [verdict]  consensus-auto review verdict
- * @property {SessionCriticalIssue[]} [criticalIssues]  consensus-auto tagged issues
+ * @property {(("APPROVE"|"REQUEST_CHANGES"|"REJECT")|null)} [verdict]  consensus loop review verdict
+ * @property {SessionCriticalIssue[]} [criticalIssues]  consensus loop tagged issues
  */
 
 /**
@@ -82,19 +84,21 @@ const DEFAULT_MAX_AGE_DAYS = 30;
  * @property {(string|null)} parentId
  * @property {number} schemaVersion
  * @property {string} createdAt  ISO timestamp
- * @property {("consensus"|"ask-all"|"consensus-auto")} tool
+ * @property {("consensus"|"ask-all")} tool
  * @property {string} question
  * @property {(string|null)} [expert]
  * @property {(SessionFileRef[]|null)} [files]
  * @property {SessionOpinion[]} opinions
  * @property {(string|null)} [blindVerdict]
- * @property {(string|null)} [verdict]
+ * @property {(string|null)} [verdict]  loop verdict enum (APPROVE|REQUEST_CHANGES|REJECT); null in synthesize mode
+ * @property {(string|null)} [synthesis]  free-text arbiter synthesis (synthesizeAlways runs); null in loop mode
+ * @property {boolean} [synthesizeAlways]  the run was a one-pass synthesis, not the convergence loop
  * @property {(SessionArbiter|null)} [arbiter]
  * @property {string[]} [warnings]
  * @property {SessionAnnotation[]} [annotations]
- * @property {boolean} [converged]  consensus-auto: did the loop converge
- * @property {string} [confidence]  consensus-auto: final confidence (none|low|medium|high)
- * @property {number} [rounds]  consensus-auto: number of rounds the loop ran
+ * @property {boolean} [converged]  consensus loop: did the loop converge
+ * @property {string} [confidence]  consensus loop: final confidence (none|low|medium|high)
+ * @property {number} [rounds]  consensus loop: number of rounds the loop ran
  */
 
 /**
@@ -206,6 +210,7 @@ function sanitizeRecord(record) {
     });
   }
   if (record.verdict != null) out.verdict = capText(scrubSecrets(String(record.verdict)));
+  if (record.synthesis != null) out.synthesis = capText(scrubSecrets(String(record.synthesis)));
   if (record.blindVerdict != null) out.blindVerdict = capText(scrubSecrets(String(record.blindVerdict)));
   if (Array.isArray(record.files)) {
     out.files = record.files.map((f) => {

--- a/plugins/deliberation/skills/deliberation/SKILL.md
+++ b/plugins/deliberation/skills/deliberation/SKILL.md
@@ -27,16 +27,15 @@ Fan-out and single-provider:
 
 - `ask-all` - send one question to GPT, Gemini, Grok, and configured OpenRouter
   models in parallel, get every answer back independently (no cross-talk).
-- `consensus` - fan out, then run one arbiter pass that cross-reviews the
-  independent answers and returns a single synthesized verdict. An optional
-  server-side blind pre-vote (`consensus.blindVote` in config) returns a
-  `blindVerdict` alongside the `verdict`.
-- `consensus-auto` - run the FULL multi-round convergence loop server-side with a
-  provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to
-  `consensus.maxRounds`, default 5) and get the converged verdict in one call. Use
-  this when you want the whole loop without driving it step by step. Set a concrete
-  `consensus.arbiter` (a provider or `openrouter:<alias>`); `host` mode is for the
-  client-driven path below.
+- `consensus` - run the FULL multi-round convergence loop server-side with a provider
+  arbiter (blind pass + peer fan-out -> adjudicate -> revise) and get the converged
+  verdict in one call. Depth is `consensus.maxRounds` (config, default 5); pass
+  `maxRounds` to override. Pass `synthesizeAlways:true` for a SINGLE arbiter synthesis
+  pass instead of the loop (best for open questions): it returns a free-text `synthesis`
+  (the enum `verdict` and `converged`/`confidence` are null, `rounds` is 1). Set a concrete
+  `consensus.arbiter` (a provider or `openrouter:<alias>`) for the server-side pass; in
+  `host` mode the tool returns the opinions for YOU to synthesize. An optional blind
+  pre-vote (`consensus.blindVote`) is available on the synthesize path.
 - `consensus-step` - drive the loop yourself as the arbiter, one action per call:
   `init` (returns a `sessionId` + blind prompt) -> `record_blind` (your pre-commit
   verdict) -> `dispatch_peers` (the server fans out to the panel) ->
@@ -58,12 +57,12 @@ tools to apply one persona to every delegate):
 - `debugger` - ranked root-cause hypotheses and the smallest safe fix.
 
 Session tools (only useful when `sessions.persist` is enabled in config; they report
-"persistence disabled" otherwise). When on, `consensus`/`ask-all`/`consensus-auto` return a `sessionId`:
+"persistence disabled" otherwise). When on, `consensus`/`ask-all` return a `sessionId`:
 
 - `session-get { sessionId }` - fetch a recorded run (opinions, verdict, annotations).
 - `session-revisit { sessionId }` - re-run the recorded question with the current
-  providers/config and save a linked child record. A `consensus-auto` record re-runs the
-  full loop, not a one-shot pass.
+  providers/config and save a linked child record. A `consensus` record replays its
+  mode (the loop, or a synthesize pass).
 - `session-annotate { sessionId, note }` - append a note to a run's audit trail.
 
 Every fan-out, single-provider, and expert tool takes a `prompt`. Give it full context: the goal, the relevant code

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -55,6 +55,37 @@ function inputSchema() {
   };
 }
 
+// The unified consensus tool: the fan-out fields plus the loop knobs. maxRounds
+// overrides the config default; synthesizeAlways switches to a single synthesis pass.
+function consensusInputSchema() {
+  return {
+    type: "object",
+    required: ["prompt"],
+    properties: {
+      prompt: { type: "string" },
+      expert: { type: "string" },
+      developerInstructions: { type: "string" },
+      reasoningEffort: { type: "string", enum: ["low", "medium", "high", "none"] },
+      maxRounds: { type: "integer", minimum: 1, maximum: 50, description: "Override consensus.maxRounds for this call (loop mode only; ignored when synthesizeAlways is true). Clamped to 50." },
+      synthesizeAlways: { type: "boolean", description: "Run ONE arbiter synthesis pass instead of the convergence loop. Returns a free-text `synthesis` (verdict/converged/confidence are null, rounds is 1). Best for open questions." },
+      cwd: { type: "string" },
+      files: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            path: { type: "string" },
+            dir: { type: "string" },
+            file_id: { type: "string" },
+            file_url: { type: "string" },
+            mode: { type: "string", enum: ["auto", "inline", "upload"] },
+          },
+        },
+      },
+    },
+  };
+}
+
 // Session tools take a sessionId (+ note for annotate), NOT a prompt - so they
 // need their OWN input schemas rather than the prompt-required inputSchema().
 function sessionGetInputSchema() {
@@ -91,8 +122,7 @@ function toolList() {
   /** @type {any[]} */
   const tools = [
     { name: "ask-all", description: "Fan out one question to GPT, Gemini, Grok, and any configured OpenRouter models in parallel for independent second opinions, then return all results (advisory, no cross-contamination). Pass `expert` to apply a persona to every delegate.", inputSchema: inputSchema(), annotations: ADVISORY },
-    { name: "consensus", description: "Fan out one question to all enabled providers, then run a single arbiter pass that cross-reviews the independent opinions and returns one synthesized verdict (advisory). Pass `expert` to apply a persona to the fan-out and arbiter.", inputSchema: inputSchema(), annotations: ADVISORY },
-    { name: "consensus-auto", description: "Run the FULL multi-round consensus convergence loop server-side with a provider arbiter (blind pass + peer fan-out -> adjudicate -> revise, up to consensus.maxRounds rounds; default 5) and return the converged verdict. For non-Claude hosts that want the loop in one call. Advisory; pass `expert` to apply a persona. Configure the arbiter via consensus.arbiter.", inputSchema: inputSchema(), annotations: ADVISORY },
+    { name: "consensus", description: "Run the FULL multi-round consensus convergence loop server-side with a provider arbiter (blind pass + peer fan-out -> adjudicate -> revise) and return the converged verdict. Default depth is `consensus.maxRounds` (config, default 5); pass `maxRounds` to override. Pass `synthesizeAlways:true` for a SINGLE arbiter synthesis pass instead of the loop (best for open questions, not plan convergence): it returns a free-text `synthesis` and `maxRounds` is ignored. Configure the arbiter via `consensus.arbiter` - a concrete provider/openrouter alias runs server-side; `host` mode returns the opinions for YOU to synthesize. Advisory; pass `expert` to apply a persona. NOTE (Claude Code): use the `/consensus` slash command for the transcript-visible host-arbiter loop (it drives `consensus-step`); this tool is the provider-arbiter path for any host.", inputSchema: consensusInputSchema(), annotations: ADVISORY },
     { name: "consensus-step", description: "Client-driven consensus loop where YOU (the host model) are the arbiter, one step per call: action=init (start, returns sessionId + blind prompt) -> record_blind (your pre-commit verdict) -> dispatch_peers (server fans out to the providers) -> submit_adjudication (your verdict + per-issue accept/dismiss/defer) -> submit_revision (your revised plan), looping until converged or consensus.maxRounds rounds (default 5). State is held server-side by sessionId. Advisory.", inputSchema: consensusStepInputSchema(), annotations: ADVISORY },
   ];
   for (const t of Object.keys(ASK_PROVIDER)) {
@@ -347,10 +377,10 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
   /**
    * Persist a completed run when persistence is on. Best-effort: a write failure
    * never fails the tool call. Returns the new sessionId, or null when off.
-   * @param {("consensus"|"ask-all"|"consensus-auto")} tool
+   * @param {("consensus"|"ask-all")} tool
    * @param {DelegationRequest} req
    * @param {string|undefined} expert
-   * @param {any} parts  // { opinions, blindVerdict?, verdict?, arbiter?, warnings?, parentId?, converged?, confidence?, rounds? }
+   * @param {any} parts  // { opinions, blindVerdict?, verdict?, synthesis?, synthesizeAlways?, arbiter?, warnings?, parentId?, converged?, confidence?, rounds? }
    * @returns {(string|null)}
    */
   function persistRun(tool, req, expert, parts) {
@@ -374,10 +404,13 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       warnings: Array.isArray(parts.warnings) ? parts.warnings : [],
       annotations: [],
     };
-    // consensus-auto loop summary (omitted for one-shot tools; JSON drops undefined).
+    // consensus loop summary (omitted for ask-all / synthesize runs; JSON drops undefined).
     if (typeof parts.converged === "boolean") record.converged = parts.converged;
     if (typeof parts.confidence === "string") record.confidence = parts.confidence;
     if (typeof parts.rounds === "number") record.rounds = parts.rounds;
+    // synthesize-mode fields: free-text synthesis + the mode flag (so revisit replays the mode).
+    if (typeof parts.synthesis === "string") record.synthesis = parts.synthesis;
+    if (typeof parts.synthesizeAlways === "boolean") record.synthesizeAlways = parts.synthesizeAlways;
     try {
       sessions.writeSession(record, { dir: sessionsDir, maxRecords: cfg.maxRecords, maxAgeDays: cfg.maxAgeDays });
       return id;
@@ -461,9 +494,10 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
    * this one). Shares runConsensus's panel selection + floor-of-2 exclusion.
    * @param {DelegationRequest} req
    * @param {string|undefined} expert
+   * @param {number} [maxRoundsOverride]  per-call cap; falls back to consensus.maxRounds, then the engine default
    * @returns {Promise<{payload:any, parts:(any|null)}>}  payload is the tool result; parts is non-null only on a real run (drives persistence); never throws
    */
-  async function runConsensusAuto(req, expert) {
+  async function runConsensusAuto(req, expert, maxRoundsOverride) {
     try {
       const cfg = getConfig() || {};
       const { providers: selected } = registry.selectForConsensus({ config: cfg, expert: expert || "" });
@@ -482,7 +516,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
         // host mode is the client-driven /consensus path; do NOT silently pick a peer.
         const host = resolved.mode === "host";
         warnings.push(host
-          ? "consensus-auto runs the loop server-side and needs a concrete arbiter; set consensus.arbiter to a provider or openrouter:<alias> (host mode drives the client-side /consensus instead)"
+          ? "consensus runs the loop server-side and needs a concrete arbiter; set consensus.arbiter to a provider or openrouter:<alias> (host mode drives the client-side /consensus instead)"
           : "no usable arbiter provider available");
         return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: resolved.mode, provider: null }, warnings, error: host ? "arbiter-is-host" : "no-arbiter" }, parts: null };
       }
@@ -491,10 +525,13 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       // A single distinct peer is a valid minimal panel (peer != arbiter).
       const peers = selected.filter((p) => p.name !== arbiterP.name);
       if (peers.length < 1) {
-        return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: "server", provider: arbiterP.name }, warnings: warnings.concat(["consensus-auto needs at least one peer distinct from the arbiter"]), error: "insufficient-peers" }, parts: null };
+        return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: { mode: "server", provider: arbiterP.name }, warnings: warnings.concat(["consensus needs at least one peer distinct from the arbiter"]), error: "insufficient-peers" }, parts: null };
       }
 
-      const maxRounds = Number.isInteger(cc.maxRounds) && cc.maxRounds > 0 ? cc.maxRounds : undefined;
+      // Per-call maxRounds wins; else the config default; else the engine default.
+      const maxRounds = Number.isInteger(maxRoundsOverride) && /** @type {number} */ (maxRoundsOverride) > 0
+        ? maxRoundsOverride
+        : (Number.isInteger(cc.maxRounds) && cc.maxRounds > 0 ? cc.maxRounds : undefined);
       const out = await runToConvergence(peers, withPersona(req, expert), { arbiter: arbiterP, maxRounds });
       const allWarnings = out.error ? warnings.concat([`loop: ${out.error}`]) : warnings;
       const rounds = Array.isArray(out.rounds) ? out.rounds.length : 0;
@@ -526,6 +563,70 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
     } catch (e) {
       // Never reject the tool call - degrade to a structured error.
       return { payload: { converged: false, verdict: null, confidence: "none", rounds: 0, opinions: [], arbiter: null, warnings: [], error: `internal: ${String((e && /** @type {any} */ (e).message) || e)}` }, parts: null };
+    }
+  }
+
+  /**
+   * The unified `consensus` tool: ONE shape for both modes, shared by the tool
+   * dispatch and session-revisit (so the engine stays the single source of truth).
+   * - default (loop): runs the full convergence loop via runConsensusAuto.
+   * - synthesizeAlways: ONE arbiter synthesis pass via runConsensus; the one-shot's
+   *   free-text verdict becomes `synthesis` and the enum `verdict` is null.
+   * Return envelope keys are identical across modes; the inapplicable fields are
+   * null (explicit, caller-selected - not hidden polymorphism). `parts` is null on
+   * a loop error path (no persistence); synthesize runs always persist.
+   * @param {DelegationRequest} req
+   * @param {string|undefined} expert
+   * @param {{synthesizeAlways?:boolean, maxRounds?:number}} [opts]
+   * @returns {Promise<{payload:any, parts:(any|null)}>}
+   */
+  async function runConsensusTool(req, expert, opts = {}) {
+    try {
+      if (opts.synthesizeAlways === true) {
+        const { payload: p } = await runConsensus(req, expert);
+        // One-shot `verdict` is the arbiter's result OBJECT (free-text synthesis), or
+        // null in host mode where the host synthesizes. Extract its text into
+        // `synthesis`; the enum `verdict` field stays null in synthesize mode.
+        const synthesis = textOf(p.verdict);
+        const blindVerdict = textOf(p.blindVerdict); // carries the optional blindVote pre-vote
+        const warnings = Array.isArray(p.warnings) ? p.warnings.slice() : [];
+        // A failed arbiter result (isError, not a throw) yields synthesis:null with no
+        // top-level error - surface it as a warning so it does not read as empty success.
+        if (synthesis == null && p.verdict && p.verdict.isError) {
+          warnings.push(`arbiter synthesis failed${p.verdict.errorKind ? `: ${p.verdict.errorKind}` : ""}`);
+        }
+        const envelope = {
+          opinions: p.opinions, verdict: null, synthesis, blindVerdict,
+          arbiter: p.arbiter, warnings,
+          converged: null, confidence: null, rounds: 1,
+          synthesizeAlways: true, error: p.error == null ? null : p.error,
+        };
+        const parts = {
+          opinions: p.opinions, verdict: null, synthesis, blindVerdict,
+          arbiter: p.arbiter, warnings, synthesizeAlways: true,
+        };
+        return { payload: envelope, parts };
+      }
+      const { payload: p, parts } = await runConsensusAuto(req, expert, opts.maxRounds);
+      const envelope = {
+        opinions: p.opinions, verdict: p.verdict, synthesis: null, blindVerdict: null,
+        arbiter: p.arbiter, warnings: p.warnings,
+        converged: p.converged, confidence: p.confidence, rounds: p.rounds,
+        synthesizeAlways: false, error: p.error == null ? null : p.error,
+      };
+      if (!parts) return { payload: envelope, parts: null }; // error path - do not persist
+      return { payload: envelope, parts: { ...parts, synthesis: null, synthesizeAlways: false } };
+    } catch (e) {
+      // Never reject the tool call - degrade to a structured error (matches runConsensusAuto).
+      const synth = opts.synthesizeAlways === true;
+      return {
+        payload: {
+          opinions: [], verdict: null, synthesis: null, blindVerdict: null, arbiter: null, warnings: [],
+          converged: null, confidence: null, rounds: synth ? 1 : 0, synthesizeAlways: synth,
+          error: `internal: ${String((e && /** @type {any} */ (e).message) || e)}`,
+        },
+        parts: null,
+      };
     }
   }
 
@@ -673,23 +774,19 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
       return jsonResult(payload);
     }
     if (name === "consensus") {
-      // selectForConsensus returns a FLAT, uncapped voting panel. The arbiter is
-      // resolved from config (host/auto/builtin/openrouter:<alias>) instead of the
-      // implicit providers[0], so any host can synthesize a real verdict. The whole
-      // pass lives in runConsensus so session-revisit can re-run it identically.
-      const { payload, parts } = await runConsensus(req, expert);
-      const sid = persistRun("consensus", req, expert, parts);
-      if (sid) payload.sessionId = sid;
-      return jsonResult(payload);
-    }
-    if (name === "consensus-auto") {
-      // Server-internal full convergence loop (provider arbiter). Persisted as a v2
-      // record (tool:"consensus-auto" + converged/confidence/rounds + per-opinion
-      // verdict/criticalIssues) so session-revisit re-runs the LOOP, not a one-shot.
-      // parts is null on an error path (no-arbiter/insufficient-peers) - skip the write.
-      const { payload, parts } = await runConsensusAuto(req, expert);
+      // The unified consensus tool: the full convergence loop (provider arbiter) by
+      // default, or a single arbiter synthesis pass with synthesizeAlways:true. One
+      // engine, one return shape (split verdict/synthesis). Persisted as tool:"consensus"
+      // with the mode flag so session-revisit replays the same mode. parts is null on a
+      // loop error path (no-arbiter/insufficient-peers) - skip the write.
+      const { payload, parts } = await runConsensusTool(req, expert, {
+        synthesizeAlways: args.synthesizeAlways === true,
+        // Clamp the per-call override to the same hard cap the config path uses (50),
+        // so a caller cannot drive an unbounded paid loop.
+        maxRounds: Number.isInteger(args.maxRounds) && args.maxRounds > 0 ? Math.min(args.maxRounds, 50) : undefined,
+      });
       if (parts) {
-        const sid = persistRun("consensus-auto", req, expert, parts);
+        const sid = persistRun("consensus", req, expert, parts);
         if (sid) payload.sessionId = sid;
       }
       return jsonResult(payload);
@@ -737,15 +834,15 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir }) {
         files: childFiles,
         cwd: typeof args.cwd === "string" ? args.cwd : undefined,
       };
-      // Route by the ORIGINAL tool so a consensus-auto record re-runs the full loop
-      // (not a one-shot consensus). consensus-auto can return parts:null on an error
-      // path; the others always carry parts.
-      const tool = rec.tool === "ask-all" ? "ask-all" : rec.tool === "consensus-auto" ? "consensus-auto" : "consensus";
+      // Route by the ORIGINAL tool. A "consensus" record re-runs the consensus tool,
+      // REPLAYING its mode (the loop, or a synthesize pass) from the stored flag - a
+      // missing flag means loop. The consensus path can return parts:null on a loop
+      // error; ask-all always carries parts. (Records written before this PR are
+      // unsupported - pre-1.0, no users; wipe the local session store if any exist.)
+      const tool = rec.tool === "ask-all" ? "ask-all" : "consensus";
       const { payload, parts } = tool === "ask-all"
         ? await runAskAll(childReq, childExpert)
-        : tool === "consensus-auto"
-          ? await runConsensusAuto(childReq, childExpert)
-          : await runConsensus(childReq, childExpert);
+        : await runConsensusTool(childReq, childExpert, { synthesizeAlways: rec.synthesizeAlways === true });
       if (parts) {
         const sid = persistRun(tool, childReq, childExpert, { ...parts, parentId: rec.id });
         if (sid) payload.sessionId = sid;

--- a/test/core-mcp-persona.test.js
+++ b/test/core-mcp-persona.test.js
@@ -50,7 +50,7 @@ test("PJ3: consensus with expert injects the expert persona on PEERS and the arb
   const sink = { di: /** @type {(string|undefined)[]} */ ([]) };
   const srv = buildServer({ providers: [capturingProvider("codex", sink), capturingProvider("grok", sink)], getConfig: () => config });
   await srv.handle({ jsonrpc: "2.0", id: 3, method: "tools/call",
-    params: { name: "consensus", arguments: { prompt: "x", expert: "debugger" } } });
+    params: { name: "consensus", arguments: { prompt: "x", expert: "debugger", synthesizeAlways: true } } });
   // 2 peer opinions carry the debugger persona; the trailing arbiter pass carries the arbiter persona.
   assert.equal(sink.di.length, 3);
   assert.equal(sink.di[0], PROMPTS["debugger"]);
@@ -171,7 +171,10 @@ function cfg(arbiter, models = []) {
 
 /** @param {any} srv @param {any} args */
 async function callConsensus(srv, args) {
-  const res = await srv.handle({ jsonrpc: "2.0", id: 99, method: "tools/call", params: { name: "consensus", arguments: { prompt: "Q", ...args } } });
+  // These exercise the shared arbiter-resolution + one-pass synthesis path, which
+  // post-merge lives behind synthesizeAlways:true on the unified `consensus` tool.
+  // (The convergence-loop path is covered in mcp-consensus.test.js.)
+  const res = await srv.handle({ jsonrpc: "2.0", id: 99, method: "tools/call", params: { name: "consensus", arguments: { prompt: "Q", synthesizeAlways: true, ...args } } });
   return JSON.parse(res.result.content[0].text);
 }
 
@@ -196,7 +199,7 @@ test("AR2: arbiter 'auto' picks the first healthy provider and surfaces an auto-
   const out = await callConsensus(srv, { expert: "architect" });
   assert.equal(out.arbiter.mode, "server");
   assert.equal(out.arbiter.provider, "codex"); // first healthy
-  assert.ok(out.verdict);
+  assert.ok(out.synthesis);
   assert.ok(out.warnings.some((/** @type {string} */ w) => /auto-selected/i.test(w)));
 });
 
@@ -272,7 +275,7 @@ test("AR8: floor-of-2 - with only 2 providers the arbiter stays in peers (panel 
   // peers would be [grok] (1) -> floor keeps codex in -> 2 opinions
   assert.equal(out.opinions.length, 2);
   assert.ok(out.warnings.some((/** @type {string} */ w) => /floor|kept|panel/i.test(w)));
-  assert.ok(out.verdict);
+  assert.ok(out.synthesis);
 });
 
 test("AR9: consensusWarnings from config are surfaced in the consensus response", async () => {
@@ -331,7 +334,7 @@ test("AR11: arbiter set to a DISABLED built-in degrades to auto + warning (no ha
   assert.equal(out.arbiter.mode, "server");
   assert.notEqual(out.arbiter.provider, "grok", "disabled arbiter must not be selected");
   assert.ok(out.warnings.length >= 1);
-  assert.ok(out.verdict, "degraded arbiter still produces a verdict");
+  assert.ok(out.synthesis, "degraded arbiter still produces a synthesis");
   // grok (disabled) is never asked as the arbiter
   assert.equal(sink.calls.some((cl) => cl.provider === "grok"), false);
 });

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -379,16 +379,16 @@ test("S20b: non-path file refs (dir/file_id/file_url/mode) survive a round-trip"
   assert.deepEqual(back.files, files); // preserved so session-revisit keeps context
 });
 
-// --- v2 record: consensus-auto fields (verdict / criticalIssues / loop summary) ---
+// --- consensus-loop record fields (verdict / criticalIssues / loop summary) ---
 
-test("S21: the writer's SCHEMA_VERSION is 2 (consensus-auto round summary support)", () => {
-  assert.equal(SCHEMA_VERSION, 2);
+test("S21: the writer's SCHEMA_VERSION is 1 (single stamp, no dual-version support)", () => {
+  assert.equal(SCHEMA_VERSION, 1);
 });
 
-test("S22: a consensus-auto opinion persists its verdict + criticalIssues losslessly", () => {
+test("S22: a consensus opinion persists its verdict + criticalIssues losslessly", () => {
   const dir = tmpDir();
   const id = writeSession(rec({
-    tool: "consensus-auto",
+    tool: "consensus",
     opinions: [{
       provider: "codex",
       verdict: "REQUEST_CHANGES",
@@ -398,7 +398,7 @@ test("S22: a consensus-auto opinion persists its verdict + criticalIssues lossle
   const back = readSession(id, { dir });
   assert.ok(back);
   if (!back) return;
-  assert.equal(back.tool, "consensus-auto");
+  assert.equal(back.tool, "consensus");
   assert.equal(back.opinions[0].provider, "codex");
   assert.equal(back.opinions[0].verdict, "REQUEST_CHANGES");
   assert.deepEqual(back.opinions[0].criticalIssues, [{ category: "security", description: "missing auth check" }]);
@@ -409,7 +409,7 @@ test("S22b: a critical-issue description is secret-scrubbed + capped on write", 
   const secret = "sk-" + "q".repeat(30);
   const huge = "y".repeat(MAX_TEXT_BYTES + 4000);
   const id = writeSession(rec({
-    tool: "consensus-auto",
+    tool: "consensus",
     opinions: [{ provider: "grok", verdict: "REJECT", criticalIssues: [
       { category: "ops", description: `leaked ${secret}` },
       { category: "correctness", description: huge },
@@ -428,7 +428,7 @@ test("S22c: a non-enum verdict is coerced to null on write (writer is the trust 
   const dir = tmpDir();
   const secret = "sk-" + "v".repeat(30);
   const id = writeSession(rec({
-    tool: "consensus-auto",
+    tool: "consensus",
     // A hand-built record that ignores parseReview's enum contract: the writer
     // must NOT persist arbitrary free text (incl. a secret) in the verdict field.
     opinions: [{ provider: "codex", verdict: /** @type {any} */ (`bogus ${secret}`) }],
@@ -451,10 +451,10 @@ test("S22d: question is capped at ~100 KB on write", () => {
   assert.ok(back.question.includes("[truncated"));
 });
 
-test("S23: converged / confidence / rounds round-trip on a consensus-auto record", () => {
+test("S23: converged / confidence / rounds round-trip on a consensus record", () => {
   const dir = tmpDir();
   const id = writeSession(rec({
-    tool: "consensus-auto",
+    tool: "consensus",
     converged: true,
     confidence: "high",
     rounds: 3,

--- a/test/mcp-consensus-step.test.js
+++ b/test/mcp-consensus-step.test.js
@@ -153,3 +153,16 @@ test("CS9: config consensus.maxRounds caps the step loop -> unresolved (engine o
   assert.ok(typeof rev2.finalReport === "string" && rev2.finalReport.includes("v3"));
   assert.equal(rev2.confidence, "none");
 });
+
+test("CS10: HOST is the arbiter - a host REQUEST_CHANGES blocks convergence even when every peer APPROVES", async () => {
+  // Regression for the consensus tool merge: consensus-step stays host-arbitrated.
+  // Peers all APPROVE, but the host's adjudication verdict gates the round.
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => config });
+  const sid = (await step(srv, { action: "init", prompt: "ship it" }, 50)).sessionId;
+  await step(srv, { action: "record_blind", sessionId: sid, blindVerdict: "looks risky" }, 51);
+  const dp = await step(srv, { action: "dispatch_peers", sessionId: sid }, 52);
+  assert.ok(dp.opinions.every((o) => o.verdict === "APPROVE")); // peers approve
+  const adj = await step(srv, { action: "submit_adjudication", sessionId: sid, verdict: "REQUEST_CHANGES", decisions: [] }, 53);
+  assert.equal(adj.converged, undefined); // not converged - the host vote, not the peers, decides
+  assert.equal(adj.status, "await_revision");
+});

--- a/test/mcp-consensus.test.js
+++ b/test/mcp-consensus.test.js
@@ -1,4 +1,4 @@
-// test/mcp-consensus-auto.test.js
+// test/mcp-consensus.test.js
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
@@ -38,17 +38,17 @@ const cfg = (over) => ({ providers: {}, openrouter: { maxFanout: 3, models: [] }
 /** cfg with persistence ON (sessions.persist). */
 const cfgPersist = (over) => ({ ...cfg(over), sessions: { persist: true } });
 
-test("CA1: tools/list advertises consensus-auto (advisory)", async () => {
+test("CA1: tools/list advertises consensus (advisory)", async () => {
   const srv = buildServer({ providers: [approve("codex")], getConfig: () => cfg() });
   const res = await srv.handle({ jsonrpc: "2.0", id: 1, method: "tools/list" });
-  const t = res.result.tools.find((x) => x.name === "consensus-auto");
+  const t = res.result.tools.find((x) => x.name === "consensus");
   assert.ok(t);
   assert.equal(t.annotations.readOnlyHint, true);
 });
 
 test("CA2: all-APPROVE panel converges with a verdict", async () => {
   const srv = buildServer({ providers: [approve("codex"), approve("gemini"), approve("grok")], getConfig: () => cfg() });
-  const res = await srv.handle({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "ship it", expert: "architect" } } });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "consensus", arguments: { prompt: "ship it", expert: "architect" } } });
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.converged, true);
   assert.equal(payload.verdict, "APPROVE");
@@ -57,7 +57,7 @@ test("CA2: all-APPROVE panel converges with a verdict", async () => {
 
 test("CA3: persistent dissent ends unresolved at the configured maxRounds", async () => {
   const srv = buildServer({ providers: [reject("codex"), reject("gemini"), reject("grok")], getConfig: () => cfg({ maxRounds: 2 }) });
-  const res = await srv.handle({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "ship it" } } });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "consensus", arguments: { prompt: "ship it" } } });
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.converged, false);
   assert.equal(payload.rounds, 2);
@@ -65,7 +65,7 @@ test("CA3: persistent dissent ends unresolved at the configured maxRounds", asyn
 
 test("CA4: never throws on an empty panel - returns a structured error", async () => {
   const srv = buildServer({ providers: [], getConfig: () => cfg() });
-  const res = await srv.handle({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "x" } } });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "consensus", arguments: { prompt: "x" } } });
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.converged, false);
   assert.ok(typeof payload.error === "string");
@@ -73,7 +73,7 @@ test("CA4: never throws on an empty panel - returns a structured error", async (
 
 test("CA5: host-mode arbiter -> explicit arbiter-is-host error (no silent peer hijack)", async () => {
   const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg({ arbiter: "host" }) });
-  const res = await srv.handle({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "x" } } });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "consensus", arguments: { prompt: "x" } } });
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.converged, false);
   assert.equal(payload.error, "arbiter-is-host");
@@ -82,22 +82,22 @@ test("CA5: host-mode arbiter -> explicit arbiter-is-host error (no silent peer h
 
 test("CA6: a 2-provider panel (arbiter + 1 distinct peer) converges without self-arbitration", async () => {
   const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg() });
-  const res = await srv.handle({ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "consensus-auto", arguments: { prompt: "x" } } });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "consensus", arguments: { prompt: "x" } } });
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.converged, true);
   assert.equal(payload.opinions.length, 1); // exactly one peer reviewed (arbiter excluded)
 });
 
-test("CA7: with persistence ON, a converged run is saved as a tool:consensus-auto v2 record", async () => {
+test("CA7: with persistence ON, a converged run is saved as a tool:consensus record", async () => {
   const dir = tmpDir();
   const srv = buildServer({ providers: [approve("codex"), approve("gemini"), approve("grok")], getConfig: () => cfgPersist(), sessionsDir: dir });
-  const payload = await callTool(srv, "consensus-auto", { prompt: "ship it" }, 7);
+  const payload = await callTool(srv, "consensus", { prompt: "ship it" }, 7);
   assert.equal(payload.converged, true);
   assert.ok(payload.sessionId, "a sessionId is returned when persistence is on");
 
   const got = await callTool(srv, "session-get", { sessionId: payload.sessionId }, 8);
-  assert.equal(got.session.tool, "consensus-auto");
-  assert.equal(got.session.schemaVersion, 2);
+  assert.equal(got.session.tool, "consensus");
+  assert.equal(got.session.schemaVersion, 1);
   assert.equal(got.session.converged, true);
   assert.equal(typeof got.session.confidence, "string");
   assert.equal(typeof got.session.rounds, "number");
@@ -106,10 +106,10 @@ test("CA7: with persistence ON, a converged run is saved as a tool:consensus-aut
   assert.equal(got.session.opinions[0].verdict, "APPROVE");
 });
 
-test("CA8: session-revisit on a consensus-auto record re-runs the LOOP + links a child", async () => {
+test("CA8: session-revisit on a consensus record re-runs the LOOP + links a child", async () => {
   const dir = tmpDir();
   const srv = buildServer({ providers: [approve("codex"), approve("gemini"), approve("grok")], getConfig: () => cfgPersist(), sessionsDir: dir });
-  const first = await callTool(srv, "consensus-auto", { prompt: "ship it" }, 9);
+  const first = await callTool(srv, "consensus", { prompt: "ship it" }, 9);
 
   const revisit = await callTool(srv, "session-revisit", { sessionId: first.sessionId }, 10);
   // The re-run is the LOOP (converged + rounds), not a one-shot consensus.
@@ -119,15 +119,73 @@ test("CA8: session-revisit on a consensus-auto record re-runs the LOOP + links a
   assert.ok(revisit.sessionId && revisit.sessionId !== first.sessionId);
 
   const child = await callTool(srv, "session-get", { sessionId: revisit.sessionId }, 11);
-  assert.equal(child.session.tool, "consensus-auto");
+  assert.equal(child.session.tool, "consensus");
   assert.equal(child.session.parentId, first.sessionId);
 });
 
 test("CA9: an error-path run (host arbiter) does NOT persist - no sessionId", async () => {
   const dir = tmpDir();
   const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfgPersist({ arbiter: "host" }), sessionsDir: dir });
-  const payload = await callTool(srv, "consensus-auto", { prompt: "x" }, 12);
+  const payload = await callTool(srv, "consensus", { prompt: "x" }, 12);
   assert.equal(payload.error, "arbiter-is-host");
   assert.equal(payload.sessionId, undefined);
   assert.deepEqual(fs.readdirSync(dir), []); // nothing written
+});
+
+test("CA10: synthesizeAlways:true runs ONE synthesis pass (split envelope: synthesis set, verdict null)", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg() });
+  const payload = await callTool(srv, "consensus", { prompt: "Redis vs in-memory?", synthesizeAlways: true }, 13);
+  assert.equal(payload.synthesizeAlways, true);
+  assert.ok(payload.synthesis); // arbiter synthesis text
+  assert.equal(payload.verdict, null); // enum verdict null in synthesize mode
+  assert.equal(payload.converged, null);
+  assert.equal(payload.confidence, null);
+  assert.equal(payload.rounds, 1);
+});
+
+test("CA11: synthesizeAlways:true with a host arbiter returns opinions for the host to synthesize (no error)", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg({ arbiter: "host" }) });
+  const payload = await callTool(srv, "consensus", { prompt: "x", synthesizeAlways: true }, 14);
+  assert.equal(payload.arbiter.mode, "host");
+  assert.equal(payload.synthesis, null); // the host synthesizes; server runs no arbiter pass
+  assert.equal(payload.verdict, null);
+  assert.equal(payload.error, null);
+  assert.ok(payload.opinions.length >= 1);
+});
+
+test("CA12: a synthesizeAlways run persists tool:consensus + the flag; revisit replays synthesize mode", async () => {
+  const dir = tmpDir();
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfgPersist(), sessionsDir: dir });
+  const made = await callTool(srv, "consensus", { prompt: "q", synthesizeAlways: true }, 15);
+  assert.ok(made.sessionId);
+  const got = await callTool(srv, "session-get", { sessionId: made.sessionId }, 16);
+  assert.equal(got.session.tool, "consensus");
+  assert.equal(got.session.synthesizeAlways, true);
+
+  const revisit = await callTool(srv, "session-revisit", { sessionId: made.sessionId }, 17);
+  assert.equal(revisit.synthesizeAlways, true); // replayed the same mode, not the loop
+  assert.equal(revisit.rounds, 1);
+});
+
+test("CA13: a per-call maxRounds OVERRIDES consensus.maxRounds from config", async () => {
+  // config says 5; the call passes 1, so persistent dissent must stop after round 1.
+  const srv = buildServer({ providers: [reject("codex"), reject("grok")], getConfig: () => cfg({ maxRounds: 5 }) });
+  const payload = await callTool(srv, "consensus", { prompt: "ship it", maxRounds: 1 }, 18);
+  assert.equal(payload.converged, false);
+  assert.equal(payload.rounds, 1);
+});
+
+test("CA14: synthesizeAlways carries the blindVote pre-vote into blindVerdict", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => cfg({ blindVote: true }) });
+  const payload = await callTool(srv, "consensus", { prompt: "x", synthesizeAlways: true }, 19);
+  assert.equal(payload.synthesizeAlways, true);
+  assert.ok(payload.blindVerdict, "blindVote pre-vote surfaces as blindVerdict in synthesize mode");
+});
+
+test("CA15: a per-call maxRounds above the cap is clamped to 50", async () => {
+  // 999 would run 999 rounds if unclamped; clamped to 50, persistent dissent stops at 50.
+  const srv = buildServer({ providers: [reject("codex"), reject("grok")], getConfig: () => cfg({ maxRounds: 5 }) });
+  const payload = await callTool(srv, "consensus", { prompt: "ship it", maxRounds: 999 }, 20);
+  assert.equal(payload.converged, false);
+  assert.equal(payload.rounds, 50);
 });

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -41,13 +41,15 @@ test("M3: ask-gpt routes to codex only", async () => {
   assert.equal(payload.result.provider, "codex");
 });
 
-test("M4: consensus runs fan-out + one arbiter pass and returns opinions + verdict", async () => {
+test("M4: consensus synthesizeAlways runs fan-out + one arbiter pass and returns opinions + synthesis", async () => {
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => config });
   const res = await srv.handle({ jsonrpc: "2.0", id: 4, method: "tools/call",
-    params: { name: "consensus", arguments: { prompt: "x", expert: "architect" } } });
+    params: { name: "consensus", arguments: { prompt: "x", expert: "architect", synthesizeAlways: true } } });
   const payload = JSON.parse(res.result.content[0].text);
   assert.equal(payload.opinions.length, 2);
-  assert.ok(payload.verdict); // arbiter (first provider) produced a verdict
+  assert.equal(payload.synthesizeAlways, true);
+  assert.ok(payload.synthesis); // arbiter produced a free-text synthesis
+  assert.equal(payload.verdict, null); // enum verdict is null in synthesize mode
 });
 
 // arbiterDefaulted=true simulates a user who did NOT set consensus.arbiter, so the
@@ -60,7 +62,7 @@ async function consensusArbiterMode(clientName, claudecode) {
   try {
     const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => defaultedConfig });
     if (clientName) await srv.handle({ jsonrpc: "2.0", id: 1, method: "initialize", params: { clientInfo: { name: clientName } } });
-    const res = await srv.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: "consensus", arguments: { prompt: "x", expert: "architect" } } });
+    const res = await srv.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: "consensus", arguments: { prompt: "x", expert: "architect", synthesizeAlways: true } } });
     return JSON.parse(res.result.content[0].text);
   } finally {
     if (prev === undefined) delete process.env.CLAUDECODE; else process.env.CLAUDECODE = prev;
@@ -73,10 +75,10 @@ test("M6: arbiterDefaulted + a Claude clientInfo.name defaults the arbiter to ho
   assert.equal(payload.verdict, null);
 });
 
-test("M7: arbiterDefaulted + a non-Claude client defaults the arbiter to auto (server verdict)", async () => {
+test("M7: arbiterDefaulted + a non-Claude client defaults the arbiter to auto (server synthesis)", async () => {
   const payload = await consensusArbiterMode("cursor", false);
   assert.equal(payload.arbiter.mode, "server");
-  assert.ok(payload.verdict);
+  assert.ok(payload.synthesis);
 });
 
 test("M8: CLAUDECODE=1 forces host default even when the client name is non-Claude", async () => {
@@ -126,7 +128,7 @@ test("S-MCP2: consensus with persist on writes a record and returns sessionId", 
   const dir = tmpSessionsDir();
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
-  const payload = await callTool(srv, 2, "consensus", { prompt: "q", expert: "architect" });
+  const payload = await callTool(srv, 2, "consensus", { synthesizeAlways: true, prompt: "q", expert: "architect" });
   assert.ok(payload.sessionId, "expected a sessionId");
   assert.ok(fs.existsSync(path.join(dir, `${payload.sessionId}.json`)));
 });
@@ -144,7 +146,7 @@ test("S-MCP4: persist off writes nothing and returns no sessionId", async (t) =>
   const dir = tmpSessionsDir();
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(false), sessionsDir: dir });
-  const payload = await callTool(srv, 4, "consensus", { prompt: "q" });
+  const payload = await callTool(srv, 4, "consensus", { synthesizeAlways: true, prompt: "q" });
   assert.equal(payload.sessionId, undefined);
   assert.deepEqual(fs.readdirSync(dir), []);
 });
@@ -153,7 +155,7 @@ test("S-MCP5: session-get round-trips a persisted record", async (t) => {
   const dir = tmpSessionsDir();
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
-  const made = await callTool(srv, 5, "consensus", { prompt: "the question", expert: "architect" });
+  const made = await callTool(srv, 5, "consensus", { synthesizeAlways: true, prompt: "the question", expert: "architect" });
   const got = await callTool(srv, 6, "session-get", { sessionId: made.sessionId });
   assert.equal(got.session.id, made.sessionId);
   assert.equal(got.session.question, "the question");
@@ -164,7 +166,7 @@ test("S-MCP6: session-revisit writes a CHILD record linked by parentId", async (
   const dir = tmpSessionsDir();
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
-  const parent = await callTool(srv, 7, "consensus", { prompt: "original q" });
+  const parent = await callTool(srv, 7, "consensus", { synthesizeAlways: true, prompt: "original q" });
   const child = await callTool(srv, 8, "session-revisit", { sessionId: parent.sessionId });
   assert.equal(child.parentId, parent.sessionId);
   assert.ok(child.sessionId);
@@ -178,7 +180,7 @@ test("S-MCP7: session-annotate appends to the audit trail", async (t) => {
   const dir = tmpSessionsDir();
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const srv = buildServer({ providers: [fakeProvider("codex"), fakeProvider("grok")], getConfig: () => sessionsConfig(true), sessionsDir: dir });
-  const made = await callTool(srv, 10, "consensus", { prompt: "q" });
+  const made = await callTool(srv, 10, "consensus", { synthesizeAlways: true, prompt: "q" });
   const ann = await callTool(srv, 11, "session-annotate", { sessionId: made.sessionId, note: "reviewed" });
   assert.equal(ann.session.annotations.length, 1);
   assert.equal(ann.session.annotations[0].note, "reviewed");


### PR DESCRIPTION
feat!: unify consensus tools into one + drop schema versioning

Pre-1.0, no users, so this takes the breaking simplification freely. Two changes
the owner asked for and the panel converged on (/consensus, 2 rounds).

1) ONE `consensus` tool (was three: one-shot `consensus`, full-loop `consensus-auto`,
   client-driven `consensus-step`). The one-shot and `consensus-auto` are merged:
   - `consensus` runs the FULL convergence loop server-side by default (provider arbiter).
   - `synthesizeAlways:true` runs a SINGLE arbiter synthesis pass (the old one-shot), for
     open questions - returns a free-text `synthesis`.
   - `maxRounds` overrides `consensus.maxRounds` per call (clamped to 50).
   - Unified return envelope, same keys both modes, loop-only fields nullable:
     { opinions, verdict|null, synthesis|null, blindVerdict|null, arbiter, warnings,
       converged|null, confidence|null, rounds, synthesizeAlways, error|null }.
   `consensus-step` is unchanged (the transcript-visible host-arbiter loop; `/consensus`
   still drives it). "Identical usage on every host" is unified at the user-facing layer
   (slash command on Claude, the `consensus` tool elsewhere), not the tool layer - the
   host-arbiter path is inherently multi-step and stays its own tool.

2) Session records drop dual-version support: a single `schemaVersion:1` stamp (nothing
   branches on it). Record gains `synthesis` + `synthesizeAlways`; `tool` enum is
   `"consensus"|"ask-all"`. session-revisit replays a consensus record's stored mode
   (loop or synthesize); records written before this change are unsupported (no users).

server/mcp/index.js: `runConsensusTool` (shared by the tool dispatch and session-revisit),
new `consensusInputSchema`, `runConsensusAuto` per-call maxRounds override, persistRun
persists synthesis/synthesizeAlways. core/sessions.js: SCHEMA_VERSION 2->1, +synthesis,
sanitize scrubs it. config/config.default.json: +consensus.maxRounds. Docs (CLAUDE/AGENTS/
README/TECHNICAL) + regenerated POWER.md/SKILL.md updated; config.default gains maxRounds.

Reviewed via /ask-all Code Reviewer (5 models + 1 errored). Folded: (1) synthesize now
carries the blindVote pre-vote into `blindVerdict`; (2) a failed arbiter synthesis surfaces
a warning instead of reading as empty success; (3) per-call maxRounds clamped to 50 (was
uncapped while config clamps); (4) consensusInputSchema regained developerInstructions +
reasoningEffort (parity with the shared schema); (5) runConsensusTool wrapped in try/catch
so it degrades to a structured error, never a raw -32603.

Tests: the consensus-auto suite renamed to mcp-consensus.test.js (tool "consensus");
the one-shot tests in mcp-server / core-mcp-persona re-pointed to synthesizeAlways:true
(its behavior); +synthesizeAlways, +maxRounds override + clamp, +blindVerdict, +a
consensus-step host-arbiter regression assert; schemaVersion asserts 2->1. Full suite
445/445 green, typecheck clean.

BREAKING CHANGE: the `consensus-auto` MCP tool is removed (folded into `consensus`, which
now runs the loop by default); the one-shot `consensus` behavior moves behind
`synthesizeAlways:true`. Session `schemaVersion` is 1 (no v2 reader); records written
before this change are not supported by session-revisit.
