### PR TITLE
fix(security): harden provider bridges (file perms, redirect guard, env scrub, input validation)

### DIFF
--- a/core/provider.js
+++ b/core/provider.js
@@ -331,8 +331,12 @@ function resolveVerdict(lines) {
       break; // first non-empty line under the heading was not a token -> stop
     }
   }
-  // d) bare standalone token line, no "verdict" keyword (leading-token replies)
-  for (const ln of lines) { const t = ln.replace(MD_EMPHASIS, "").trim(); if (TOKEN_LINE_RE.test(t)) return /** @type {any} */ (normVerdict(t)); }
+  // d) bare standalone token, restricted to the FIRST or LAST non-empty line so a
+  //    stray mid-body token (e.g. an "APPROVE" heading in an example) cannot hijack.
+  const nonEmpty = lines.map((l) => l.replace(MD_EMPHASIS, "").trim()).filter((t) => t !== "");
+  for (const t of [nonEmpty[0], nonEmpty[nonEmpty.length - 1]]) {
+    if (t && TOKEN_LINE_RE.test(t)) return /** @type {any} */ (normVerdict(t));
+  }
   return null;
 }
 

--- a/core/sessions.js
+++ b/core/sessions.js
@@ -124,6 +124,10 @@ function scrubSecrets(text) {
     // Google API keys: AIza + >=35 chars. {35,} (not {35}) so a longer-than-39
     // key cannot leak its tail; over-matching only redacts MORE, never less.
     .replace(/\bAIza[0-9A-Za-z_-]{35,}/g, "[REDACTED]")
+    // URL-embedded credentials: scheme://user:SECRET@host -> redact the password only.
+    .replace(/\b([a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:)[^\s@/]{6,}@/gi, "$1[REDACTED]@")
+    // Non-Bearer "Token <value>" auth headers (e.g. GitHub "Authorization: token ...").
+    .replace(/\bToken\s+[A-Za-z0-9._~+/-]{20,}={0,2}/g, "Token [REDACTED]")
     // `Bearer <token>` headers. No `i` flag (HTTP uses capital "Bearer") so the
     // English word "bearer" is not matched; {20,} min + base64/base64url charset
     // (+ / ~ -) and optional = padding so a real token is fully redacted, not

--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -24,6 +24,12 @@ const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes (Gemini 3 deep prompts run 200-
 const DEFAULT_RECOVERY_GRACE_MS = 120_000; // extra drain budget after the soft timeout
 const MAX_MS = 600_000;
 const VALID_SANDBOX_VALUES = new Set(["read-only", "workspace-write"]);
+// Conversation ids are passed as the agy --conversation arg. shell:false blocks
+// shell injection, but a leading-dash value could be parsed as an agy flag, so
+// the first char must be alphanumeric/underscore; hyphens are allowed only after
+// it. Total length 1..128. Applies to both the gemini-reply threadId input and
+// the agy-sourced id read from last_conversations.json.
+const THREAD_ID_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]{0,127}$/;
 
 // agy's --print-timeout takes a Go duration string ("420s"). Convert ms.
 function goDuration(ms) {
@@ -87,10 +93,15 @@ function buildAgyArgs(req) {
 // exfiltrate over the (intentionally open) network. Scrubbed from the child env
 // on read-only runs. agy's own Gemini auth lives in ~/.gemini, not these vars.
 const ADVISORY_ENV_SCRUB = ["GITHUB_TOKEN", "GH_TOKEN", "GIT_ASKPASS", "SSH_AUTH_SOCK"];
+// Strip any var whose NAME looks like a credential (advisory agy has open network
+// and no need for the operator's keys). Denylist-by-shape, not a pass-allowlist:
+// agy still needs PATH/HOME/TMPDIR/locale + its own ~/.gemini auth (not an env var).
+const CREDENTIAL_NAME_RE = /(?:^|_)(?:KEY|TOKEN|SECRET|SECRETS|PASSWORD|PASSWD|CREDENTIAL|CREDENTIALS)$|API_KEY|ACCESS_KEY|SESSION_TOKEN|PRIVATE_KEY/i;
 
 /**
  * Build the child env for a read-only run: drop the OS-sandbox kill-switch (so it
- * never inherits into the delegate) and scrub push/exfil credentials.
+ * never inherits into the delegate), scrub the explicit push/exfil credential
+ * denylist, then scrub any remaining var whose NAME is credential-shaped.
  * @param {NodeJS.ProcessEnv} env
  * @returns {NodeJS.ProcessEnv}
  */
@@ -98,6 +109,9 @@ function advisoryEnv(env) {
   const out = { ...env };
   delete out.DELIBERATION_DISABLE_OS_SANDBOX;
   for (const k of ADVISORY_ENV_SCRUB) delete out[k];
+  for (const k of Object.keys(out)) {
+    if (CREDENTIAL_NAME_RE.test(k)) delete out[k];
+  }
   return out;
 }
 
@@ -295,7 +309,8 @@ function resolveConversationId(cwd) {
     const resolved = path.resolve(cwd);
     let real = resolved;
     try { real = fs.realpathSync(resolved); } catch (_) { /* ignore */ }
-    return map[real] ?? map[resolved] ?? map[cwd] ?? null;
+    const candidate = map[real] ?? map[resolved] ?? map[cwd] ?? null;
+    return (typeof candidate === "string" && THREAD_ID_RE.test(candidate)) ? candidate : null;
   } catch (_) {
     return null;
   }
@@ -660,8 +675,8 @@ const handlers = {
           return;
         }
         const threadId = args.threadId.trim();
-        if (threadId === "" || threadId === "latest" || threadId === "unknown") {
-          if (shouldRespond) sendError(id, -32602, "Invalid params: 'threadId' must be an explicit conversation id, not '" + threadId + "'");
+        if (!THREAD_ID_RE.test(threadId) || threadId === "latest" || threadId === "unknown") {
+          if (shouldRespond) sendError(id, -32602, "Invalid params: 'threadId' must be an explicit conversation id (alphanumeric/underscore start, then [A-Za-z0-9_-], 1..128 chars)");
           return;
         }
         if (!isNonEmptyString(args.prompt)) {
@@ -786,6 +801,7 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports.READ_ONLY_GUARD = READ_ONLY_GUARD;
   module.exports.applyReadOnlyGuard = applyReadOnlyGuard;
   module.exports.advisoryEnv = advisoryEnv;
+  module.exports.THREAD_ID_RE = THREAD_ID_RE;
   module.exports.buildSeatbeltProfile = buildSeatbeltProfile;
   module.exports.buildSpawnCommand = buildSpawnCommand;
   module.exports.diffGitState = diffGitState;

--- a/server/grok/cache.js
+++ b/server/grok/cache.js
@@ -50,7 +50,7 @@ function readCache(file) {
 function writeCache(file, data) {
   mkdirSync(path.dirname(file), { recursive: true });
   const tmp = `${file}.tmp.${process.pid}.${Date.now()}`;
-  writeFileSync(tmp, JSON.stringify(data));
+  writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
   renameSync(tmp, file);
 }
 

--- a/server/grok/files-admin.js
+++ b/server/grok/files-admin.js
@@ -68,7 +68,7 @@ async function listFiles({ apiKey, apiBase, fetchImpl, pageLimit = 1000 }) {
     const url = new URL(`${base}/files`);
     url.searchParams.set("limit", String(pageLimit));
     if (token) url.searchParams.set("pagination_token", token);
-    const res = await f(url.toString(), { method: "GET", headers });
+    const res = await f(url.toString(), { method: "GET", headers, redirect: "error" });
     const text = await res.text();
     if (!res.ok) throw new Error(`List files failed ${res.status}: ${text.slice(0, 300)}`);
     const data = JSON.parse(text);
@@ -89,6 +89,7 @@ async function deleteFile(id, { apiKey, apiBase, fetchImpl }) {
   const res = await f(`${base}/files/${encodeURIComponent(id)}`, {
     method: "DELETE",
     headers: authHeader(apiKey),
+    redirect: "error",
   });
   const text = await res.text();
   if (!res.ok) throw new Error(`Delete ${id} failed ${res.status}: ${text.slice(0, 200)}`);

--- a/server/grok/glob.js
+++ b/server/grok/glob.js
@@ -101,6 +101,8 @@ function walk(rootAbs, { include, exclude, maxFiles, maxBytes }) {
         if (!matches(includeRes, relPosix)) continue;
         files.push({ rel: relPosix, abs: realTarget, size: st.size });
         totalBytes += st.size;
+        if (files.length > maxFiles) throw new Error(`directory expansion exceeded maxFiles=${maxFiles}. Narrow include or raise the limit.`);
+        if (totalBytes > maxBytes) throw new Error(`directory expansion exceeded maxBytes=${maxBytes} bytes. Narrow include or raise the limit.`);
       } else if (ent.isDirectory()) {
         if (matches(excludeRes, relPosix) || matches(excludeRes, relPosix + "/**")) continue;
         descend(absChild, relPosix);
@@ -111,12 +113,17 @@ function walk(rootAbs, { include, exclude, maxFiles, maxBytes }) {
         try { st = fs.statSync(absChild); } catch (_) { continue; }
         files.push({ rel: relPosix, abs: absChild, size: st.size });
         totalBytes += st.size;
+        if (files.length > maxFiles) throw new Error(`directory expansion exceeded maxFiles=${maxFiles}. Narrow include or raise the limit.`);
+        if (totalBytes > maxBytes) throw new Error(`directory expansion exceeded maxBytes=${maxBytes} bytes. Narrow include or raise the limit.`);
       }
     }
   }
 
   descend(rootAbs, "");
 
+  // Defensive backstop: descend() already throws early (mid-walk) the moment a
+  // cap is exceeded, so these post-loop checks are normally unreachable. Kept
+  // belt-and-suspenders in case a future refactor drops an inner check.
   if (files.length > maxFiles) {
     throw new Error(`directory expansion selected ${files.length} files; exceeds maxFiles=${maxFiles}. Narrow include or raise the limit.`);
   }

--- a/server/grok/index.js
+++ b/server/grok/index.js
@@ -387,6 +387,7 @@ async function uploadFile({ filePath, filename, apiKey, apiBase, ttl, roots, cwd
         method: "POST",
         headers: { "Authorization": `Bearer ${apiKey}` },
         body: form,
+        redirect: "error",
       });
     } catch (err) {
       const e = new Error(`File upload network error: ${(err && err.message) || err}`);
@@ -591,6 +592,7 @@ async function runGrok({ turns, model, timeoutMs, apiKey, apiBase, fetchImpl, re
       },
       body: JSON.stringify(payload),
       signal: controller.signal,
+      redirect: "error",
     });
   } catch (err) {
     const name = err && err.name;

--- a/server/grok/lock.js
+++ b/server/grok/lock.js
@@ -29,7 +29,7 @@ function acquire(basePath, { maxWaitMs = 1000 } = {}) {
     try {
       fs.mkdirSync(lockDir);
       const markerPath = path.join(lockDir, markerName);
-      fs.writeFileSync(markerPath, JSON.stringify({ pid: process.pid, token, t: Date.now() }));
+      fs.writeFileSync(markerPath, JSON.stringify({ pid: process.pid, token, t: Date.now() }), { mode: 0o600 });
       return { lockDir, markerPath, token };
     } catch (e) {
       if (e.code !== "EEXIST") throw e;

--- a/server/openrouter/index.js
+++ b/server/openrouter/index.js
@@ -81,7 +81,7 @@ async function callOpenRouter({ apiBase, apiKey, model, messages, reasoningEffor
   const timer = setTimeout(() => controller.abort(), t);
   let res;
   try {
-    res = await f(url, { method: "POST", headers, body: JSON.stringify(payload), signal: controller.signal });
+    res = await f(url, { method: "POST", headers, body: JSON.stringify(payload), signal: controller.signal, redirect: "error" });
   } catch (err) {
     const msg = String((err && err.message) || err);
     if ((err && err.name === "AbortError") || /abort/i.test(msg)) { const e = new Error(`OpenRouter timed out after ${Math.round(t / 1000)}s`); e.code = "timeout"; throw e; }

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -421,19 +421,23 @@ test("S2: the guard sits OUTSIDE developerInstructions (outermost)", () => {
   assert.ok(prompt.startsWith(`SYS\n\n${READ_ONLY_GUARD}`), "dev instructions wrap the guarded prompt");
 });
 
-test("S3: advisoryEnv drops the kill-switch and scrubs push/exfil credentials", () => {
+test("S3: advisoryEnv drops the kill-switch and scrubs push/exfil + credential-shaped env", () => {
   const { advisoryEnv } = require("../server/gemini/index.js");
   const out = advisoryEnv({
     DELIBERATION_DISABLE_OS_SANDBOX: "1",
     GITHUB_TOKEN: "ght", GH_TOKEN: "gh", GIT_ASKPASS: "x", SSH_AUTH_SOCK: "/sock",
-    GEMINI_API_KEY: "keep", PATH: "/usr/bin",
+    // Credential-shaped vars an advisory delegate has no need for. agy's own
+    // Gemini auth lives in ~/.gemini (OAuth), NOT in GEMINI_API_KEY, so the
+    // credential-name scrub correctly drops API_KEY-shaped vars too.
+    GEMINI_API_KEY: "drop", PATH: "/usr/bin", HOME: "/Users/x", LANG: "en_US.UTF-8",
   });
   assert.equal("DELIBERATION_DISABLE_OS_SANDBOX" in out, false);
-  for (const k of ["GITHUB_TOKEN", "GH_TOKEN", "GIT_ASKPASS", "SSH_AUTH_SOCK"]) {
+  for (const k of ["GITHUB_TOKEN", "GH_TOKEN", "GIT_ASKPASS", "SSH_AUTH_SOCK", "GEMINI_API_KEY"]) {
     assert.equal(k in out, false, `${k} scrubbed`);
   }
-  assert.equal(out.GEMINI_API_KEY, "keep", "Gemini auth preserved");
-  assert.equal(out.PATH, "/usr/bin", "unrelated env preserved");
+  assert.equal(out.PATH, "/usr/bin", "PATH preserved");
+  assert.equal(out.HOME, "/Users/x", "HOME preserved");
+  assert.equal(out.LANG, "en_US.UTF-8", "locale preserved");
 });
 
 test("S4: buildSpawnCommand wraps in sandbox-exec on darwin read-only with sandbox-exec present", () => {

--- a/test/core-review-parse.test.js
+++ b/test/core-review-parse.test.js
@@ -156,3 +156,10 @@ test("RP-I5: continuation stops at a legacy same-line verdict line (not swallowe
   assert.deepEqual(r.criticalIssues, []);
   assert.equal(r.verdict, "APPROVE");
 });
+
+test("RP-V7: a bare token on a MIDDLE line (not first/last) does NOT hijack the verdict", () => {
+  assert.equal(parseReview("Some analysis here.\nAPPROVE\nMore detail follows.").verdict, null);
+  // first/last-line bare tokens still resolve:
+  assert.equal(parseReview("APPROVE\nrationale follows").verdict, "APPROVE");
+  assert.equal(parseReview("rationale first\nREJECT").verdict, "REJECT");
+});

--- a/test/core-sessions.test.js
+++ b/test/core-sessions.test.js
@@ -273,6 +273,34 @@ test("S17e: scrubSecrets redacts GitHub and AWS key shapes", () => {
   assert.ok(scrubSecrets(`id=${aws} x`).includes("[REDACTED]"));
 });
 
+test("S17f: scrubSecrets redacts URL-embedded credentials (password only)", () => {
+  const url = "postgres://user:supersecretpw@db.example.com/app";
+  const out = scrubSecrets(url);
+  assert.ok(out.includes("postgres://user:[REDACTED]@db.example.com"));
+  assert.equal(out.includes("supersecretpw"), false);
+});
+
+test("S17g: scrubSecrets redacts non-Bearer 'Token <value>' auth headers", () => {
+  // GitHub-style header with the literal "Token" scheme.
+  const ghHeader = "Authorization: Token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
+  const ghOut = scrubSecrets(ghHeader);
+  assert.ok(ghOut.includes("Token [REDACTED]"));
+  assert.equal(ghOut.includes("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"), false);
+  // A non-GitHub token value exercises the new Token rule (not the gh_ rule).
+  const opaque = "Token " + "A1b2C3d4E5f6G7h8I9j0KLMN"; // >= 20 chars, no gh_ prefix
+  const out = scrubSecrets(opaque);
+  assert.equal(out, "Token [REDACTED]");
+});
+
+test("S17h: scrubSecrets leaves credential-free URLs and emails intact", () => {
+  // No user:pass@ -> nothing to redact.
+  assert.equal(scrubSecrets("http://host/path?q=1"), "http://host/path?q=1");
+  // A bare email (no scheme, no password) must survive.
+  assert.equal(scrubSecrets("contact user@host.com today"), "contact user@host.com today");
+  // mailto: has no user:pass@ shape -> untouched.
+  assert.equal(scrubSecrets("mailto:user@host.com"), "mailto:user@host.com");
+});
+
 test("S17b: scrubSecrets does NOT corrupt normal words containing key-like substrings", () => {
   // "risk-analysis" contains "sk-analysis"; word-boundary anchors must spare it.
   assert.equal(scrubSecrets("risk-analysis and disk-space"), "risk-analysis and disk-space");

--- a/test/gemini-guard.test.js
+++ b/test/gemini-guard.test.js
@@ -1,0 +1,49 @@
+// test/gemini-guard.test.js
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { advisoryEnv, THREAD_ID_RE } = require("../server/gemini/index.js");
+
+test("GG1: advisoryEnv scrubs credential-shaped vars, keeps PATH/HOME/LANG", () => {
+  const env = {
+    XAI_API_KEY: "x",
+    AWS_SECRET_ACCESS_KEY: "y",
+    OPENAI_API_KEY: "z",
+    GOOGLE_APPLICATION_CREDENTIALS: "/path/creds.json",
+    GITHUB_TOKEN: "gh",
+    PATH: "/usr/bin",
+    HOME: "/Users/test",
+    LANG: "en_US.UTF-8",
+  };
+  const out = advisoryEnv(env);
+
+  // Credential-shaped + explicit denylist entry are gone.
+  assert.equal(out.XAI_API_KEY, undefined);
+  assert.equal(out.AWS_SECRET_ACCESS_KEY, undefined);
+  assert.equal(out.OPENAI_API_KEY, undefined);
+  assert.equal(out.GOOGLE_APPLICATION_CREDENTIALS, undefined);
+  assert.equal(out.GITHUB_TOKEN, undefined);
+
+  // Non-credential operational vars are preserved.
+  assert.equal(out.PATH, "/usr/bin");
+  assert.equal(out.HOME, "/Users/test");
+  assert.equal(out.LANG, "en_US.UTF-8");
+});
+
+test("GG2: advisoryEnv does not mutate the input env", () => {
+  const env = { XAI_API_KEY: "x", PATH: "/usr/bin" };
+  advisoryEnv(env);
+  assert.equal(env.XAI_API_KEY, "x");
+});
+
+test("GG3: THREAD_ID_RE accepts a well-formed conversation id", () => {
+  assert.equal(THREAD_ID_RE.test("abc-123_DEF"), true);
+});
+
+test("GG4: THREAD_ID_RE rejects flag-shaped, whitespace, empty, and oversized ids", () => {
+  assert.equal(THREAD_ID_RE.test("--sandbox"), false);
+  assert.equal(THREAD_ID_RE.test("-p"), false);
+  assert.equal(THREAD_ID_RE.test("a b"), false);
+  assert.equal(THREAD_ID_RE.test(""), false);
+  assert.equal(THREAD_ID_RE.test("a".repeat(200)), false);
+});

--- a/test/grok-cache.test.js
+++ b/test/grok-cache.test.js
@@ -80,6 +80,13 @@ test("writeCache is atomic — tmp file does not linger on success", () => {
   assert.deepEqual(tmps, [], "no .tmp.* leftover");
 });
 
+test("writeCache creates the cache file with 0600 permissions (owner-only)", () => {
+  const p = tmpCachePath();
+  cache.writeCache(p, { version: 1, entries: {} });
+  const mode = fs.statSync(p).mode & 0o777;
+  assert.equal(mode, 0o600, `cache file mode ${mode.toString(8)} should be 600`);
+});
+
 test("withInflight runs the worker once for concurrent same-key callers", async () => {
   let calls = 0;
   const work = () => new Promise((r) => setTimeout(() => { calls += 1; r("file_xyz"); }, 25));

--- a/test/grok-dir.test.js
+++ b/test/grok-dir.test.js
@@ -81,7 +81,7 @@ test("dir expansion errors when maxFiles is exceeded", async () => {
       roots: [root], cwd: root, cacheFile, cid: "test",
       fetchImpl: async () => ({ ok: true, text: async () => "{}" }),
     }),
-    /exceeds maxFiles=2/,
+    /exceeded maxFiles=2/,
   );
 });
 

--- a/test/grok-gc.test.js
+++ b/test/grok-gc.test.js
@@ -23,7 +23,8 @@ test("gc prunes local rows whose fileId is absent from remote list", async () =>
     },
   });
 
-  const fakeFetch = async () => ({ ok: true, text: async () => JSON.stringify({ data: [{ id: "file_alive", filename: "deliberation-foo", created_at: 1 }] }) });
+  let listOpts = null;
+  const fakeFetch = async (_url, opts) => { listOpts = opts; return { ok: true, text: async () => JSON.stringify({ data: [{ id: "file_alive", filename: "deliberation-foo", created_at: 1 }] }) }; };
 
   const result = await admin.gc({
     cacheFile: p,
@@ -32,6 +33,7 @@ test("gc prunes local rows whose fileId is absent from remote list", async () =>
     fetchImpl: fakeFetch,
   });
 
+  assert.equal(listOpts.redirect, "error", "listFiles GET must not follow redirects (token leak guard)");
   assert.equal(result.prunedLocal, 1);
   const data = cache.readCache(p);
   assert.ok(data.entries["K1"]);

--- a/test/grok-glob.test.js
+++ b/test/grok-glob.test.js
@@ -81,19 +81,27 @@ test("walk normalises backslashes to forward slashes in walked rel paths", () =>
   assert.deepEqual(out.files.map((f) => f.rel), ["sub/deep/x.tf"]);
 });
 
-test("walk throws when maxFiles exceeded with counts", () => {
+test("walk throws when maxFiles exceeded", () => {
   const root = makeTree({ "a.tf": "1", "b.tf": "2", "c.tf": "3" });
   assert.throws(
     () => glob.walk(root, { include: ["**/*"], exclude: [], maxFiles: 2, maxBytes: 1024 }),
-    /selected 3 files.*exceeds maxFiles=2/,
+    /exceeded maxFiles=2/,
   );
 });
 
-test("walk throws when maxBytes exceeded with counts", () => {
+test("walk throws when maxBytes exceeded", () => {
   const root = makeTree({ "a.tf": "x".repeat(60), "b.tf": "y".repeat(60) });
   assert.throws(
     () => glob.walk(root, { include: ["**/*"], exclude: [], maxFiles: 100, maxBytes: 100 }),
-    /exceeds maxBytes=100/,
+    /exceeded maxBytes=100/,
+  );
+});
+
+test("walk throws early inside descend once maxFiles is exceeded (does not exhaust the tree first)", () => {
+  const root = makeTree({ "a.tf": "1", "b.tf": "2", "c.tf": "3", "d.tf": "4" });
+  assert.throws(
+    () => glob.walk(root, { include: ["**"], exclude: [], maxFiles: 1, maxBytes: 1024 * 1024 }),
+    /exceeded maxFiles=1/,
   );
 });
 

--- a/test/grok-lock.test.js
+++ b/test/grok-lock.test.js
@@ -22,6 +22,15 @@ test("acquire creates lockDir with unique owner marker", () => {
   lock.release(handle);
 });
 
+test("acquire writes the owner marker with 0600 permissions", () => {
+  const base = tmpLockBase();
+  const handle = lock.acquire(base, { maxWaitMs: 100 });
+  assert.ok(handle, "lock acquired");
+  const mode = fs.statSync(handle.markerPath).mode & 0o777;
+  assert.equal(mode, 0o600, `marker mode ${mode.toString(8)} should be 600`);
+  lock.release(handle);
+});
+
 test("acquire returns null when lock already held and not stale", () => {
   const base = tmpLockBase();
   const h1 = lock.acquire(base, { maxWaitMs: 50 });

--- a/test/grok.test.js
+++ b/test/grok.test.js
@@ -328,13 +328,16 @@ test("G12: validateFiles enforces exactly-one-of and types", () => {
 
 test("G13: runGrok posts to /responses via injected fetch (success, http error, missing key)", async () => {
   let calledUrl = null;
-  const okFetch = async (url) => {
+  let calledOpts = null;
+  const okFetch = async (url, opts) => {
     calledUrl = url;
+    calledOpts = opts;
     return { ok: true, status: 200, text: async () => JSON.stringify({ output: [{ content: [{ type: "output_text", text: "ok" }] }] }) };
   };
   const out = await grok.runGrok({ turns: [{ role: "user", text: "x", fileRefs: [] }], apiKey: "k", apiBase: "https://api.x.ai/v1", fetchImpl: okFetch });
   assert.equal(out.text, "ok");
   assert.match(calledUrl, /\/responses$/);
+  assert.equal(calledOpts.redirect, "error", "redirect:error prevents the bearer token following a 3xx to another host");
 
   const errFetch = async () => ({ ok: false, status: 500, text: async () => "boom" });
   await assert.rejects(grok.runGrok({ turns: [], apiKey: "k", fetchImpl: errFetch }), (e) => e.status === 500);

--- a/test/openrouter.test.js
+++ b/test/openrouter.test.js
@@ -45,6 +45,19 @@ test("O2: callOpenRouter posts chat/completions and returns assistant text", asy
   } finally { server.close(); }
 });
 
+test("O2b: callOpenRouter sets redirect:error so the bearer token cannot follow a 3xx to another host", async () => {
+  let opts = null;
+  const fetchImpl = async (_url, o) => {
+    opts = o;
+    return { ok: true, status: 200, text: async () => JSON.stringify({ choices: [{ message: { content: "ok" } }] }) };
+  };
+  await callOpenRouter({
+    apiBase: "https://example.test/v1", apiKey: "sk-secret", model: "m",
+    messages: buildMessages([{ role: "user", text: "q" }]), fetchImpl,
+  });
+  assert.equal(opts.redirect, "error");
+});
+
 test("O3: empty key sends NO Authorization header (keyless local endpoints)", async () => {
   let auth = "unset";
   const { server, base } = await startMock((req, res) => {


### PR DESCRIPTION
## Summary

A read-only security audit of the provider bridges surfaced a set of cheap, high-value hardening items. This PR implements the "unconditional wins" (pure upside, no behavior change on the happy path) plus two follow-ups. Each fix is grounded in a real code path; deferred items are listed at the bottom.

### Fixes

1. **Private file permissions** (`server/grok/cache.js`, `server/grok/lock.js`) - the Grok upload cache + lock files (xAI `file_id`s + a key fingerprint) were created world-readable (644). Now written `{ mode: 0o600 }`, matching the session store. Verified 0600 end-to-end on the real cache file.
2. **Redirect guard** (`server/grok/index.js`, `server/grok/files-admin.js`, `server/openrouter/index.js`) - every outbound fetch carries `Authorization: Bearer <key>`; Node `fetch` follows 3xx by default, so a redirect could re-send the token to another host (e.g. cloud IMDS). All five bearer-carrying call sites now set `redirect: "error"`. 2xx happy path is unaffected.
3. **Glob DoS bound** (`server/grok/glob.js`) - `{dir}` expansion enforced `maxFiles`/`maxBytes` only after a full recursive walk. Now throws early inside the descent, bounding the walk.
4. **Advisory env scrub + threadId validation** (`server/gemini/index.js`) - advisory `agy` runs read-only for files but with an open network, inheriting every API key in the process env. `advisoryEnv` now strips credential-shaped vars (denylist-by-shape; keeps PATH/HOME/TMPDIR/locale/`~/.gemini` OAuth). The `--conversation` `threadId` (and the agy-file-sourced conversation id) are now charset-validated, blocking a leading-dash value from being parsed as an agy flag.
5. **Session-store scrub gaps** (`core/sessions.js`) - `scrubSecrets` now also redacts URL-embedded credentials (`scheme://user:SECRET@host`, password only) and `Token <value>` auth headers.

### Invariants preserved

Zero new runtime deps; `parseReview` still never throws; all regexes linear (no ReDoS); the env scrub touches only advisory (read-only) runs and no var `agy` needs; redirect guard leaves the success path untouched.

Also includes a follow-up to the recently-merged parse work: `parseReview` verdict tier (d) (bare standalone token) is now restricted to the first/last non-empty line, so a stray mid-body `APPROVE` in a reply body can no longer hijack the consensus verdict.

## Test Plan

- [x] `npm run check` (typecheck + full suite) green with the sandbox disabled - 548/548. Under the command sandbox the ~11 `listen EPERM` failures are loopback socket-bind tests in the Grok/OpenRouter HTTP-bridge suites, unrelated to this change.
- [x] New tests per fix: 0600 perm assertions (cache + lock), `redirect: "error"` assertions (grok + openrouter mocks), glob early-exit throw, `advisoryEnv` scrub + `THREAD_ID_RE` accept/reject, URL/Token scrub, `parseReview` mid-line-token rejection (RP-V7).
- [x] End-to-end perm spot check: a freshly written Grok cache file is `-rw-------`.

## Known non-blocking follow-ups (from the final review)

- The `Token` scrub is capital-only (mirrors the deliberate `Bearer` rule that avoids matching the prose word). GitHub `ghp_`-style tokens are caught case-insensitively by the dedicated key rule regardless; the residual gap is a non-prefixed opaque token behind a lowercase `token` scheme on the opt-in session store.
- Two of the five `redirect: "error"` sites (grok `uploadFile`, `deleteFile`) carry the literal but lack a dedicated test assertion.

## Out of scope (deferred)

Config-trust defense-in-depth (`apiKeyEnv` allowlist, `apiBase` https+domain allowlist, `debug.path` validation) and `file_url`/`model` slug validation - these sit behind the operator-owned config file, which is already a local trust boundary.