### PR TITLE
fix(core): cap peer opinions in arbiter + adjudication prompts

### DIFF
--- a/core/orchestrate.js
+++ b/core/orchestrate.js
@@ -140,6 +140,22 @@ async function askOne(provider, req, opts = {}) {
   return callProvider(provider, req, opts.logger || NULL_LOGGER, opts.tool || "ask-one", opts.cache, opts.orientationFiles);
 }
 
+// Per-opinion cap for the arbiter prompt. The arbiter inlines every peer opinion
+// into ONE prompt, so worst-case size is (peers x opinion length). Cap each block
+// so one rambly model can't blow the arbiter's context or crowd out the others.
+// ~2k chars keeps a full verdict + rationale while bounding the total.
+const MAX_PEER_OPINION_CHARS = 2000;
+
+/**
+ * Cap a peer opinion's text for inlining, appending a marker when truncated.
+ * @param {string} text
+ * @returns {string}
+ */
+function capPeerOpinion(text) {
+  if (typeof text !== "string" || text.length <= MAX_PEER_OPINION_CHARS) return text;
+  return text.slice(0, MAX_PEER_OPINION_CHARS) + "\n...[truncated]";
+}
+
 /**
  * Assemble the arbiter prompt from independent opinions for blind cross-review.
  * @param {string} question
@@ -149,8 +165,9 @@ async function askOne(provider, req, opts = {}) {
 function buildArbiterPrompt(question, opinions) {
   // Labels are anonymized (### Opinion N, no provider name) so the arbiter
   // judges substance, not source reputation. The opinions array returned to the
-  // caller keeps provider names; only this prompt is anonymized.
-  const blocks = opinions.map((o, i) => `### Opinion ${i + 1}\n${o.text}`).join("\n\n");
+  // caller keeps provider names; only this prompt is anonymized. Each opinion is
+  // capped (MAX_PEER_OPINION_CHARS) so the combined prompt stays bounded.
+  const blocks = opinions.map((o, i) => `### Opinion ${i + 1}\n${capPeerOpinion(o.text)}`).join("\n\n");
   return [
     "You are the arbiter. Below are independent expert opinions on the same question.",
     "Cross-review them: note where they agree, where they disagree, and which view is best supported.",
@@ -233,7 +250,9 @@ function buildAdjudicationPrompt(state, results) {
   const peerBlocks = results.map((r) => {
     if (r.isError) return `Peer ${r.source}: ERRORED`;
     const issues = (r.criticalIssues || []).map((i) => `  - [${i.category}] ${i.description}`).join("\n");
-    return `Peer ${r.source}: ${r.verdict || "UNKNOWN"}${issues ? "\n" + issues : ""}`;
+    // Cap each peer block (same bound as buildArbiterPrompt): a peer with many
+    // long issue descriptions must not blow the arbiter's per-round context.
+    return capPeerOpinion(`Peer ${r.source}: ${r.verdict || "UNKNOWN"}${issues ? "\n" + issues : ""}`);
   }).join("\n");
   return [
     "ADJUDICATE the peer reviews below and give ONE overall verdict.",
@@ -363,4 +382,4 @@ async function runToConvergence(providers, req, opts = {}) {
   };
 }
 
-module.exports = { askAll, askOne, consensus, buildArbiterPrompt, runToConvergence };
+module.exports = { askAll, askOne, consensus, buildArbiterPrompt, buildAdjudicationPrompt, runToConvergence };

--- a/test/core-orchestrate.test.js
+++ b/test/core-orchestrate.test.js
@@ -2,7 +2,7 @@
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { askAll, askOne, consensus, buildArbiterPrompt, runToConvergence } = require("../core/orchestrate.js");
+const { askAll, askOne, consensus, buildArbiterPrompt, buildAdjudicationPrompt, runToConvergence } = require("../core/orchestrate.js");
 /** @typedef {import("../core/types.js").Provider} Provider */
 
 /** @param {string} name @param {string} [behavior] @returns {Provider} */
@@ -145,6 +145,33 @@ test("C6: buildArbiterPrompt anonymizes opinion labels (no provider names leak)"
   }
   // bodies and the original question are preserved
   assert.match(prompt, /the question/);
+});
+
+test("C6b: buildArbiterPrompt caps an over-long opinion and marks it; short ones untouched", () => {
+  const long = "x".repeat(5000);
+  const opinions = /** @type {any} */ ([
+    { provider: "codex", text: long },
+    { provider: "gemini", text: "short body" },
+  ]);
+  const prompt = buildArbiterPrompt("q", opinions);
+  // long opinion is truncated to the cap + marker, not inlined whole
+  assert.equal(prompt.includes("x".repeat(5000)), false, "uncapped long opinion leaked into prompt");
+  assert.match(prompt, /x{2000}\n\.\.\.\[truncated\]/);
+  // short opinion is left exactly as-is (no marker)
+  assert.match(prompt, /### Opinion 2\nshort body/);
+  assert.equal((prompt.match(/\[truncated\]/g) || []).length, 1);
+});
+
+test("C6c: buildAdjudicationPrompt caps a peer block with many long issues", () => {
+  const issues = Array.from({ length: 50 }, (_, i) => ({ category: "bug", description: "y".repeat(100) + i }));
+  const results = /** @type {any} */ ([
+    { source: "codex", isError: false, verdict: "REJECT", criticalIssues: issues },
+    { source: "gemini", isError: false, verdict: "APPROVE", criticalIssues: [] },
+  ]);
+  const prompt = buildAdjudicationPrompt({ currentPlan: "the plan" }, results);
+  assert.match(prompt, /\.\.\.\[truncated\]/); // the verbose peer was capped
+  assert.match(prompt, /Peer gemini: APPROVE/); // the short peer is intact
+  assert.match(prompt, /the plan/);
 });
 
 /** A provider that records the req it was asked with. @param {string} name @param {boolean|undefined} walks */


### PR DESCRIPTION
## What

The arbiter inlines **every** peer opinion into one prompt - cost is `peers x opinion_length x rounds`. Un-truncated, one verbose model (or a multi-issue review with code) could blow the arbiter's context window, inflate token cost, and bias the arbiter toward the longest voice rather than the best-supported one.

Adds `MAX_PEER_OPINION_CHARS = 2000` (~500 tokens) + a `capPeerOpinion()` helper, applied in **both** arbiter-facing assemblers in `core/orchestrate.js`:

- `buildArbiterPrompt` - caps each inlined opinion.
- `buildAdjudicationPrompt` - caps each per-peer `verdict + issues` block (the provider-arbiter convergence loop).

Truncated blocks get a `...[truncated]` marker.

## Why 2000

~500 tokens/opinion. At 4-5 peers the arbiter prompt's peer text is bounded at ~2.5k tokens vs ~20k worst-case uncapped. Conservative but safe; matches the planned spec. Single named constant - bump to 3000-4000 if dense reviews ever need more headroom.

## Does it lose value?

Only for the **arbiter's input**, and only on opinions >2000 chars (tail clipped). Crucially, the cap trims **only** the arbiter prompt - the **full** opinion text is still returned to the caller and written to the session record, so nothing is lost from the user-facing output or the audit trail.

## Test plan

- [x] `npm run check` green (559/559; +C6b arbiter cap, +C6c adjudication cap)
- [x] short opinions pass through untouched (no marker)
- [x] over-long opinion truncated to cap + exactly one marker

Independent of #143 (different files).