### PR TITLE
fix: pin mcp-publisher asset name in the registry publish step

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           set -uo pipefail
           gh release download --repo modelcontextprotocol/registry \
-            --pattern '*_linux_amd64.tar.gz' --output mcp-publisher.tar.gz || {
+            --pattern 'mcp-publisher_linux_amd64.tar.gz' --output mcp-publisher.tar.gz || {
               echo "::warning::could not download mcp-publisher; skipping registry publish"; exit 0; }
           tar xzf mcp-publisher.tar.gz mcp-publisher || {
               echo "::warning::could not extract mcp-publisher; skipping"; exit 0; }


### PR DESCRIPTION
fix: pin mcp-publisher asset name in the registry publish step

The registry-publish step globbed `*_linux_amd64.tar.gz`, which matched more
than one asset on the modelcontextprotocol/registry release, so `gh release
download --output` failed ("unable to write more than one asset"). The asset
name is version-less and stable, so pin it exactly: `mcp-publisher_linux_amd64.tar.gz`.

The step is best-effort (warned, did not fail the 3.1.0 release - npm OIDC publish
succeeded). 3.1.0 itself will not auto-publish to the MCP registry (its tag already
exists, publish is gated on a fresh tag); the next release picks it up, or run
mcp-publisher manually once for 3.1.0.
