### PR TITLE
fix: populate root .mcp.json so plugin MCP servers register

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,29 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "deliberation-codex": {
+      "command": "codex",
+      "args": ["mcp-server"],
+      "type": "stdio"
+    },
+    "deliberation-gemini": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/gemini/index.js"],
+      "type": "stdio"
+    },
+    "deliberation-grok": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/grok/index.js"],
+      "type": "stdio"
+    },
+    "deliberation-openrouter": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/openrouter/index.js"],
+      "type": "stdio"
+    },
+    "deliberation": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/mcp/index.js"],
+      "type": "stdio"
+    }
+  }
 }


### PR DESCRIPTION
TL;DR: the plugin registered **zero** MCP servers on install. Root `.mcp.json` shipped empty; Claude Code reads MCP definitions from that file, not from `.claude-plugin/mcp.json`.

## Symptom
After install + `/reload-plugins`, none of the `mcp__deliberation-*` tools (codex / gemini / grok / openrouter / deliberation) are available. `/deliberation:ask-grok` etc. fail with no provider. `/plugin update` + `/reload-plugins` does not fix it.

## Root cause
Claude Code reads a plugins MCP server definitions from the plugin **root `.mcp.json`**. This repo shipped:

- root `.mcp.json` -> `{"mcpServers": {}}` (empty)
- `.claude-plugin/mcp.json` -> the real 5-server manifest

Claude Code does not read `.claude-plugin/mcp.json` for plugin MCP registration, so it registered nothing. `/reload-plugins` reloads skills/commands/rules, not MCP connections, so it could never recover. Regression from `00be051` ("register MCP servers via plugin manifest").

Every plugin whose MCP loads correctly (ecc, playwright, telegram) declares its servers in the **root `.mcp.json`**.

## Fix
Copy the canonical 5-server manifest into root `.mcp.json`. No other changes.

## Verification (local)
- root + cache `.mcp.json` parse as valid JSON
- `codex` binary on PATH; `XAI_API_KEY` / `OPENROUTER_API_KEY` present
- all four node bridges complete the `initialize` handshake and list tools:
  - gemini -> `gemini, gemini-reply`
  - grok -> `grok, grok-reply`
  - openrouter -> `openrouter, openrouter-reply, openrouter-list`
  - deliberation -> 21 tools (`ask-all, consensus, ask-grok, ...`)
- live end-to-end Grok call ("what is 2+3+4?") returns `9`

## Follow-up (not in this PR)
`.claude-plugin/mcp.json` appears unread by Claude Code for plugin MCP. Worth reconciling to a single source of truth (keep root `.mcp.json`, drop or repurpose the `.claude-plugin` copy, and update CLAUDE.md/docs that call it "the SOLE runtime MCP registration").

Note: MCP servers connect at Claude Code startup, so installed users must fully restart Claude Code (not just `/reload-plugins`) to pick up the servers after this lands.