### PR TITLE
fix: robust consensus review-verdict parsing across providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,9 @@ No build step, no dependencies. Codex exposes a native MCP server; Gemini, Grok,
   (`recommendation` + `confidence` enum + optional `dissent_points`/`assumptions`/`tradeoffs`
   `string[]`), `parseOpinion(text) -> OpinionEnvelope` (best-effort, never throws; `structured` =
   parse provenance), advisory `validateOpinion` (`{valid, wellFormed, warnings}`), `OPINION_INSTRUCTIONS`,
-  and `parseReview(text) -> {verdict, criticalIssues}` (anchored verdict regex + the closed 6-category
-  taxonomy) used by the convergence loop. `registry.js` (`selectForAskAll` /
+  and `parseReview(text) -> {verdict, criticalIssues}` (best-effort, never-throws: fenced-code-skipped
+  verdict ladder - `VERDICT:` sentinel / same-line keyword / `Verdict` heading-split / bare token - plus
+  the closed 6-category taxonomy with next-line continuation-join) used by the convergence loop. `registry.js` (`selectForAskAll` /
   `selectForConsensus`); `orchestrate.js` (`askAll` / `askOne` / `consensus` / `runToConvergence` -
   the non-Claude server-side loop driver); `consensus-loop.js` (the PURE convergence state machine -
   the SSOT for round counting, the convergence rule, the configurable max-rounds cap, history, and the

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -82,6 +82,16 @@ self-approve. The cap is `consensus.maxRounds` (default 5).
 - `performance` - latency, throughput, resource use, scaling limit
 - `ops` - rollback, observability, deploy, migration, on-call surface
 
+**Verdict shape.** The shared review prompt (one byte-identical string per provider) instructs every
+reviewer to end with a machine-readable `VERDICT: APPROVE` (or `VERDICT: REQUEST_CHANGES` /
+`VERDICT: REJECT`) line on its own, then list issues as `- [category] description`. `parseReview`
+tolerates real-world drift across models: it first strips fenced code blocks (so a quoted/echoed
+template cannot hijack the verdict), then resolves the verdict via a 4-tier ladder - the `VERDICT:`
+sentinel, a same-line `Verdict: <token>`, a `Verdict` heading with the token on a following line, or a
+bare standalone token line - and joins a category heading to a description on the next line when the
+bullet itself has none. An unparsed verdict stays `null` (treated as "not APPROVE"), so a parse miss
+never false-approves into convergence.
+
 **Stage 2 (anonymized peer cross-review) is not part of the current loop.** Earlier revisions ran
 a command-layer Stage 2 (each reviewer scored the others' anonymized answers, with a shuffle
 mapping in the report). The engine-driven rewrite removed it: the core loop has no Stage 2 model,

--- a/core/consensus-loop.js
+++ b/core/consensus-loop.js
@@ -136,12 +136,12 @@ function prepareRound(state) {
   const peerPrompt = [
     body,
     "Review the plan for correctness, security, scope, ambiguity, performance, and ops gaps.",
-    "End with: **Verdict**: APPROVE | REQUEST_CHANGES | REJECT, then categorized critical issues.",
+    "End with a line by itself in exactly this form (no markdown, token on the SAME line): VERDICT: APPROVE   (or VERDICT: REQUEST_CHANGES, or VERDICT: REJECT). Then list any critical issues, one per line as: - [category] description   where category is one of security, correctness, scope, ambiguity, performance, ops.",
   ].join("\n\n");
   const blindPrompt = [
     body,
     "Give your own independent verdict BEFORE seeing peer opinions.",
-    "End with: **Verdict**: APPROVE | REQUEST_CHANGES | REJECT, then categorized critical issues.",
+    "End with a line by itself in exactly this form (no markdown, token on the SAME line): VERDICT: APPROVE   (or VERDICT: REQUEST_CHANGES, or VERDICT: REJECT). Then list any critical issues, one per line as: - [category] description   where category is one of security, correctness, scope, ambiguity, performance, ops.",
   ].join("\n\n");
   return { peerPrompt, blindPrompt };
 }

--- a/core/provider.js
+++ b/core/provider.js
@@ -368,7 +368,7 @@ function resolveIssues(lines) {
         const nt = lines[j].trim();
         if (!nt) break;                                  // blank -> stop
         if (BULLET_RE.test(nt) || HEADING_RE.test(nt)) break;  // next bullet/heading -> stop
-        if (SENTINEL_RE.test(nt) || VERDICT_WORD_RE.test(nt)) break; // verdict line -> stop
+        if (SENTINEL_RE.test(nt) || VERDICT_WORD_RE.test(nt) || VERDICT_RE.test(nt)) break; // verdict line -> stop
         description = nt.replace(STRIP_LEAD, "").replace(STRIP_TRAIL, "").trim();
         break;                                           // take the first usable continuation line
       }

--- a/core/provider.js
+++ b/core/provider.js
@@ -264,7 +264,7 @@ const REVIEW_FALLBACK_CATEGORY = "ambiguity";
 // echoed instruction line cannot hijack the verdict.
 const VERDICT_RE = /\bverdict\b[^A-Za-z0-9]*\b(APPROVE|REJECT|REQUEST[_\s]CHANGES)\b/i;
 const BULLET_RE = /^([-*+•]|`?\[)/;
-const BRACKET_CAT_RE = /\[\s*([A-Za-z_]+)\s*\]/g;
+const BRACKET_CAT_RE = /\[\s*([A-Za-z_]+)\s*\]/g; // /g: consumed ONLY via matchAll (does not touch lastIndex); do NOT .exec()/.test() this
 
 // Verdict-line shapes (all anchored / bounded - no backtracking):
 const SENTINEL_RE = /^[#>*_`\s]*verdict\s*[:=]\s*[*_`\s]*(APPROVE|REJECT|REQUEST[_\s]CHANGES)\b/i;
@@ -272,6 +272,10 @@ const VERDICT_WORD_RE = /^[#>*_`\s]*verdict[*_`:\s]*$/i;   // a "Verdict" headin
 const TOKEN_LINE_RE = /^(APPROVE|REJECT|REQUEST[_\s]CHANGES)$/i; // a whole line that IS just the token
 const MD_EMPHASIS = /[*_`~]/g;                             // emphasis chars to strip when isolating a token
 const FENCE_RE = /^\s*(```|~~~)/;                          // fenced code-block delimiter
+const ARTIFACT_RE = /^[*_`~\s:.\-]*$/;                     // empty or only markdown/punct
+const STRIP_LEAD = /^[*_`~\s:.\-]+/;                       // leading noise to trim off a description
+const STRIP_TRAIL = /[*_`~\s]+$/;                          // trailing emphasis to trim
+const HEADING_RE = /^#{1,6}\s/;
 /** Normalize a verdict token: "REQUEST CHANGES" -> "REQUEST_CHANGES", upper-cased. */
 function normVerdict(/** @type {string} */ tok) { return tok.replace(/\s+/g, "_").toUpperCase(); }
 
@@ -332,8 +336,47 @@ function resolveVerdict(lines) {
   return null;
 }
 
-/** @param {string[]} lines @returns {ReviewCriticalIssue[]} */
-function resolveIssues(lines) { void lines; return []; }
+/**
+ * Extract categorized critical issues. Only bullet/bracket lines are considered;
+ * the first bracket that is a known category wins (else the first bracket degrades
+ * to `ambiguity`). The description is the text after the chosen `]`; when that is
+ * empty or only markdown artifacts (e.g. a bold `**[security]**` heading with the
+ * text on the following line), pull the next usable line as the description. A
+ * still-empty/artifact-only description is dropped (not actionable for convergence).
+ * @param {string[]} lines
+ * @returns {ReviewCriticalIssue[]}
+ */
+function resolveIssues(lines) {
+  /** @type {ReviewCriticalIssue[]} */
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!BULLET_RE.test(trimmed)) continue;
+    let chosen = null;
+    for (const mm of trimmed.matchAll(BRACKET_CAT_RE)) {
+      if (REVIEW_CATEGORIES.includes(mm[1].toLowerCase())) { chosen = mm; break; }
+      if (chosen === null) chosen = mm;
+    }
+    if (!chosen) continue;
+    const cat = chosen[1].toLowerCase();
+    const category = /** @type {ReviewCriticalIssue["category"]} */ (
+      REVIEW_CATEGORIES.includes(cat) ? cat : REVIEW_FALLBACK_CATEGORY
+    );
+    let description = trimmed.slice(chosen.index + chosen[0].length).replace(STRIP_LEAD, "").replace(STRIP_TRAIL, "").trim();
+    if (!description || ARTIFACT_RE.test(description)) {
+      for (let j = i + 1; j < lines.length; j++) {
+        const nt = lines[j].trim();
+        if (!nt) break;                                  // blank -> stop
+        if (BULLET_RE.test(nt) || HEADING_RE.test(nt)) break;  // next bullet/heading -> stop
+        if (SENTINEL_RE.test(nt) || VERDICT_WORD_RE.test(nt)) break; // verdict line -> stop
+        description = nt.replace(STRIP_LEAD, "").replace(STRIP_TRAIL, "").trim();
+        break;                                           // take the first usable continuation line
+      }
+    }
+    if (description && !ARTIFACT_RE.test(description)) out.push({ category, description });
+  }
+  return out;
+}
 
 module.exports = {
   toErrorResult,

--- a/core/provider.js
+++ b/core/provider.js
@@ -299,8 +299,8 @@ function normVerdict(/** @type {string} */ tok) { return tok.replace(/\s+/g, "_"
  */
 function parseReview(text) {
   const raw = safeString(text);
-  // Drop fenced code blocks so an echoed template / quoted example cannot hijack
-  // the verdict (the shared prompt now keeps its VERDICT example inside a fence).
+  // Drop fenced code blocks so a reviewer's quoted/fenced example cannot hijack
+  // the verdict.
   const lines = [];
   let inFence = false;
   for (const ln of raw.split(/\r?\n/)) {

--- a/core/provider.js
+++ b/core/provider.js
@@ -266,6 +266,15 @@ const VERDICT_RE = /\bverdict\b[^A-Za-z0-9]*\b(APPROVE|REJECT|REQUEST[_\s]CHANGE
 const BULLET_RE = /^([-*+•]|`?\[)/;
 const BRACKET_CAT_RE = /\[\s*([A-Za-z_]+)\s*\]/g;
 
+// Verdict-line shapes (all anchored / bounded - no backtracking):
+const SENTINEL_RE = /^[#>*_`\s]*verdict\s*[:=]\s*[*_`\s]*(APPROVE|REJECT|REQUEST[_\s]CHANGES)\b/i;
+const VERDICT_WORD_RE = /^[#>*_`\s]*verdict[*_`:\s]*$/i;   // a "Verdict" heading line, nothing else
+const TOKEN_LINE_RE = /^(APPROVE|REJECT|REQUEST[_\s]CHANGES)$/i; // a whole line that IS just the token
+const MD_EMPHASIS = /[*_`~]/g;                             // emphasis chars to strip when isolating a token
+const FENCE_RE = /^\s*(```|~~~)/;                          // fenced code-block delimiter
+/** Normalize a verdict token: "REQUEST CHANGES" -> "REQUEST_CHANGES", upper-cased. */
+function normVerdict(/** @type {string} */ tok) { return tok.replace(/\s+/g, "_").toUpperCase(); }
+
 /**
  * Parse a consensus REVIEW reply into a verdict + categorized critical issues.
  * Best-effort and NEVER throws. Line-based (no regex backtracking on large input).
@@ -286,39 +295,45 @@ const BRACKET_CAT_RE = /\[\s*([A-Za-z_]+)\s*\]/g;
  */
 function parseReview(text) {
   const raw = safeString(text);
-  const lines = raw.split(/\r?\n/);
-  /** @type {ParsedReview["verdict"]} */
-  let verdict = null;
-  /** @type {ReviewCriticalIssue[]} */
-  const criticalIssues = [];
-
-  for (const line of lines) {
-    if (verdict === null) {
-      const vm = line.match(VERDICT_RE);
-      if (vm) verdict = /** @type {ParsedReview["verdict"]} */ (vm[1].replace(/\s+/g, "_").toUpperCase());
-    }
-    const trimmed = line.trim();
-    if (!BULLET_RE.test(trimmed)) continue;
-    // Pick the first bracketed token that is a known category; else the first
-    // bracket at all (degraded to ambiguity). matchAll is reset each line.
-    let chosen = null;
-    for (const mm of trimmed.matchAll(BRACKET_CAT_RE)) {
-      if (REVIEW_CATEGORIES.includes(mm[1].toLowerCase())) { chosen = mm; break; }
-      if (chosen === null) chosen = mm; // remember the first bracket as fallback
-    }
-    if (!chosen) continue;
-    const cat = chosen[1].toLowerCase();
-    const category = /** @type {ReviewCriticalIssue["category"]} */ (
-      REVIEW_CATEGORIES.includes(cat) ? cat : REVIEW_FALLBACK_CATEGORY
-    );
-    const description = trimmed
-      .slice((chosen.index || 0) + chosen[0].length)
-      .replace(/^[`\s:.\-]+/, "")
-      .trim();
-    if (description) criticalIssues.push({ category, description });
+  // Drop fenced code blocks so an echoed template / quoted example cannot hijack
+  // the verdict (the shared prompt now keeps its VERDICT example inside a fence).
+  const lines = [];
+  let inFence = false;
+  for (const ln of raw.split(/\r?\n/)) {
+    if (FENCE_RE.test(ln)) { inFence = !inFence; continue; }
+    if (!inFence) lines.push(ln);
   }
-  return { verdict, criticalIssues };
+  return { verdict: resolveVerdict(lines), criticalIssues: resolveIssues(lines) };
 }
+
+/**
+ * Verdict ladder, first match wins (priority a > b > c > d). All passes scan a
+ * small fence-filtered line array - no backtracking.
+ * @param {string[]} lines
+ * @returns {ParsedReview["verdict"]}
+ */
+function resolveVerdict(lines) {
+  // a) explicit machine-readable sentinel: `VERDICT: APPROVE`
+  for (const ln of lines) { const m = ln.match(SENTINEL_RE); if (m) return /** @type {any} */ (normVerdict(m[1])); }
+  // b) keyword + token on the same line (legacy shape; the reviewer's own verdict)
+  for (const ln of lines) { const m = ln.match(VERDICT_RE); if (m) return /** @type {any} */ (normVerdict(m[1])); }
+  // c) heading-split: a "Verdict" heading line, then a bare token within the next 3 non-empty lines
+  for (let i = 0; i < lines.length; i++) {
+    if (!VERDICT_WORD_RE.test(lines[i].trim())) continue;
+    for (let j = i + 1; j < lines.length && j <= i + 3; j++) {
+      const t = lines[j].replace(MD_EMPHASIS, "").trim();
+      if (!t) continue;
+      if (TOKEN_LINE_RE.test(t)) return /** @type {any} */ (normVerdict(t));
+      break; // first non-empty line under the heading was not a token -> stop
+    }
+  }
+  // d) bare standalone token line, no "verdict" keyword (leading-token replies)
+  for (const ln of lines) { const t = ln.replace(MD_EMPHASIS, "").trim(); if (TOKEN_LINE_RE.test(t)) return /** @type {any} */ (normVerdict(t)); }
+  return null;
+}
+
+/** @param {string[]} lines @returns {ReviewCriticalIssue[]} */
+function resolveIssues(lines) { void lines; return []; }
 
 module.exports = {
   toErrorResult,

--- a/test/core-review-parse.test.js
+++ b/test/core-review-parse.test.js
@@ -127,3 +127,24 @@ test("RP-V5: a bare token in prose does NOT match (only a whole-line token)", ()
 test("RP-V6: still returns null when there is genuinely no verdict", () => {
   assert.equal(parseReview("Some commentary with no decision.").verdict, null);
 });
+
+test("RP-I1: bold category heading with description on the NEXT line", () => {
+  const t = ["VERDICT: REQUEST_CHANGES", "- **[security]**", "  the endpoint has no authz check"].join("\n");
+  assert.deepEqual(parseReview(t).criticalIssues, [{ category: "security", description: "the endpoint has no authz check" }]);
+});
+
+test("RP-I2: pure markdown-artifact description (** with nothing after) is dropped", () => {
+  const t = ["VERDICT: APPROVE", "- [correctness] **", "", "next paragraph"].join("\n");
+  assert.deepEqual(parseReview(t).criticalIssues, []);
+});
+
+test("RP-I3: same-line category + description still works (no regression)", () => {
+  const t = ["VERDICT: REQUEST_CHANGES", "- [ops] missing rollback step"].join("\n");
+  assert.deepEqual(parseReview(t).criticalIssues, [{ category: "ops", description: "missing rollback step" }]);
+});
+
+test("RP-I4: continuation stops at a blank line / next bullet (no over-capture)", () => {
+  const t = ["- [scope] ", "- [perf-ish] should not be swallowed"].join("\n");
+  // first bullet has empty desc and the next line is another bullet -> dropped, not joined
+  assert.deepEqual(parseReview(t).criticalIssues.filter(c => c.category === "scope"), []);
+});

--- a/test/core-review-parse.test.js
+++ b/test/core-review-parse.test.js
@@ -98,3 +98,32 @@ test("RP11: REVIEW_CATEGORIES is the frozen 6-set", () => {
   assert.deepEqual([...REVIEW_CATEGORIES].sort(), ["ambiguity", "correctness", "ops", "performance", "scope", "security"]);
   assert.equal(Object.isFrozen(REVIEW_CATEGORIES), true);
 });
+
+test("RP-V1: heading-split verdict (### Verdict then token on next line)", () => {
+  assert.equal(parseReview("### Verdict\n**REQUEST CHANGES**").verdict, "REQUEST_CHANGES");
+  assert.equal(parseReview("**Verdict**\nAPPROVE").verdict, "APPROVE");
+  assert.equal(parseReview("### **Verdict**\nAPPROVE").verdict, "APPROVE");
+});
+
+test("RP-V2: bare leading token with no 'verdict' keyword", () => {
+  assert.equal(parseReview("REQUEST CHANGES\n\nThe cache regression needs a fix.").verdict, "REQUEST_CHANGES");
+  assert.equal(parseReview("APPROVE\n\n- [correctness] minor nit").verdict, "APPROVE");
+});
+
+test("RP-V3: explicit VERDICT: sentinel line wins", () => {
+  assert.equal(parseReview("blah\nVERDICT: APPROVE\nmore").verdict, "APPROVE");
+  assert.equal(parseReview("VERDICT: REQUEST_CHANGES").verdict, "REQUEST_CHANGES");
+});
+
+test("RP-V4: tokens inside fenced code blocks do NOT hijack the verdict", () => {
+  const t = ["```", "VERDICT: REJECT", "```", "VERDICT: APPROVE"].join("\n");
+  assert.equal(parseReview(t).verdict, "APPROVE");
+});
+
+test("RP-V5: a bare token in prose does NOT match (only a whole-line token)", () => {
+  assert.equal(parseReview("I would not REJECT this; it is fine.").verdict, null);
+});
+
+test("RP-V6: still returns null when there is genuinely no verdict", () => {
+  assert.equal(parseReview("Some commentary with no decision.").verdict, null);
+});

--- a/test/core-review-parse.test.js
+++ b/test/core-review-parse.test.js
@@ -148,3 +148,11 @@ test("RP-I4: continuation stops at a blank line / next bullet (no over-capture)"
   // first bullet has empty desc and the next line is another bullet -> dropped, not joined
   assert.deepEqual(parseReview(t).criticalIssues.filter(c => c.category === "scope"), []);
 });
+
+test("RP-I5: continuation stops at a legacy same-line verdict line (not swallowed as description)", () => {
+  const t = ["- [security]", "Final verdict - APPROVE"].join("\n");
+  // empty-desc bullet must NOT swallow the following same-line verdict line; issue is dropped, verdict still resolves
+  const r = parseReview(t);
+  assert.deepEqual(r.criticalIssues, []);
+  assert.equal(r.verdict, "APPROVE");
+});


### PR DESCRIPTION
## Summary

`core/provider.js parseReview` was line-based and silently returned `verdict: null` for ~23% of real reviewer replies (measured over the persisted session corpus), which the convergence loop treats as "not APPROVE" - stalling consensus. The failure was cross-provider, not one model's fault: two shapes dominated - a `Verdict` heading with the token on the next line, and a bare leading `APPROVE` / `REQUEST CHANGES` token with no "verdict" keyword.

This hardens both sides of the contract:

- **Parser** (`core/provider.js`): skip fenced code blocks (so a quoted/echoed template can't hijack the verdict), then resolve the verdict via a 4-tier ladder - `VERDICT:` sentinel > same-line keyword > `Verdict` heading-split > bare standalone token. Critical-issue extraction gains a next-line continuation-join (for a bold `**[category]**` heading with its text on the following line) plus a two-sided markdown strip, and drops artifact-only descriptions.
- **Shared prompt** (`core/consensus-loop.js prepareRound`): the peer/blind review instruction now mandates a machine-readable `VERDICT: <TOKEN>` line on its own plus `- [category] description` issues. One byte-identical string per provider - zero cross-contamination.

Invariants preserved: `parseReview` is best-effort and never throws; all regexes are linear (no ReDoS); the closed 6-category taxonomy is unchanged; the convergence rule is unchanged (a `null` verdict stays "not APPROVE", never auto-APPROVE); `core/` stays zero runtime deps.

## Test Plan

- [x] `npm run check` (typecheck + full suite): 535/535 pass with the sandbox disabled (the 11 transient fails under the command sandbox are `listen EPERM` socket binds in the OpenRouter HTTP-bridge tests, unrelated to this change)
- [x] New parse fixtures lock every captured failure shape (heading-split, bare token, sentinel, fenced-token guard, bold-heading continuation, artifact drop, legacy same-line stop)
- [x] Real-corpus regression: re-running the real `parseReview` over the session store drops the null-verdict rate from ~23% to 4.7%, with the remainder spread thin (genuine no-verdict replies)
- [x] Docs updated (CLAUDE.md, TECHNICAL.md) to describe the sentinel contract + ladder