### PR TITLE
ci: add Renovate (weekly, 7-day cooldown) + close the esbuild CI gap

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run bridge tests
         run: node --test test/*.test.js
 
+      - name: Build published bundle (esbuild prepack smoke)
+        run: npm run prepack --workspace=server/mcp
+
       - name: Check generated artifacts in sync
         run: npm run sync:check
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["npm", "github-actions"],
+  "timezone": "Etc/UTC",
+  "schedule": ["before 6am on monday"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "rangeStrategy": "bump",
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "automerge": false,
+  "dependencyDashboard": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Group non-major npm devDependency updates into one PR",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm devDependencies (non-major)"
+    },
+    {
+      "description": "Isolate npm major updates for careful manual review",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    },
+    {
+      "description": "Group non-major GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions (non-major)"
+    },
+    {
+      "description": "Isolate GitHub Actions major updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds automated weekly dependency updates via Renovate, configured so a **green Renovate PR is safe to merge by hand**. Design validated by a 4-model `/ask-all` (Architect) which reached unanimous agreement and surfaced one real gap (esbuild), closed here.

### `renovate.json` (root)
- **Weekly** schedule (`before 6am on monday`) + weekly `lockFileMaintenance`.
- **1-week cool-down**: `minimumReleaseAge: "7 days"` + `internalChecksFilter: "strict"` - a freshly published (or yanked) version never reaches a PR until it has aged 7 days.
- **No accidental releases**: `semanticCommitType: "chore"` + scope `deps` -> `chore(deps):` commits, which the conventional-commits release automation treats as non-releasing. (A `fix:`/`feat:` dep commit would otherwise cut a release.)
- **CI tests the adopted version**: `rangeStrategy: "bump"` advances the manifest range + lockfile together.
- Grouped non-major npm devDeps and non-major Actions into single PRs; majors isolated for individual review.
- `automerge: false` - every PR is merged by the maintainer. `dependencyDashboard: true` for visibility.
- Scoped to the only two managers present (`npm`, `github-actions`). Never touches `version` fields, so the version-sync gate stays green inherently (no `bumpVersion`).

Validated with `renovate-config-validator` (Config validated successfully).

### `validate.yml` - close the esbuild gap
`esbuild` (the published bundler in `server/mcp`) was only ever run at `prepack`/publish, never by `npm run check` - so a green PR did not prove an esbuild bump still bundles. Added one step that runs `npm run prepack --workspace=server/mcp` on every PR. It builds the gitignored `dist/` (no effect on `sync:check` or version-sync) and fails the PR if the bundle breaks. With this, a green Renovate PR covers every dependency class.

## Maintainer action required (cannot be automated)

Renovate runs as a hosted GitHub App - install it once at https://github.com/apps/renovate and select this repo. Once this PR is on `master` and the App is installed, Renovate posts the Dependency Dashboard issue and starts the weekly cadence.

## Test Plan

- [x] `renovate.json` passes the official `renovate-config-validator`.
- [x] `npm run prepack --workspace=server/mcp` builds `dist/index.js` + `dist/setup.js` locally (proves the new CI step passes).
- [x] This PR's own `validate` run exercises the new esbuild step end-to-end - a green check here confirms it works in CI before merge.

## Notes / deferred

- Considered and rejected: self-hosted Renovate (adds a token + workflow + scheduling failure modes for no benefit on a public repo) and automerge (maintainer merges all green PRs).
- Out of scope: a Node 18/20 test matrix (CI tests only Node 20 while the package engine is `>=18`). Real but pre-existing and broader than Renovate; revisit if a Node-18 break ever occurs.