### PR TITLE
feat: auto-publish on release, npm README, per-tenant key seam (extras A)

### DIFF
--- a/.github/release/pre-commit.js
+++ b/.github/release/pre-commit.js
@@ -36,6 +36,13 @@ const TARGETS = [
   // like the rest: the generator reads the same version.json, so the patched line
   // matches what a regenerate would produce and the drift test stays green.
   { rel: 'plugins/deliberation/.codex-plugin/plugin.json', re: /^( {2}"version":\s*)"[^"]*"/m },
+  // The PUBLISHED npm package + the MCP registry manifest. These are what `npx`
+  // and the Official MCP Registry resolve, so they must track version.json too.
+  { rel: 'server/mcp/package.json', re: /^( {2}"version":\s*)"[^"]*"/m },
+  // server.json carries TWO version lines (top-level + packages[0].version) at
+  // different indents; sync both. Same-file targets re-read the file each pass.
+  { rel: 'server.json', re: /^( {2}"version":\s*)"[^"]*"/m },
+  { rel: 'server.json', re: /^( {6}"version":\s*)"[^"]*"/m },
 ]
 
 function repoRoot() {

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # OIDC: npm trusted publishing (provenance) + MCP registry login
 
 concurrency:
   group: tag-release
@@ -91,6 +92,44 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+      # Publish the npm package via OIDC trusted publishing (no stored token).
+      # Gated on a freshly-created tag so a re-run never double-publishes a version.
+      # Requires a one-time "trusted publisher" config on npmjs.com for
+      # @antonbabenko/deliberation-mcp linked to this repo + workflow.
+      - name: Set up Node for publish
+        if: steps.tag.outputs.created == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm (OIDC trusted publishing + provenance)
+        if: steps.tag.outputs.created == 'true'
+        run: |
+          set -euo pipefail
+          npm ci
+          npm install -g npm@latest # OIDC trusted publishing needs npm >= 11.5
+          npm publish -w server/mcp --provenance --access public
+
+      # Submit the version-synced server.json to the Official MCP Registry via
+      # GitHub OIDC (namespace io.github.antonbabenko/* is owned by this repo's
+      # identity). Best-effort: a registry hiccup must not red an already-published
+      # npm release - it can be re-published manually with mcp-publisher.
+      - name: Publish to the MCP Registry
+        if: steps.tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -uo pipefail
+          gh release download --repo modelcontextprotocol/registry \
+            --pattern '*_linux_amd64.tar.gz' --output mcp-publisher.tar.gz || {
+              echo "::warning::could not download mcp-publisher; skipping registry publish"; exit 0; }
+          tar xzf mcp-publisher.tar.gz mcp-publisher || {
+              echo "::warning::could not extract mcp-publisher; skipping"; exit 0; }
+          chmod +x mcp-publisher
+          ./mcp-publisher login github-oidc && ./mcp-publisher publish \
+            || echo "::warning::MCP registry publish failed; re-run mcp-publisher manually"
 
       # On a real release, nudge the agent-plugins marketplace to re-pin this
       # plugin now instead of waiting for its daily cron. Needs a PAT with

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,6 +70,9 @@ jobs:
             ['.claude-plugin/marketplace.json', (readJSON('.claude-plugin/marketplace.json').plugins || [])[0]?.version],
             ['package.json', readJSON('package.json').version],
             ['plugins/deliberation/.codex-plugin/plugin.json', readJSON('plugins/deliberation/.codex-plugin/plugin.json').version],
+            ['server/mcp/package.json', readJSON('server/mcp/package.json').version],
+            ['server.json', readJSON('server.json').version],
+            ['server.json packages[0]', (readJSON('server.json').packages || [])[0]?.version],
           ]
 
           let bad = false

--- a/core/providers/grok.js
+++ b/core/providers/grok.js
@@ -28,7 +28,7 @@ function makeGrokProvider(opts = {}) {
     async ask(req) {
       const started = Date.now();
       const reasoningEffort = bridge.resolveReasoningEffort(req.reasoningEffort);
-      const apiKey = process.env.XAI_API_KEY;
+      const apiKey = (req && req.apiKey) || process.env.XAI_API_KEY;
       try {
         // runWithFiles builds its own turns from prompt + developer-instructions;
         // runGrok takes pre-built turns. Both return { text, output }.

--- a/core/providers/openai-compatible.js
+++ b/core/providers/openai-compatible.js
@@ -55,7 +55,7 @@ function makeOpenAICompatibleProvider(opts) {
         : bridge.buildInitialTurns(req.developerInstructions, req.prompt, blocks);
       try {
         const { text } = await bridge.callOpenRouter({
-          apiBase, apiKey: process.env[apiKeyEnv], model,
+          apiBase, apiKey: (req && req.apiKey) || process.env[apiKeyEnv], model,
           messages: bridge.buildMessages(turns),
           reasoningEffort: req.reasoningEffort, temperature: req.temperature, timeoutMs: req.timeoutMs,
         });

--- a/core/types.js
+++ b/core/types.js
@@ -22,6 +22,12 @@
  * @property {string}  [threadId]
  * @property {string}  [expert]
  * @property {string}  [model]
+ * @property {string}  [apiKey]  per-request provider key override; when set, a provider
+ *   prefers it over its `process.env` key. The seam a remote/multi-tenant adapter injects
+ *   per request (Phase 3). Unset in the stdio path - providers fall back to `process.env`.
+ *   Phase-3 note: when this is used for real multi-tenancy, the remote adapter must also
+ *   scope any per-thread session state (e.g. the openai-compatible `threadId` map) by tenant,
+ *   so a reused threadId cannot resume another tenant's context under a different key.
  */
 
 /**

--- a/server.json
+++ b/server.json
@@ -2,13 +2,13 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.antonbabenko/deliberation",
   "description": "Second opinions in Claude Code and any MCP host from GPT, Gemini, Grok, and 400+ OpenRouter models.",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@antonbabenko/deliberation-mcp",
-      "version": "0.1.0",
+      "version": "3.0.0",
       "transport": { "type": "stdio" }
     }
   ]

--- a/server/mcp/README.md
+++ b/server/mcp/README.md
@@ -1,0 +1,103 @@
+# deliberation-mcp
+
+Get a second opinion from GPT, Gemini, Grok, and 400+ OpenRouter models - and let them
+reach a cross-model **consensus** - from inside any MCP host (Claude Code, Cursor, Codex,
+Kiro, VS Code, Windsurf, Zed, ...).
+
+One model is a guess. Three that agree is a plan.
+
+This is the standalone MCP server. For the Claude Code plugin, one-click install buttons,
+and full docs, see the repo: **https://github.com/antonbabenko/deliberation**
+
+## What it does
+
+You stay the primary agent. When a task needs a second opinion or cross-model review, call
+one of the tools below, read the result, and apply your own judgment. Seven expert personas
+(architect, code reviewer, security analyst, and four more) shape the review. GPT and Gemini
+can also implement changes; Grok and OpenRouter only advise.
+
+## Install
+
+Add the server to your MCP host (most hosts use the `mcpServers` key):
+
+```json
+{
+  "mcpServers": {
+    "deliberation": {
+      "command": "npx",
+      "args": ["-y", "@antonbabenko/deliberation-mcp"],
+      "env": {
+        "XAI_API_KEY": "xai-...",
+        "OPENROUTER_API_KEY": "sk-or-v1-..."
+      }
+    }
+  }
+}
+```
+
+Per-host config location and key:
+
+| Host | Config | Key |
+|------|--------|-----|
+| Claude Code | `claude mcp add deliberation -- npx -y @antonbabenko/deliberation-mcp` | `mcpServers` |
+| Cursor | `~/.cursor/mcp.json` or project `.cursor/mcp.json` | `mcpServers` |
+| Codex CLI | `~/.codex/config.toml` (e.g. `[mcp_servers.deliberation]`) | `mcp_servers` |
+| Gemini CLI | `~/.gemini/settings.json` | `mcpServers` |
+| VS Code | `.vscode/mcp.json` (each entry needs `"type": "stdio"`) | `servers` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` |
+| Zed | `settings.json` | `context_servers` |
+
+## Provider setup
+
+Set only the providers you use:
+
+- **GPT** - install the Codex CLI and run `codex login` (keys are not read from `env` here).
+- **Gemini** - install the Antigravity CLI (`agy`) and run it once to sign in.
+- **Grok** - set `XAI_API_KEY` (https://console.x.ai).
+- **OpenRouter** - set `OPENROUTER_API_KEY` and declare models in
+  `~/.config/deliberation/config.json` (Windows: `%APPDATA%\deliberation\config.json`;
+  override with `DELIBERATION_CONFIG`). OpenRouter is advisory-only.
+
+A starter config writer ships as a bin:
+
+```
+npx -y --package @antonbabenko/deliberation-mcp deliberation-setup
+```
+
+It writes a starter `config.json` (never overwrites an existing one).
+
+## Tools
+
+- `ask-all` - one question to every configured provider in parallel; get each answer back
+  independently (no cross-talk).
+- `consensus` - run the full multi-round convergence loop with a provider arbiter (blind
+  pass + peer review -> adjudicate -> revise) and return the converged verdict. Pass
+  `synthesizeAlways: true` for a single synthesis pass instead of the loop (best for open
+  questions), or `maxRounds` to cap the loop.
+- `consensus-step` - drive the loop yourself as the arbiter, one action per call
+  (`init` -> `record_blind` -> `dispatch_peers` -> `submit_adjudication` -> `submit_revision`).
+- `ask-gpt` / `ask-gemini` / `ask-grok` / `ask-openrouter` - one question to one provider.
+- Experts: `architect`, `plan-reviewer`, `scope-analyst`, `code-reviewer`,
+  `security-analyst`, `researcher`, `debugger` - call directly, or pass `expert` on the
+  fan-out tools to apply one persona to every delegate.
+- Session tools (opt-in `sessions.persist`): `session-get`, `session-revisit`,
+  `session-annotate`.
+
+Every tool takes a `prompt` - give it full context (the goal, relevant code/paths, prior
+attempts), since the experts do not share your session.
+
+## How consensus stays honest
+
+The orchestrator commits a blind verdict before seeing the panel, cannot reach consensus on
+its own vote alone (at least one external must approve), and records a reason for every
+dismissed issue. The loop stops on agreement or at `consensus.maxRounds` (default 5).
+
+## More
+
+Configuration reference, the Claude Code plugin, per-host guides, and architecture docs are
+in the repo: **https://github.com/antonbabenko/deliberation**
+(see `AGENTS.md` for the tool guide and `TECHNICAL.md` for the full config reference).
+
+## License
+
+MIT

--- a/server/mcp/package.json
+++ b/server/mcp/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@antonbabenko/deliberation-mcp",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "description": "Deliberation for Claude Code and any MCP host - GPT, Gemini, Grok, and OpenRouter expert subagents.",
   "mcpName": "io.github.antonbabenko/deliberation",
-  "bin": { "deliberation-mcp": "./dist/index.js", "deliberation-setup": "./dist/setup.js" },
-  "main": "./dist/index.js",
+  "repository": { "type": "git", "url": "git+https://github.com/antonbabenko/deliberation.git", "directory": "server/mcp" },
+  "homepage": "https://github.com/antonbabenko/deliberation#readme",
+  "bin": { "deliberation-mcp": "dist/index.js", "deliberation-setup": "dist/setup.js" },
+  "main": "dist/index.js",
   "files": ["dist/"],
   "engines": { "node": ">=18" },
   "scripts": {

--- a/test/core-grok.test.js
+++ b/test/core-grok.test.js
@@ -45,3 +45,16 @@ test("GK5: a thrown bridge call -> normalized error via classifyGrokError", asyn
   assert.equal(r.isError, true);
   assert.equal(r.errorKind, "auth");
 });
+
+test("GK6: req.apiKey overrides process.env.XAI_API_KEY; absent -> falls back to env", async () => {
+  let seen;
+  const capturing = { ...fakeBridge, runGrok: async (/** @type {any} */ a) => { seen = a.apiKey; return { text: "ok", output: null }; } };
+  process.env.XAI_API_KEY = "env-key";
+  const p = makeGrokProvider({ bridge: capturing, model: "grok-4.3" });
+
+  await p.ask({ prompt: "hi", apiKey: "tenant-key" });
+  assert.equal(seen, "tenant-key"); // per-request override wins
+
+  await p.ask({ prompt: "hi" });
+  assert.equal(seen, "env-key"); // no override -> process.env fallback
+});


### PR DESCRIPTION
feat: auto-publish on release, npm README, per-tenant key seam (extras A)

Three "extras (group A)" items from the master plan, one PR.

A1 - auto-publish on release (npm + MCP registry):
- The published npm package was stuck at 0.1.0 (manual, never synced); server.json +
  server/mcp/package.json were absent from the release version-sync. Bring both to 3.0.0
  and add them to the sync targets (.github/release/pre-commit.js) + the drift gate
  (validate.yml), so they can never drift again. server.json has two version lines
  (top-level + packages[0]); both are synced.
- tag-release.yml now publishes on a freshly-created tag: npm via OIDC trusted publishing
  (--provenance, no stored token) and the Official MCP Registry via `mcp-publisher login
  github-oidc`. Gated on steps.tag.outputs.created so a re-run never double-publishes; the
  registry step is best-effort so a hiccup never reds an already-published npm release.
  Adds permissions: id-token: write.
- bin paths de-`./`'d so npm stops auto-correcting them on publish.
- One-time prereq (done by the owner): npm trusted publishing enabled for the package.
  3.0.0 was published manually to fix the staleness immediately; CI handles 3.0.1+.

A2 - npm-facing README (server/mcp/README.md):
- The package shipped with no README, so the npmjs.com page was bare. Add a self-contained,
  npm-audience README: what it is, per-host install (npx config table), provider auth, the
  tool surface (incl. consensus + synthesizeAlways + consensus-step + session tools), the
  honesty-guards summary, and links back to the repo for full docs. npm auto-includes
  README.md on publish (files stays ["dist/"]).

A3 - per-tenant key resolution seam (Phase-2 shaping; remote resolver deferred to Phase 3):
- DelegationRequest gains optional `apiKey`; core/providers/grok.js and openai-compatible.js
  prefer `req.apiKey` over their process.env key (`(req && req.apiKey) || process.env[...]`).
  Backward-compatible: unset -> falls back to env exactly as today; stdio + existing tests
  unaffected. The standalone single-provider bridges stay env-based (out of the core seam).

Tests: +GK6 (req.apiKey overrides env; absent -> env fallback). Full suite 446/446 green,
typecheck clean.
