### PR TITLE
feat(commands): /deliberation:help + /deliberation:doctor + analyze drift diagnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 |-----------|---------|-------|
 | `rules/*.md` | When/how to delegate | Installed to `~/.claude/rules/deliberation/` |
 | `prompts/*.md` | Expert personalities | Injected via `developer-instructions` |
-| `commands/*.md` | Slash commands | `/setup`, `/uninstall` |
+| `commands/*.md` | Slash commands | `/setup`, `/uninstall`, `/help`, `/doctor`, `/analyze` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
 | `config/config.schema.json` | JSON Schema (in `config/`) | Validates `config.json` in editors (VS Code built-in JSON support, no extension); `.vscode/` wires it for in-repo example configs |
 | `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote` + `maxRounds`: the loop cap, default 5, clamped to 50), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off; single `schemaVersion:1` stamp), `debug` (opt-in debug log: `enabled`/`path`, default off - see Observability), `orientation` (opt-in auto-attach of a repo bundle to file-blind providers: `enabled`/`maxFiles`, default off - see Key Design Decisions #8). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Bundled with the plugin (available once installed):
 | Command | Purpose |
 |---------|---------|
 | `/deliberation:setup` | Configure Codex/Gemini/Grok/OpenRouter MCP servers + orchestration rules |
+| `/deliberation:help` | How to use deliberation on your host, with paste-ready example prompts |
+| `/deliberation:doctor` | Health check (config, provider CLIs, sessions/debug, path drift) with fixes; read-only |
 | `/deliberation:consensus` | 🔥🔥🔥 Arbiter-mediated GPT + Gemini + Grok + Claude convergence loop |
 | `/deliberation:ask-all` | 🔥 GPT + Gemini + Grok (+ configured OpenRouter models) in parallel, synthesized |
 | `/deliberation:ask-gpt` | One-shot GPT (Codex) second opinion |

--- a/commands/analyze.md
+++ b/commands/analyze.md
@@ -57,6 +57,18 @@ correlated by timestamp:
    `provider | model | votes | agreement % | abstained`, least-agreeing first.
    Note that abstain-only models (ask-all runs have no verdict) carry no signal.
 
+   **When Lens B is empty, say WHY** (use the `meta` fields - do not guess):
+   - `sessionsPersist` is false -> persistence is off; enable `sessions.persist: true`.
+   - `sessionsPersist` true but `sessionsRead` is 0 -> the server read no records from
+     `meta.sessionsDir`. Either nothing has run yet, OR the running server resolved a
+     different sessions dir than where records were written (an `XDG_CACHE_HOME` /
+     `DELIBERATION_SESSIONS` drift). Print `meta.sessionsDir` and point to
+     `/deliberation:doctor`, which compares it to the shell-resolved path.
+   - `sessionsRead` > 0 but `meta.agreementVotes` is 0 -> records exist but none carry a
+     per-opinion verdict (they are old records or `ask-all` runs, which have no verdict).
+     Tell the user to run a fresh `/consensus` to populate Lens B - the data is not lost,
+     it just predates verdict capture / wasn't a consensus run.
+
 5. **Render keep/cut candidates** from `outliers` + `recommendations`. For each
    recommendation print its `action` and `rationale`. Separate the two targets:
    - `target: "deliberation"` -> show the exact `config.json` edit

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,0 +1,139 @@
+---
+name: doctor
+description: Check deliberation's health - config, provider CLIs, sessions/debug, and path drift - and suggest fixes. Read-only; never changes anything.
+allowed-tools: Bash, Read, mcp__deliberation__analyze
+timeout: 60000
+---
+
+# Doctor
+
+A quick health check for deliberation. It looks at what is actually set up on
+this machine - your config, the provider CLIs, the session store - and tells you
+what is fine, what is off, and the exact command to fix each problem.
+
+It never changes anything. Every fix is yours to run.
+
+## How it works
+
+Two steps in order:
+
+1. **One Bash call** - all the local checks (config, CLIs, keys, sessions dir,
+   stale registrations). Run it with the **sandbox disabled** - it reads
+   `~/.claude.json`, `~/.config`, and `~/.cache`, which a sandbox blocks.
+2. **One `analyze` tool call** - to learn the path the *running server* resolved,
+   so we can catch the one drift bug a local check can't see on its own.
+
+Render a `flutter doctor`-style report: one line per check, tagged `[OK]`,
+`[WARN]`, or `[FAIL]`, and a fix line under anything that is not OK. End with a
+one-line summary. If everything passes, say so in one line - do not pad it.
+
+## Step 1: Local checks (ONE Bash call, sandbox DISABLED)
+
+```bash
+set -u
+
+ok(){ printf '[OK]   %s\n' "$1"; }
+warn(){ printf '[WARN] %s\n' "$1"; }
+fail(){ printf '[FAIL] %s\n' "$1"; }
+
+# --- plugin root + version: env -> marketplace cache (highest semver) -> checkout ---
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/server/mcp/index.js" ]; then printf '%s' "$CLAUDE_PLUGIN_ROOT"; return 0; fi
+  local c; c=$(find "$HOME/.claude/plugins/cache" -maxdepth 6 -path '*/deliberation/*/server/mcp/index.js' -type f 2>/dev/null | sort -V | tail -1)
+  if [ -n "$c" ]; then printf '%s' "${c%/server/mcp/index.js}"; return 0; fi
+  if [ -f "$PWD/server/mcp/index.js" ] && grep -q '"name": "deliberation"' "$PWD/.claude-plugin/plugin.json" 2>/dev/null; then printf '%s' "$PWD"; return 0; fi
+  return 1
+}
+echo "== deliberation doctor =="
+PR="$(resolve_plugin_root || true)"
+if [ -n "$PR" ]; then
+  VER="$(node -e "process.stdout.write(require('$PR/package.json').version||'?')" 2>/dev/null || echo '?')"
+  ok "plugin found ($PR, v$VER)"
+else
+  fail "plugin root not found"; echo "       fix: reinstall with /plugin, then /deliberation:setup"
+fi
+
+# --- config: env override > canonical XDG ---
+CFG="${DELIBERATION_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/deliberation/config.json}"
+case "$CFG" in /*) ;; *) CFG="$HOME/.config/deliberation/config.json";; esac
+if [ -f "$CFG" ]; then
+  if node -e "JSON.parse(require('fs').readFileSync('$CFG','utf8'))" 2>/dev/null; then
+    ok "config valid ($CFG)"
+    node -e '
+      const c=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));
+      const s=c.sessions||{}, d=c.debug||{};
+      console.log((s.persist?"[OK]   ":"[WARN] ")+"sessions.persist: "+(!!s.persist)+(s.persist?"":"  fix: set sessions.persist:true for /analyze Lens B"));
+      console.log((d.enabled?"[OK]   ":"[WARN] ")+"debug.enabled: "+(!!d.enabled)+(d.enabled?"":"  fix: set debug.enabled:true for /analyze Lens A"));
+    ' "$CFG"
+  else
+    fail "config is not valid JSON ($CFG)"; echo "       fix: correct the JSON, or move it aside and run /deliberation:setup"
+  fi
+else
+  warn "no config at $CFG"; echo "       fix: run /deliberation:setup"
+fi
+
+# --- provider CLIs (presence + version only; auth is confirmed by a real /ask-* call) ---
+if command -v codex >/dev/null 2>&1; then ok "codex CLI on PATH ($(codex --version 2>/dev/null | head -1))"; else warn "codex (GPT) not on PATH"; echo "       fix: install the Codex CLI, or ignore if you don't use GPT"; fi
+if command -v agy >/dev/null 2>&1; then ok "agy CLI on PATH (Gemini)"; else warn "agy (Gemini) not on PATH"; echo "       fix: install the Antigravity CLI, or ignore if you don't use Gemini"; fi
+[ -n "${XAI_API_KEY:-}" ] && ok "XAI_API_KEY set (Grok)" || warn "XAI_API_KEY unset - Grok calls return missing-auth"
+[ -n "${OPENROUTER_API_KEY:-}" ] && ok "OPENROUTER_API_KEY set" || warn "OPENROUTER_API_KEY unset - OpenRouter models will error"
+
+# --- sessions dir the SHELL resolves (compared to the server's in step 2) ---
+SD="${DELIBERATION_SESSIONS:-${XDG_CACHE_HOME:-$HOME/.cache}/deliberation/sessions}"
+case "$SD" in /*) ;; *) SD="$HOME/.cache/deliberation/sessions";; esac
+echo "SHELL_SESSIONS_DIR=$SD"
+if [ -d "$SD" ]; then
+  N=$(ls -1 "$SD"/*.json 2>/dev/null | wc -l | tr -d ' ')
+  ok "sessions dir exists ($SD, $N record(s))"
+else
+  warn "sessions dir not found ($SD) - nothing persisted there yet"
+fi
+
+# --- stale user-scope MCP registrations (the inline plugin manifest is the SSOT) ---
+LEFT="$(node -e 'try{const fs=require("fs"),h=require("os").homedir();const j=JSON.parse(fs.readFileSync(h+"/.claude.json","utf8"));const m=j.mcpServers||{};process.stdout.write(Object.keys(m).filter(k=>k==="deliberation"||k.indexOf("deliberation-")===0).join(" "))}catch(e){}')"
+[ -n "$LEFT" ] && { warn "user-scope MCP entries shadow the plugin manifest: $LEFT"; echo "       fix: /deliberation:uninstall (then they load from the plugin)"; } || ok "no shadowing user-scope MCP registrations"
+echo "== end local checks =="
+```
+
+## Step 2: Runtime path drift (ONE `analyze` call)
+
+Call the tool, then compare the server's resolved sessions dir to the shell's:
+
+```
+mcp__deliberation__analyze({})
+```
+
+- Read `meta.sessionsDir` (the dir the **running server** uses) and compare it to
+  `SHELL_SESSIONS_DIR` from step 1.
+  - **Match** -> `[OK] sessions path: server and shell agree`.
+  - **Differ** -> this is the drift bug:
+    ```
+    [FAIL] sessions path drift
+           server reads: <meta.sessionsDir>
+           shell wrote:  <SHELL_SESSIONS_DIR>
+           cause: XDG_CACHE_HOME / DELIBERATION_SESSIONS differs between the shell
+                  that wrote records and the process that launched the MCP server.
+           fix: set DELIBERATION_SESSIONS to one path in both places, then restart.
+    ```
+- If `meta.sessionsRead > 0` but `meta.agreementVotes === 0`, add an `[INFO]`: records
+  exist but carry no per-opinion verdicts (old or `ask-all` runs); run a fresh
+  `/consensus` to populate `/analyze` Lens B.
+- If the `analyze` call fails or returns nothing, the unified `deliberation` server
+  isn't reachable -> `[FAIL] MCP server not responding; fix: restart Claude Code, or
+  /deliberation:setup`.
+
+## Step 3: Summary + optional update check
+
+- Print one summary line: `N OK, M warnings, K failures`.
+- If there are failures, lead with the single most important one.
+- Offer (do NOT run): "Want me to check for a newer deliberation release?" If the user
+  says yes, `/plugin marketplace update antonbabenko` then `/reload-plugins` - their call.
+
+## Rules
+
+- **Read-only.** Never write config, never register/unregister MCP, never delete. Diagnose
+  and suggest; the user runs the fix.
+- **Never trigger an interactive login.** Check CLI presence and key env vars; do not run a
+  command that could open a browser auth flow. Real auth is confirmed by an actual `/ask-*` call.
+- **No secrets.** Report keys as set / unset, never their values.
+- **Quiet when healthy.** All green -> one summary line, not a victory lap.

--- a/commands/help.md
+++ b/commands/help.md
@@ -1,0 +1,84 @@
+---
+name: help
+description: Show how to use deliberation here - what each command does, when to reach for it, and real prompts you can paste right now. Read-only.
+allowed-tools: Bash
+timeout: 15000
+---
+
+# Help
+
+Deliberation gives you a second opinion from GPT, Gemini, Grok, and OpenRouter,
+without leaving your editor. You ask; they answer independently; Claude reads the
+answers back to you. The experts advise by default - GPT and Gemini can also make
+changes when you ask them to.
+
+## Step 1: One quick look at your setup (ONE Bash call)
+
+```bash
+set -u
+host="Claude Code"
+[ -n "${CURSOR_TRACE_ID:-}${CURSOR:-}" ] && host="Cursor"
+[ -n "${KIRO_VERSION:-}${KIRO:-}" ] && host="Kiro"
+[ -n "${CODEX_HOME:-}" ] && [ -z "${CLAUDECODE:-}" ] && host="Codex CLI"
+echo "Host: $host"
+CFG="${DELIBERATION_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/deliberation/config.json}"
+case "$CFG" in /*) ;; *) CFG="$HOME/.config/deliberation/config.json";; esac
+[ -f "$CFG" ] && echo "Config: found" || echo "Config: missing - run /deliberation:setup first"
+[ -n "${XAI_API_KEY:-}" ] && echo "Grok key: set" || echo "Grok key: unset (Grok will skip)"
+[ -n "${OPENROUTER_API_KEY:-}" ] && echo "OpenRouter key: set" || echo "OpenRouter key: unset (OpenRouter will skip)"
+```
+
+If the host is not Claude Code, tell the user the commands work the same way but
+the exact syntax can differ on their host, and point them at the per-host guides
+in the project's `public-docs/hosts/`. Then show the rest of this guide.
+
+## Step 2: Show the guide
+
+Render the sections below. Keep it tight - this is a cheat sheet, not a manual.
+
+### What each command is for
+
+| Command | Use it when |
+|---------|-------------|
+| `/ask-gpt`, `/ask-gemini`, `/ask-grok`, `/ask-openrouter` | You want one model's take on something. |
+| `/ask-all` | You want several models in parallel and a side-by-side read. |
+| `/consensus` | The decision matters and you want the models to argue to one verdict. |
+| `/deliberation:analyze` | You want to see which models are slow or rarely add anything. |
+| `/deliberation:doctor` | Something looks broken - commands missing, providers failing, empty analyze. |
+| `/deliberation:setup` | First install, or to repair the install. |
+
+### Prompts you can paste right now
+
+```text
+# Quick second opinion on what you're doing
+/ask-gpt Is the token-expiry check in my auth middleware off-by-one? It uses < not <=.
+
+# Several models at once, then compare
+/ask-all Review the current diff for real bugs, security issues, and missing tests.
+
+# Make a hard call with the models cross-checking each other
+/consensus Should this be a config migration or a backward-compatible fallback? Tradeoffs: <paste them>
+
+# Hand a stubborn bug to the debugger
+/ask-gemini Debug why this test fails intermittently, ranked by likelihood: <paste the error>
+
+# Weigh an architecture choice
+/ask-gpt Keep provider routing in one module or split it per provider? Weigh maintainability vs testability.
+
+# Research without leaving your editor
+/ask-grok Best way to validate Node CLI auth state without mutating the user's config?
+```
+
+### Tips
+
+- Add an expert by name to sharpen the answer: "as the security-analyst, ..." or
+  "have the code-reviewer ...". The seven experts: architect, plan-reviewer,
+  scope-analyst, code-reviewer, security-analyst, researcher, debugger.
+- Point at files in your prompt - the local experts (GPT, Gemini) can read them.
+- Stuck? Run `/deliberation:doctor`. Curious which models earn their slot? `/deliberation:analyze`.
+
+## Rules
+
+- Read-only. This command only explains - it changes nothing.
+- Keep it short and concrete. Lead with the paste-ready prompts; skip the theory.
+- Be honest about the host: if it is not Claude Code, say the syntax may differ.

--- a/core/analyze.js
+++ b/core/analyze.js
@@ -97,6 +97,8 @@ const OR_PREFIX = "openrouter:";
  * @property {boolean} sessionsPersist
  * @property {number} eventsParsed
  * @property {number} sessionsRead
+ * @property {(string|null)} sessionsDir  dir the running server resolved (for the doctor drift check)
+ * @property {number} agreementVotes  total agreement votes across models (0 with sessionsRead>0 => no per-opinion verdicts)
  * @property {boolean} insufficientData  true when there are no provider_result events to analyze
  */
 
@@ -374,7 +376,7 @@ function recommend(stats, agreement, config) {
  * @param {DebugEvent[]} events
  * @param {SessionRecord[]} records
  * @param {any} config
- * @param {{logPath?:string, debugEnabled?:boolean, sessionsPersist?:boolean}} [meta]
+ * @param {{logPath?:string, debugEnabled?:boolean, sessionsPersist?:boolean, sessionsDir?:(string|null)}} [meta]
  * @returns {Analysis}
  */
 function buildAnalysis(events, records, config, meta) {
@@ -395,6 +397,14 @@ function buildAnalysis(events, records, config, meta) {
       sessionsPersist: !!(meta && meta.sessionsPersist),
       eventsParsed: evs.length,
       sessionsRead: recs.length,
+      // sessionsDir is the dir the RUNNING server resolved (passed by the caller).
+      // /deliberation:doctor compares this to the shell-resolved path to detect the
+      // XDG_CACHE_HOME / DELIBERATION_SESSIONS drift that silently empties Lens B.
+      sessionsDir: (meta && meta.sessionsDir) || null,
+      // Total agreement votes across all models. sessionsRead>0 with agreementVotes==0
+      // means records exist but none carry a per-opinion verdict (old or ask-all runs) -
+      // Lens B is empty for a content reason, not a read-path one.
+      agreementVotes: agreement.reduce((n, a) => n + (a && a.votes ? a.votes : 0), 0),
       insufficientData: stats.length === 0,
     },
   };

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -936,7 +936,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         if (rec) records.push(rec);
       }
     }
-    return analyzeCore.buildAnalysis(events, records, cfg, { logPath, debugEnabled, sessionsPersist: persist });
+    return analyzeCore.buildAnalysis(events, records, cfg, { logPath, debugEnabled, sessionsPersist: persist, sessionsDir });
   }
 
   /**

--- a/test/core-analyze.test.js
+++ b/test/core-analyze.test.js
@@ -175,3 +175,21 @@ test("A11: buildAnalysis reports meta + insufficientData when no events", () => 
   assert.equal(withData.meta.eventsParsed, 2);
   assert.equal(withData.meta.logPath, "/tmp/x.jsonl");
 });
+
+test("A12: meta surfaces sessionsDir + agreementVotes for the doctor/empty-Lens-B diagnostic", () => {
+  // sessionsDir echoes the caller-resolved server path; defaults to null when absent.
+  const a = buildAnalysis([], [], {}, { sessionsDir: "/cache/deliberation/sessions" });
+  assert.equal(a.meta.sessionsDir, "/cache/deliberation/sessions");
+  assert.equal(buildAnalysis([], [], {}, {}).meta.sessionsDir, null);
+
+  // records with a final verdict AND a matching per-opinion verdict -> votes > 0.
+  const recVoted = /** @type {any} */ ({ verdict: "APPROVE", opinions: [{ provider: "codex", model: "default", verdict: "APPROVE" }] });
+  assert.ok(buildAnalysis([], [recVoted], {}, {}).meta.agreementVotes > 0);
+
+  // records present but no per-opinion verdict (ask-all shape) -> read>0 but votes==0
+  // (this is the case that explains an empty Lens B without it being a read-path bug).
+  const recAbstain = /** @type {any} */ ({ verdict: null, opinions: [{ provider: "codex", model: "default", text: "hi" }] });
+  const ab = buildAnalysis([], [recAbstain], {}, {});
+  assert.equal(ab.meta.sessionsRead, 1);
+  assert.equal(ab.meta.agreementVotes, 0);
+});


### PR DESCRIPTION
## What

Two new namespaced commands, plus the `analyze` metadata that makes `/doctor` useful.

### `/deliberation:help`
Host-aware usage guide: paste-ready, expert-tagged example prompts, a when-to-use table, pointers to doctor/analyze. Read-only. Humanized prose.

### `/deliberation:doctor`
Read-only health check (flutter/brew-doctor style): config validity, sessions/debug flags, provider CLI presence + key env vars, stale user-scope MCP registrations, and the **sessions-path drift** check (server-resolved vs shell-resolved). `[OK]/[WARN]/[FAIL]` with a fix line under each problem; quiet when healthy. Never mutates, never triggers a login, never prints secrets.

Both are **namespaced-only** (like `/setup` and `/uninstall`), NOT copied as bare aliases - `/help` and `/doctor` are built-in Claude Code commands, so bare aliases would collide. Confirmed by `/consensus` (8-for-8 APPROVE, high confidence).

### Analyze drift diagnostic (enables doctor's drift check)
- `core/analyze.js`: `buildAnalysis` meta now carries `sessionsDir` (the running server's resolved sessions dir) + `agreementVotes` (total). Typedef + test A12.
- `server/mcp/index.js`: passes `sessionsDir` into the meta.
- `commands/analyze.md`: an empty Lens B now self-explains - persistence off / read-path drift (prints `sessionsDir`, points to `/doctor`) / records-without-verdicts (run a fresh `/consensus`).

Motivating bug: 34 session records on disk but `analyze` Lens B reported `sessionsRead: 0` with a misleading "records didn't land" message. Root cause was per-opinion verdicts missing from old records + potential read-path drift; the diagnostic now makes both legible.

## Design process
Used `/ask-all` (GPT + Gemini + Grok + 2 OpenRouter) for the help/doctor design, and `/consensus` (7 voices) to confirm the namespaced-only alias decision.

## Test plan
- [x] `npm run check` green (560/560; +A12 for the new meta fields)
- [x] `npm run sync:check` clean (host artifacts unaffected; commands auto-discovered)
- [x] manual: run `/deliberation:doctor` and `/deliberation:help` in a real session

## Notes
- No `lib/*.sh` extraction - kept the repo's self-contained command-bash pattern; flagged as a future refactor if duplication grows.
- Auth checks are presence-only by design (no API spend, no browser-login risk).