### PR TITLE
refactor: code-quality cleanups (prompt SSOT, glob cap collapse, verdict types, scrub-list clarity)

### DIFF
--- a/core/consensus-loop.js
+++ b/core/consensus-loop.js
@@ -22,6 +22,17 @@ const MAX_ROUNDS_DEFAULT = 5;
 const VERDICTS = Object.freeze(["APPROVE", "REQUEST_CHANGES", "REJECT"]);
 
 /**
+ * The wire-format mandate appended verbatim to BOTH the peer and blind review
+ * prompts. SSOT: parseReview (core/provider.js) parses exactly this shape
+ * (a `VERDICT: <token>` sentinel line + `- [category] description` issue lines,
+ * categories == REVIEW_CATEGORIES). Edit here only; the two prompts MUST stay
+ * byte-identical in this suffix or peer/blind replies diverge and the single
+ * parser silently mis-handles one path.
+ */
+const REVIEW_FORMAT_INSTRUCTION =
+  "End with a line by itself in exactly this form (no markdown, token on the SAME line): VERDICT: APPROVE   (or VERDICT: REQUEST_CHANGES, or VERDICT: REJECT). Then list any critical issues, one per line as: - [category] description   where category is one of security, correctness, scope, ambiguity, performance, ops.";
+
+/**
  * @typedef {Object} CriticalIssue
  * @property {("security"|"correctness"|"scope"|"ambiguity"|"performance"|"ops")} category
  * @property {string} description
@@ -136,12 +147,12 @@ function prepareRound(state) {
   const peerPrompt = [
     body,
     "Review the plan for correctness, security, scope, ambiguity, performance, and ops gaps.",
-    "End with a line by itself in exactly this form (no markdown, token on the SAME line): VERDICT: APPROVE   (or VERDICT: REQUEST_CHANGES, or VERDICT: REJECT). Then list any critical issues, one per line as: - [category] description   where category is one of security, correctness, scope, ambiguity, performance, ops.",
+    REVIEW_FORMAT_INSTRUCTION,
   ].join("\n\n");
   const blindPrompt = [
     body,
     "Give your own independent verdict BEFORE seeing peer opinions.",
-    "End with a line by itself in exactly this form (no markdown, token on the SAME line): VERDICT: APPROVE   (or VERDICT: REQUEST_CHANGES, or VERDICT: REJECT). Then list any critical issues, one per line as: - [category] description   where category is one of security, correctness, scope, ambiguity, performance, ops.",
+    REVIEW_FORMAT_INSTRUCTION,
   ].join("\n\n");
   return { peerPrompt, blindPrompt };
 }

--- a/core/provider.js
+++ b/core/provider.js
@@ -276,8 +276,12 @@ const ARTIFACT_RE = /^[*_`~\s:.\-]*$/;                     // empty or only mark
 const STRIP_LEAD = /^[*_`~\s:.\-]+/;                       // leading noise to trim off a description
 const STRIP_TRAIL = /[*_`~\s]+$/;                          // trailing emphasis to trim
 const HEADING_RE = /^#{1,6}\s/;
-/** Normalize a verdict token: "REQUEST CHANGES" -> "REQUEST_CHANGES", upper-cased. */
-function normVerdict(/** @type {string} */ tok) { return tok.replace(/\s+/g, "_").toUpperCase(); }
+/**
+ * Normalize a verdict token: "REQUEST CHANGES" -> "REQUEST_CHANGES", upper-cased.
+ * @param {string} tok
+ * @returns {Exclude<ParsedReview["verdict"], null>}
+ */
+function normVerdict(tok) { return /** @type {any} */ (tok.replace(/\s+/g, "_").toUpperCase()); }
 
 /**
  * Parse a consensus REVIEW reply into a verdict + categorized critical issues.
@@ -318,16 +322,16 @@ function parseReview(text) {
  */
 function resolveVerdict(lines) {
   // a) explicit machine-readable sentinel: `VERDICT: APPROVE`
-  for (const ln of lines) { const m = ln.match(SENTINEL_RE); if (m) return /** @type {any} */ (normVerdict(m[1])); }
+  for (const ln of lines) { const m = ln.match(SENTINEL_RE); if (m) return normVerdict(m[1]); }
   // b) keyword + token on the same line (legacy shape; the reviewer's own verdict)
-  for (const ln of lines) { const m = ln.match(VERDICT_RE); if (m) return /** @type {any} */ (normVerdict(m[1])); }
+  for (const ln of lines) { const m = ln.match(VERDICT_RE); if (m) return normVerdict(m[1]); }
   // c) heading-split: a "Verdict" heading line, then a bare token within the next 3 non-empty lines
   for (let i = 0; i < lines.length; i++) {
     if (!VERDICT_WORD_RE.test(lines[i].trim())) continue;
     for (let j = i + 1; j < lines.length && j <= i + 3; j++) {
       const t = lines[j].replace(MD_EMPHASIS, "").trim();
       if (!t) continue;
-      if (TOKEN_LINE_RE.test(t)) return /** @type {any} */ (normVerdict(t));
+      if (TOKEN_LINE_RE.test(t)) return normVerdict(t);
       break; // first non-empty line under the heading was not a token -> stop
     }
   }
@@ -335,7 +339,7 @@ function resolveVerdict(lines) {
   //    stray mid-body token (e.g. an "APPROVE" heading in an example) cannot hijack.
   const nonEmpty = lines.map((l) => l.replace(MD_EMPHASIS, "").trim()).filter((t) => t !== "");
   for (const t of [nonEmpty[0], nonEmpty[nonEmpty.length - 1]]) {
-    if (t && TOKEN_LINE_RE.test(t)) return /** @type {any} */ (normVerdict(t));
+    if (t && TOKEN_LINE_RE.test(t)) return normVerdict(t);
   }
   return null;
 }

--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -92,7 +92,10 @@ function buildAgyArgs(req) {
 // Credentials an advisory delegate has no need for but could use to push or
 // exfiltrate over the (intentionally open) network. Scrubbed from the child env
 // on read-only runs. agy's own Gemini auth lives in ~/.gemini, not these vars.
-const ADVISORY_ENV_SCRUB = ["GITHUB_TOKEN", "GH_TOKEN", "GIT_ASKPASS", "SSH_AUTH_SOCK"];
+// These two are NOT name-shape-visible to CREDENTIAL_NAME_RE (no _KEY/_TOKEN/_SECRET/
+// PASSWORD suffix) but still hand sensitive material to a child, so they must be
+// scrubbed explicitly. Do NOT fold this list into the regex — that would re-leak them.
+const ADVISORY_ENV_SCRUB = ["GIT_ASKPASS", "SSH_AUTH_SOCK"];
 // Strip any var whose NAME looks like a credential (advisory agy has open network
 // and no need for the operator's keys). Denylist-by-shape, not a pass-allowlist:
 // agy still needs PATH/HOME/TMPDIR/locale + its own ~/.gemini auth (not an env var).

--- a/server/grok/glob.js
+++ b/server/grok/glob.js
@@ -78,6 +78,13 @@ function walk(rootAbs, { include, exclude, maxFiles, maxBytes }) {
     return false;
   }
 
+  function pushFile(rel, abs, size) {
+    files.push({ rel, abs, size });
+    totalBytes += size;
+    if (files.length > maxFiles) throw new Error(`directory expansion exceeded maxFiles=${maxFiles}. Narrow include or raise the limit.`);
+    if (totalBytes > maxBytes) throw new Error(`directory expansion exceeded maxBytes=${maxBytes} bytes. Narrow include or raise the limit.`);
+  }
+
   function descend(absDir, relDir) {
     let entries;
     try { entries = fs.readdirSync(absDir, { withFileTypes: true }); }
@@ -99,10 +106,7 @@ function walk(rootAbs, { include, exclude, maxFiles, maxBytes }) {
         if (!st.isFile()) continue;
         if (matches(excludeRes, relPosix)) continue;
         if (!matches(includeRes, relPosix)) continue;
-        files.push({ rel: relPosix, abs: realTarget, size: st.size });
-        totalBytes += st.size;
-        if (files.length > maxFiles) throw new Error(`directory expansion exceeded maxFiles=${maxFiles}. Narrow include or raise the limit.`);
-        if (totalBytes > maxBytes) throw new Error(`directory expansion exceeded maxBytes=${maxBytes} bytes. Narrow include or raise the limit.`);
+        pushFile(relPosix, realTarget, st.size);
       } else if (ent.isDirectory()) {
         if (matches(excludeRes, relPosix) || matches(excludeRes, relPosix + "/**")) continue;
         descend(absChild, relPosix);
@@ -111,25 +115,12 @@ function walk(rootAbs, { include, exclude, maxFiles, maxBytes }) {
         if (!matches(includeRes, relPosix)) continue;
         let st;
         try { st = fs.statSync(absChild); } catch (_) { continue; }
-        files.push({ rel: relPosix, abs: absChild, size: st.size });
-        totalBytes += st.size;
-        if (files.length > maxFiles) throw new Error(`directory expansion exceeded maxFiles=${maxFiles}. Narrow include or raise the limit.`);
-        if (totalBytes > maxBytes) throw new Error(`directory expansion exceeded maxBytes=${maxBytes} bytes. Narrow include or raise the limit.`);
+        pushFile(relPosix, absChild, st.size);
       }
     }
   }
 
   descend(rootAbs, "");
-
-  // Defensive backstop: descend() already throws early (mid-walk) the moment a
-  // cap is exceeded, so these post-loop checks are normally unreachable. Kept
-  // belt-and-suspenders in case a future refactor drops an inner check.
-  if (files.length > maxFiles) {
-    throw new Error(`directory expansion selected ${files.length} files; exceeds maxFiles=${maxFiles}. Narrow include or raise the limit.`);
-  }
-  if (totalBytes > maxBytes) {
-    throw new Error(`directory expansion selected ${totalBytes} bytes; exceeds maxBytes=${maxBytes}. Narrow include or raise the limit.`);
-  }
 
   files.sort((a, b) => a.rel.localeCompare(b.rel, "en"));
   return { files, totalBytes };

--- a/test/core-consensus-loop.test.js
+++ b/test/core-consensus-loop.test.js
@@ -139,6 +139,15 @@ test("L11: prepareRound returns peer + blind prompts that include the current pl
   assert.ok(/round 1/i.test(peerPrompt));
 });
 
+test("L11b: peer and blind prompts share the byte-identical VERDICT-format mandate", () => {
+  const s = initConsensusLoop({ plan: "ship the widget", arbiterMode: "host" });
+  const { peerPrompt, blindPrompt } = prepareRound(s);
+  const grab = (/** @type {string} */ p) => p.slice(p.indexOf("End with a line by itself"));
+  assert.equal(grab(peerPrompt), grab(blindPrompt));
+  assert.match(peerPrompt, /VERDICT: APPROVE/);
+  assert.match(blindPrompt, /- \[category\] description/);
+});
+
 test("L12: full happy path - converge in round 1 yields a final report + high confidence", () => {
   let s = initConsensusLoop({ plan: "p", arbiterMode: "host" });
   s = recordBlindVerdict(s, "looks good");

--- a/test/redirect-invariant.test.js
+++ b/test/redirect-invariant.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Bridge files that make outbound HTTP via `f(url, opts)` (f = fetchImpl || globalThis.fetch).
+const FILES = ["server/grok/index.js", "server/grok/files-admin.js", "server/openrouter/index.js"];
+
+test("every outbound bridge fetch sets redirect:error (no bearer token follows a 3xx)", () => {
+  for (const rel of FILES) {
+    const src = fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+    // Count actual outbound invocations: `await f(` is the fetch call shape in all
+    // three bridges. The assignment line `const f = fetchImpl || globalThis.fetch`
+    // is NOT an invocation and is not matched here.
+    const invocations = (src.match(/\bawait f\(/g) || []).length;
+    const guarded = (src.match(/redirect:\s*["']error["']/g) || []).length;
+    assert.ok(invocations > 0, `${rel}: expected at least one outbound fetch`);
+    assert.equal(
+      guarded,
+      invocations,
+      `${rel}: ${invocations} fetch invocation(s) but ${guarded} redirect:error guard(s) — a fetch is missing redirect:"error"`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Behavior-preserving cleanups surfaced by a deep code-quality pass over the recent parse-robustness (#136) and security-hardening (#138) work. No functional change - every commit is output-identical and tests prove it. `refactor:`-only, so no release bump.

1. **One SSOT for the review-format mandate** (`core/consensus-loop.js`) - the `VERDICT:`/`- [category] description` instruction was copy-pasted byte-identically into both `peerPrompt` and `blindPrompt`. It is the sole producer of the wire format `parseReview` is the sole consumer of, and nothing pinned the equality - a future edit to one path would silently diverge peer-vs-blind reviewers without throwing. Extracted to a single `REVIEW_FORMAT_INSTRUCTION` const + a test asserting both prompts share the identical suffix.
2. **Collapse the glob cap enforcement** (`server/grok/glob.js`) - #138 added early-exit `maxFiles`/`maxBytes` checks but kept the now-unreachable post-loop backstop, leaving the cap enforced in three places with near-duplicate messages. Collapsed into one `pushFile()` closure called from both descent branches; deleted the backstop. Same throw points, ordering, and messages (net -9 lines).
3. **Type `normVerdict` to the verdict union** (`core/provider.js`) - moved a single `any` cast into `normVerdict` (typed to the non-null verdict union) and deleted the call-site casts in `resolveVerdict`, so the tier returns read cleanly. Pure type change, typecheck stays clean.
4. **Clarify the advisory env scrub + lock the redirect invariant** (`server/gemini/index.js`, new `test/redirect-invariant.test.js`) - `GITHUB_TOKEN`/`GH_TOKEN` are now caught by the credential-shape regex, so `ADVISORY_ENV_SCRUB` was trimmed to the two names the regex can't see (`GIT_ASKPASS`, `SSH_AUTH_SOCK`) with a comment explaining why they must stay explicit (folding them into the regex would re-leak the SSH agent socket + git credential helper). Added a tripwire test asserting every bridge outbound fetch carries `redirect: "error"` - the proportionate guard for that invariant instead of a shared HTTP wrapper (rejected as over-fit: the five call sites share only a one-word invariant but differ in body, abort handling, and error taxonomy across two zero-dep legacy modules).

## Test Plan

- [x] `npm run check` green with the sandbox disabled - 550/550 (+1 from the new invariant test), typecheck clean. The ~11 sandboxed `listen EPERM` failures are loopback socket-bind tests in the HTTP-bridge suites, unrelated.
- [x] Behavior-preservation verified per change: prompt extraction is byte-identical (programmatic 314-char equality); glob keeps identical throw points/messages; `normVerdict` is a pure type change; env-scrub trim confirmed to still scrub `GITHUB_TOKEN`/`GH_TOKEN` via the regex.

## Not done (deliberately rejected in review)

- A shared `secureFetch` wrapper for the 5x `redirect:error` (over-fit; tripwire test instead).
- Converting the `scrubSecrets` `.replace` chain to a rule table (a wash; only worth it alongside per-pattern false-positive tests).
- Collapsing the 4-tier verdict ladder (irreducible - each tier guards a distinct real reply shape).