### PR TITLE
feat(consensus): persist host-driven consensus-step loop records

### DIFF
--- a/core/debug-log.js
+++ b/core/debug-log.js
@@ -36,6 +36,8 @@
  * @property {boolean} [converged]
  * @property {number} [acceptedCritical]
  * @property {number} [voices]
+ * @property {string} [errorCode]      // sanitized failure kind (errno or "write_failed") - NEVER err.message
+ * @property {string} [loopSessionId]  // ephemeral consensus-step loop id, for failure correlation only
  */
 
 /**
@@ -56,7 +58,7 @@ const NULL_LOGGER = Object.freeze({ logEvent(/** @type {DebugEvent} */ _event) {
 const ALLOWED_KEYS = Object.freeze([
   "event", "at", "tool", "provider", "model", "reasoningEffort", "ms", "isError",
   "errorKind", "usage", "round", "verdict", "blindVerdict", "converged",
-  "acceptedCritical", "voices",
+  "acceptedCritical", "voices", "errorCode", "loopSessionId",
 ]);
 
 /**

--- a/core/loop-store.js
+++ b/core/loop-store.js
@@ -20,6 +20,7 @@ const DEFAULT_MAX_ENTRIES = 100;
  * @returns {{
  *   put:(id:string, state:any)=>void,
  *   get:(id:string)=>any,
+ *   take:(id:string)=>any,
  *   delete:(id:string)=>boolean,
  *   sweep:()=>number,
  *   size:()=>number,
@@ -66,6 +67,16 @@ function makeLoopStore(opts) {
       if (isExpired(entry, t)) { map.delete(id); return null; }
       entry.touchedAt = t; // sliding TTL: access keeps an active loop alive
       entry.seq = ++seq;   // mark as most-recently-used for LRU eviction
+      return entry.state;
+    },
+    take(id) {
+      // Atomic remove-and-return: get the entry and delete it in ONE synchronous
+      // step (no await between), so a concurrent/retried terminal caller cannot
+      // observe the same live state and act on it twice. Expired -> null (removed).
+      const entry = map.get(id);
+      if (!entry) return null;
+      map.delete(id);
+      if (isExpired(entry, now())) return null;
       return entry.state;
     },
     delete(id) {

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -519,10 +519,10 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
    * @param {DelegationRequest} req
    * @param {string|undefined} expert
    * @param {any} parts  // { opinions, blindVerdict?, verdict?, synthesis?, synthesizeAlways?, arbiter?, warnings?, parentId?, converged?, confidence?, rounds? }
-   * @returns {(string|null)}
+   * @returns {{id:(string|null), errorCode:(string|null)}}  id is the new sessionId on success; on write failure id is null and errorCode is a CONTENT-FREE kind (Node fs errno e.g. EACCES/ENOSPC, or "write_failed"). Persistence off -> {id:null, errorCode:null}.
    */
   function persistRun(tool, req, expert, parts) {
-    if (!persistEnabled()) return null;
+    if (!persistEnabled()) return { id: null, errorCode: null };
     const cfg = sessionsCfg();
     const id = sessions.newSessionId();
     /** @type {any} */
@@ -551,10 +551,60 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
     if (typeof parts.synthesizeAlways === "boolean") record.synthesizeAlways = parts.synthesizeAlways;
     try {
       sessions.writeSession(record, { dir: sessionsDir, maxRecords: cfg.maxRecords, maxAgeDays: cfg.maxAgeDays });
-      return id;
-    } catch {
-      return null;
+      return { id, errorCode: null };
+    } catch (e) {
+      // Surface ONLY a content-free failure kind (fs errno or a constant) - NEVER
+      // the caught error object or its message (which could embed prompt/parts).
+      const code = e && typeof /** @type {any} */ (e).code === "string" ? /** @type {any} */ (e).code : "write_failed";
+      return { id: null, errorCode: code };
     }
+  }
+
+  /**
+   * Emit ONE content-free persist-failure event for the consensus-step path.
+   * Wrapped so a debug-log I/O error can never throw into the loop step.
+   * @param {string} loopSid  the ephemeral loop id (correlation key only - non-sensitive)
+   * @param {(string|null)} errorCode  sanitized errno or "write_failed"; never err.message
+   */
+  function emitPersistFailed(loopSid, errorCode) {
+    try {
+      currentLogger().logEvent({ event: "persist_failed", at: Date.now(), tool: "consensus", errorCode: errorCode || "write_failed", loopSessionId: loopSid });
+    } catch { /* logging must never break the step */ }
+  }
+
+  /**
+   * Persist a TERMINAL consensus-step loop record (host-arbiter path). Mirrors the
+   * `consensus` tool's `parts` shape so session-revisit/analyze treat both record
+   * classes identically (opinions are normalized by persistRun's opinionsFrom).
+   * Best-effort + gated by sessions.persist: on write failure it emits a
+   * content-free persist_failed event and returns persisted:false.
+   * @param {any} state  terminal LoopState (status converged|unresolved)
+   * @param {string} loopSid  ephemeral loop id, correlation key for a failure event
+   * @param {("high"|"medium"|"low"|"none")} confidence
+   * @returns {{id:(string|null), persisted:boolean, errorCode:(string|null)}}  errorCode is null when persistence is off; a content-free kind when a write was attempted and failed.
+   */
+  function persistConsensusStep(state, loopSid, confidence) {
+    if (!persistEnabled()) return { id: null, persisted: false, errorCode: null };
+    const ex = state.expert || undefined;
+    /** @type {DelegationRequest} */
+    const req = {
+      // ORIGINAL prompt stashed at init - NOT currentPlan (overwritten each round).
+      prompt: typeof state.originalPrompt === "string" ? state.originalPrompt : (state.currentPlan || ""),
+      expert: ex,
+    };
+    const parts = {
+      opinions: Array.isArray(state.results) ? state.results : [],
+      blindVerdict: state.blindVerdict || null,
+      verdict: state.hostVerdict ? state.hostVerdict.verdict : null,
+      arbiter: { mode: "host", provider: null },
+      warnings: [],
+      converged: state.status === "converged",
+      confidence,
+      rounds: state.round,
+    };
+    const { id, errorCode } = persistRun("consensus", req, ex, parts);
+    if (!id) emitPersistFailed(loopSid, errorCode);
+    return { id, persisted: !!id, errorCode };
   }
 
   /**
@@ -790,7 +840,9 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
    * supplies the blind verdict / adjudication / revision (visible in its
    * transcript); the server only fans out to the peer providers. Never throws:
    * a wrong-order action or an expired session returns a structured error so the
-   * driver can recover. Persistence of the final record lands in PR2b-4.
+   * driver can recover. A TERMINAL transition (converged/unresolved) persists ONE
+   * session record via persistConsensusStep when sessions.persist is on (atomic
+   * take guarantees at-most-one; best-effort, content-free failure telemetry).
    * @param {any} args
    * @param {string|undefined} expert
    * @returns {Promise<any>}
@@ -802,10 +854,14 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         const cfg = getConfig() || {};
         const cc = cfg.consensus || {};
         const maxRounds = Number.isInteger(cc.maxRounds) && cc.maxRounds > 0 ? cc.maxRounds : undefined;
-        let state = loop.initConsensusLoop({ plan: typeof args.prompt === "string" ? args.prompt : "", expert: args.expert, arbiterMode: "host", maxRounds });
+        const originalPrompt = typeof args.prompt === "string" ? args.prompt : "";
+        let state = loop.initConsensusLoop({ plan: originalPrompt, expert: args.expert, arbiterMode: "host", maxRounds });
         const entered = enterBlind(state);
         const sid = sessions.newSessionId();
-        loopStore.put(sid, entered.state);
+        // Stash the ORIGINAL prompt so a terminal record's `question` is the original
+        // plan, not the final revision (currentPlan is overwritten each round). Rides
+        // through every pure-machine transition via spread, like peerPrompt.
+        loopStore.put(sid, { ...entered.state, originalPrompt });
         return { sessionId: sid, status: entered.state.status, round: entered.state.round, blindPrompt: entered.blindPrompt, note: "write your blind verdict, then call record_blind" };
       }
 
@@ -872,8 +928,13 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         } catch { /* logging must never break the step */ }
         if (next.status === "converged") {
           const { finalReport, confidence } = loop.finalize(next);
-          loopStore.delete(sid);
-          return { sessionId: sid, status: "converged", converged: true, verdict: next.hostVerdict ? next.hostVerdict.verdict : null, confidence, finalReport };
+          // Atomic take: remove-and-return in ONE synchronous step so a concurrent/
+          // retried terminal call finds nothing (session-expired) and cannot
+          // double-persist. take==null => already finalized; return non-durable.
+          const taken = loopStore.take(sid);
+          const { id, persisted, errorCode } = taken ? persistConsensusStep(next, sid, confidence) : { id: null, persisted: false, errorCode: null };
+          // persistError (content-free) lets the host tell "write failed" from "persistence off" (both persisted:false).
+          return { sessionId: id || undefined, loopSessionId: sid, persisted, ...(errorCode ? { persistError: errorCode } : {}), status: "converged", converged: true, verdict: next.hostVerdict ? next.hostVerdict.verdict : null, confidence, finalReport };
         }
         loopStore.put(sid, next);
         return { sessionId: sid, status: next.status, round: next.round, note: "not converged - revise the plan, then call submit_revision" };
@@ -883,11 +944,15 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         const advanced = loop.submitRevision(cur, typeof args.revisedPlan === "string" ? args.revisedPlan : cur.currentPlan, args.diffSummary);
         if (advanced.status === "unresolved") {
           const { finalReport, confidence } = loop.finalize(advanced);
-          loopStore.delete(sid);
-          return { sessionId: sid, status: "unresolved", converged: false, confidence, finalReport };
+          const taken = loopStore.take(sid);
+          const { id, persisted, errorCode } = taken ? persistConsensusStep(advanced, sid, confidence) : { id: null, persisted: false, errorCode: null };
+          return { sessionId: id || undefined, loopSessionId: sid, persisted, ...(errorCode ? { persistError: errorCode } : {}), status: "unresolved", converged: false, confidence, finalReport };
         }
         const entered = enterBlind(advanced);
-        loopStore.put(sid, entered.state);
+        // Re-stash originalPrompt EXPLICITLY across the revision loop-back (defensive,
+        // mirrors the peerPrompt pin in record_blind) so a future pure-machine refactor
+        // can't silently drop it and persist a revised plan as `question`.
+        loopStore.put(sid, { ...entered.state, originalPrompt: cur.originalPrompt });
         return { sessionId: sid, status: entered.state.status, round: entered.state.round, blindPrompt: entered.blindPrompt, note: "next round - write your blind verdict, then call record_blind" };
       }
 
@@ -1002,7 +1067,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
     if (name === "ask-all") {
       // selectForAskAll returns a FLAT provider list: enabled built-ins + per-alias OR wrappers.
       const { payload, parts } = await runAskAll(req, expert);
-      const sid = persistRun("ask-all", req, expert, parts);
+      const { id: sid } = persistRun("ask-all", req, expert, parts);
       if (sid) payload.sessionId = sid;
       return jsonResult(payload);
     }
@@ -1019,7 +1084,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         maxRounds: Number.isInteger(args.maxRounds) && args.maxRounds > 0 ? Math.min(args.maxRounds, 50) : undefined,
       });
       if (parts) {
-        const sid = persistRun("consensus", req, expert, parts);
+        const { id: sid } = persistRun("consensus", req, expert, parts);
         if (sid) payload.sessionId = sid;
       }
       return jsonResult(payload);
@@ -1077,7 +1142,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         ? await runAskAll(childReq, childExpert, { noCache: true })
         : await runConsensusTool(childReq, childExpert, { synthesizeAlways: rec.synthesizeAlways === true });
       if (parts) {
-        const sid = persistRun(tool, childReq, childExpert, { ...parts, parentId: rec.id });
+        const { id: sid } = persistRun(tool, childReq, childExpert, { ...parts, parentId: rec.id });
         if (sid) payload.sessionId = sid;
       }
       payload.parentId = rec.id;

--- a/test/core-debug-log.test.js
+++ b/test/core-debug-log.test.js
@@ -104,3 +104,24 @@ test("D9: askAll defaults to the no-op logger (no opts) and still returns result
   assert.equal(out.length, 1);
   assert.equal(out[0].isError, false);
 });
+
+test("D-persistfail: a persist_failed event survives the whitelist with ONLY content-free keys", () => {
+  // The consensus-step failure telemetry must carry its correlation fields
+  // (errorCode, loopSessionId) through sanitizeEvent, and nothing else.
+  assert.ok(ALLOWED_KEYS.includes("errorCode"), "errorCode is whitelisted");
+  assert.ok(ALLOWED_KEYS.includes("loopSessionId"), "loopSessionId is whitelisted");
+  const out = sanitizeEvent(/** @type {any} */ ({
+    event: "persist_failed",
+    at: 123,
+    tool: "consensus",
+    errorCode: "EACCES",
+    loopSessionId: "loop-abc",
+    // content that must be dropped even if a caller over-populates the event:
+    prompt: "SECRET PLAN TEXT",
+    parts: { opinions: ["leaky"] },
+    verdictText: "free text",
+  }));
+  // deepEqual proves the projection carries EXACTLY the content-free keys -
+  // prompt/parts/verdictText were dropped.
+  assert.deepEqual(out, { event: "persist_failed", at: 123, tool: "consensus", errorCode: "EACCES", loopSessionId: "loop-abc" });
+});

--- a/test/core-loop-store.test.js
+++ b/test/core-loop-store.test.js
@@ -108,3 +108,22 @@ test("LS10: eviction is TRUE LRU under a frozen clock (seq, not timestamp ties)"
   assert.deepEqual(s.get("a"), { v: 1 });
   assert.deepEqual(s.get("c"), { v: 3 });
 });
+
+test("LS11: take() atomically removes and returns the entry; second take -> null", () => {
+  const s = makeLoopStore({ ttlMs: 100000, maxEntries: 10 });
+  s.put("a", { v: 1 });
+  assert.deepEqual(s.take("a"), { v: 1 }, "first take returns the state");
+  assert.equal(s.size(), 0, "entry removed by take");
+  assert.equal(s.take("a"), null, "second take finds nothing (no double-handling)");
+  assert.equal(s.get("a"), null, "get also sees it gone");
+});
+
+test("LS12: take() on a missing or expired id returns null", () => {
+  const now = clock(1000);
+  const s = makeLoopStore({ ttlMs: 100, maxEntries: 10, now });
+  assert.equal(s.take("nope"), null, "missing -> null");
+  s.put("b", { v: 2 });
+  now.advance(101); // expire b
+  assert.equal(s.take("b"), null, "expired -> null");
+  assert.equal(s.size(), 0, "expired entry is removed by take");
+});

--- a/test/mcp-consensus-step.test.js
+++ b/test/mcp-consensus-step.test.js
@@ -2,7 +2,13 @@
 "use strict";
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const { buildServer } = require("../server/mcp/index.js");
+const sessions = require("../core/sessions.js");
+
+const tmpDir = () => fs.mkdtempSync(path.join(os.tmpdir(), "delib-cs-"));
 
 /** @param {string} name @param {(p:string)=>string} reply */
 function peer(name, reply) {
@@ -170,4 +176,65 @@ test("CS10: HOST is the arbiter - a host REQUEST_CHANGES blocks convergence even
   const adj = await step(srv, { action: "submit_adjudication", sessionId: sid, verdict: "REQUEST_CHANGES", decisions: [] }, 53);
   assert.equal(adj.converged, undefined); // not converged - the host vote, not the peers, decides
   assert.equal(adj.status, "await_revision");
+});
+
+test("CS11: a converged terminal run persists ONE tool:consensus record with question=ORIGINAL prompt", async () => {
+  // Dissent -> revise -> converge, so currentPlan ("REVISED...") != the original prompt.
+  // The persisted `question` must be the ORIGINAL, not the final revision.
+  const dir = tmpDir();
+  const srv = buildServer({ providers: [revSensitive("codex"), revSensitive("grok")], getConfig: () => ({ ...config, sessions: { persist: true } }), sessionsDir: dir });
+  const sid = (await step(srv, { action: "init", prompt: "ORIGINAL ship it", expert: "architect" }, 60)).sessionId;
+  await step(srv, { action: "record_blind", sessionId: sid, blindVerdict: "needs work" }, 61);
+  await step(srv, { action: "dispatch_peers", sessionId: sid }, 62);
+  await step(srv, { action: "submit_adjudication", sessionId: sid, verdict: "REQUEST_CHANGES", decisions: [{ source: "codex", category: "scope", description: "thin", action: "accept" }] }, 63);
+  await step(srv, { action: "submit_revision", sessionId: sid, revisedPlan: "REVISED detailed plan", diffSummary: "added detail" }, 64);
+  await step(srv, { action: "record_blind", sessionId: sid, blindVerdict: "better" }, 65);
+  await step(srv, { action: "dispatch_peers", sessionId: sid }, 66);
+  const adj = await step(srv, { action: "submit_adjudication", sessionId: sid, verdict: "APPROVE", decisions: [] }, 67);
+
+  assert.equal(adj.converged, true);
+  assert.equal(adj.persisted, true);
+  assert.ok(adj.sessionId, "durable record id returned on success");
+  assert.notEqual(adj.sessionId, sid, "record id differs from the ephemeral loop sid");
+  assert.equal(adj.loopSessionId, sid);
+
+  const rec = sessions.readSession(adj.sessionId, { dir });
+  assert.ok(rec, "record written to disk");
+  assert.equal(rec.tool, "consensus");
+  assert.equal(rec.question, "ORIGINAL ship it"); // NOT "REVISED detailed plan"
+  assert.equal(rec.converged, true);
+  assert.equal(rec.rounds, 2);
+  assert.equal(rec.opinions.length, 2);
+  assert.equal(sessions.listSessions({ dir }).length, 1, "exactly one record per loop");
+});
+
+test("CS12: persist OFF -> terminal returns persisted:false, no sessionId, writes nothing", async () => {
+  const srv = buildServer({ providers: [approve("codex"), approve("grok")], getConfig: () => config }); // no sessionsDir
+  const sid = (await step(srv, { action: "init", prompt: "ship it" }, 70)).sessionId;
+  await step(srv, { action: "record_blind", sessionId: sid, blindVerdict: "ok APPROVE" }, 71);
+  await step(srv, { action: "dispatch_peers", sessionId: sid }, 72);
+  const adj = await step(srv, { action: "submit_adjudication", sessionId: sid, verdict: "APPROVE", decisions: [] }, 73);
+  assert.equal(adj.converged, true);
+  assert.equal(adj.persisted, false);
+  assert.equal(adj.sessionId, undefined); // omitted on non-persist
+  assert.equal(adj.loopSessionId, sid);   // still correlatable
+});
+
+test("CS13: an UNRESOLVED (cap) terminal run also persists ONE record with the ORIGINAL question", async () => {
+  const dir = tmpDir();
+  const srv = buildServer({ providers: [reject("codex"), reject("grok")], getConfig: () => ({ ...configCap(1), sessions: { persist: true } }), sessionsDir: dir });
+  const sid = (await step(srv, { action: "init", prompt: "ORIGINAL never approves" }, 80)).sessionId;
+  await step(srv, { action: "record_blind", sessionId: sid, blindVerdict: "nope" }, 81);
+  await step(srv, { action: "dispatch_peers", sessionId: sid }, 82);
+  await step(srv, { action: "submit_adjudication", sessionId: sid, verdict: "REQUEST_CHANGES", decisions: [{ source: "codex", category: "ops", description: "needs work", action: "accept" }] }, 83);
+  const rev = await step(srv, { action: "submit_revision", sessionId: sid, revisedPlan: "still bad", diffSummary: "tried" }, 84);
+
+  assert.equal(rev.status, "unresolved");
+  assert.equal(rev.persisted, true);
+  assert.ok(rev.sessionId);
+  const rec = sessions.readSession(rev.sessionId, { dir });
+  assert.equal(rec.tool, "consensus");
+  assert.equal(rec.question, "ORIGINAL never approves");
+  assert.equal(rec.converged, false);
+  assert.equal(sessions.listSessions({ dir }).length, 1);
 });


### PR DESCRIPTION
## Problem

The `/consensus` slash command drives the `consensus-step` tool. Its terminal transitions (`runConsensusStep`) previously just `loopStore.delete(sid)` and persisted **nothing** - so the durable session store (verdict-agreement / Lens B analytics) was permanently empty for `/consensus` usage, even though the debug log showed constant consensus activity. Only `ask-all`, the server-side `consensus` tool, and `session-revisit` ever called `persistRun`.

## Change (Parts A + B)

Terminal transitions (converged / unresolved) now persist **exactly one** session record via a new `persistConsensusStep`, gated by `sessions.persist`.

**A - persistence + correctness**
- `loopStore.take()` - atomic synchronous remove-and-return; called **before** the (synchronous) persist, so the `get`->`take` span is await-free and a concurrent/retried terminal call finds `session-expired` and cannot double-write. At-most-one, lock-free.
- Record `question` = the **original** prompt (stashed at `init`, re-stashed explicitly at the revision loop-back), never the final revision (`currentPlan` is overwritten each round).
- Record-shape parity with the server-side `consensus` tool (both normalize through `persistRun`'s `opinionsFrom`).
- Terminal response: `persisted` flag; `sessionId` = durable record id on success / omitted on failure; `loopSessionId` correlation key.

**Security - debug.jsonl stays metrics-only**
- `persistRun` now returns `{id, errorCode}`; on write failure `errorCode` is a content-free fs errno (e.g. `EACCES`) or `"write_failed"` - **never** `err.message`.
- `emitPersistFailed` logs only whitelisted keys; `ALLOWED_KEYS` extended with `errorCode` + `loopSessionId`, everything else dropped by `sanitizeEvent`.
- Content-free `persistError` in the terminal response lets the host distinguish "write failed" from "persistence off" (both `persisted:false`).

**B - log-path audit**
- `ask-all` / `consensus` tool / `session-revisit` already persist via the shared `persistRun`; `consensus-step` was the only gap. `ask-one` and single-shot `ask-*` are advisory (no verdict) and intentionally not persisted.

## Tests

566/566 pass. New: `take()` atomicity (LS11-12), `persist_failed` whitelist survival (D-persistfail), and converged/off/unresolved persistence asserting `question`=original + at-most-one record (CS11-13).

## Review

Cross-model review (codex / gemini / grok / kimi / glm) via `ask-all`. Full-source reviewers (codex, gemini) APPROVED; the file-blind providers' `REQUEST_CHANGES` was a false positive on `originalPrompt` survival, disproven by CS11. Their fair points were still taken: explicit re-stash at the revision loop-back, and the `persistError` observability field.

## Out of scope

Part C (opt-in `sessions.captureText` for prompt/response BODY capture) is deferred to a separate PR.