### PR TITLE
feat(consensus): bound worst-case wall-time without truncating slow-but-good responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ shared by two drivers so there is ONE rules layer, not a Claude copy and a non-C
   the prose. This is the transcript-visible host-arbiter path; the `consensus` tool is the
   provider-arbiter path.
 
-The cap is `consensus.maxRounds` (config, default 5, clamped to 50; a per-call `maxRounds` overrides it).
+The cap is `consensus.maxRounds` (config, default 5, clamped to 50; a per-call `maxRounds` overrides it). A wall-time budget `consensus.maxWallMs` (default 1 200 000 ms, 20 min) stops the provider-arbiter `consensus` loop before the next round when the budget is spent, returning `stopReason: "budget-exhausted"`; the host-driven `consensus-step` path is not affected. The Codex provider is no longer unbounded: `core/providers/codex.js` caps each `codex exec` call to `CODEX_DEFAULT_TIMEOUT_MS` (600 000 ms). `callProvider` retries once on a `network` error only (pre-response transport failures); it does not retry on timeout or application errors.
 The `consensus` tool AND the host-driven `consensus-step` loop persist a session record on a
 terminal transition - converged or unresolved (when `sessions.persist` is on, with the mode flag).
 `consensus-step` uses an atomic `loopStore.take()` before the write so a terminal transition writes
@@ -132,7 +132,7 @@ Retries use multi-turn (`*-reply` with `threadId`) so the expert remembers previ
 | `commands/*.md` | Slash commands | `/setup`, `/uninstall`, `/help`, `/doctor`, `/analyze` |
 | `config/providers.json` | Provider metadata | Not used at runtime |
 | `config/config.schema.json` | JSON Schema (in `config/`) | Validates `config.json` in editors (VS Code built-in JSON support, no extension); `.vscode/` wires it for in-repo example configs |
-| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote` + `maxRounds`: the loop cap, default 5, clamped to 50), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off; single `schemaVersion:1` stamp), `debug` (opt-in debug log: `enabled`/`path`, default off - see Observability), `orientation` (opt-in auto-attach of a repo bundle to file-blind providers: `enabled`/`maxFiles`, default off - see Key Design Decisions #8). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
+| `~/.config/deliberation/config.json` | Unified user config | Live SSOT; stat-gated hot-reload. Sections: `providers` (connection), `models` (named records map keyed by id), `routing` (fan-out), `consensus` (`arbiter` + `blindVote` + `maxRounds`: the loop cap, default 5, clamped to 50; `maxWallMs`: the provider-arbiter wall-time budget, default 1200000 ms), `sessions` (opt-in run persistence: `persist`/`maxRecords`/`maxAgeDays`, default off; single `schemaVersion:1` stamp), `debug` (opt-in debug log: `enabled`/`path`, default off - see Observability), `orientation` (opt-in auto-attach of a repo bundle to file-blind providers: `enabled`/`maxFiles`, default off - see Key Design Decisions #8). Carries a `$schema` key for editor validation. Canonical XDG path (Windows: `%APPDATA%\deliberation\config.json`); override with `DELIBERATION_CONFIG` |
 
 > Expert prompts adapted from [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Full setup and configuration reference lives in **[SETUP.md](SETUP.md)**. It cov
 - **Expert modes** - advisory (`read-only`) vs implementation (`workspace-write`), chosen automatically from your request
 - **Config file** - location (`~/.config/deliberation/config.json`), the `DELIBERATION_CONFIG` override, and hot-reload
 - **The six config sections** - `providers`, `models`, `routing`, `consensus`, `sessions`, `debug` - with a minimal example
-- **OpenRouter models** - declaring records, `askAll` / `consensus` eligibility, fan-out, `reasoningEffort`, and arbiter selection
+- **OpenRouter models** - declaring records, `askAll` / `consensus` eligibility, fan-out, `reasoningEffort`, and arbiter selection; `consensus` also configures the round cap (`maxRounds`) and wall-time budget (`maxWallMs`, default 20 min)
 - **Debug log** - opt-in latency / token / voting trace
 - **Session persistence** - opt-in on-disk run history (incl. the host-driven `/consensus` loop) and the `session-*` tools; `sessions.captureText` (default off) additionally stores provider response bodies (scrubbed)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -63,7 +63,7 @@ Minimal example:
     }
   },
   "routing": { "maxFanout": 3 },
-  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true, "maxRounds": 5 },
+  "consensus": { "arbiter": { "model": "claude-arb" }, "blindVote": true, "maxRounds": 5, "maxWallMs": 1200000 },
   "sessions": { "persist": false, "maxRecords": 200, "maxAgeDays": 30 },
   "debug": { "enabled": false }
 }
@@ -91,7 +91,11 @@ a shorthand string (`"auto"` / `"host"` / `"codex"` / `"gemini"` / `"grok"`) or
 (boolean, default `false`) runs the arbiter cold in parallel with the panel to reduce
 anchoring - concrete-arbiter / non-host mode only. `consensus.maxRounds` (integer, default
 `5`, clamped to `50`) caps the multi-round convergence loop used by the `consensus` /
-`consensus-step` tools (a per-call `maxRounds` overrides it). Implementation tasks always route to Codex or Gemini - never OpenRouter.
+`consensus-step` tools (a per-call `maxRounds` overrides it). `consensus.maxWallMs` (integer
+ms, default `1200000` = 20 min) sets a global wall-time budget for the server-side
+provider-arbiter loop (`consensus` tool only); when spent, the loop stops before the next
+round and returns UNRESOLVED with `stopReason: "budget-exhausted"` - it never aborts an
+in-flight call. Implementation tasks always route to Codex or Gemini - never OpenRouter.
 
 For the full schema, the `$schema` / VS Code validation story, apiBase override matrix
 (Ollama, vLLM, LM Studio, HuggingFace), file-attachment caps, session model persistence,

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -245,6 +245,16 @@ that file by default (the Codex analog of `GEMINI_DEFAULT_MODEL` /
 `claude mcp add ... deliberation-codex` registration, or per call with the `model` parameter of
 `mcp__deliberation-codex__codex(...)`. See [SETUP.md](SETUP.md#openrouter-config).
 
+**Codex per-call timeout.** The `core` Codex provider caps each `codex exec` invocation to
+`CODEX_DEFAULT_TIMEOUT_MS` (600 000 ms, 10 min) by default. This prevents a stalled Codex
+process from blocking a consensus round indefinitely. A per-call `timeout` override is not
+currently exposed through the MCP tool surface; the constant is the global ceiling.
+
+**`callProvider` retry.** `callProvider` in `core/orchestrate.js` retries once on a `network`
+error (a pre-response transport failure - connection refused, DNS failure, socket hang-up) and
+does NOT retry on a provider timeout or application-level error. This is a single retry, not a
+retry loop.
+
 ## Observability + per-provider progress
 
 These are server-side on the unified `deliberation` server, so every MCP host gets them -
@@ -696,6 +706,21 @@ The loop ends `unresolved` once it hits the cap without converging.
   a single arbiter pass and is unaffected.
 - Validation lives in `resolveConsensus` (`server/openrouter/config.js`); the cap is
   enforced in `core/consensus-loop.js`.
+
+### consensus.maxWallMs
+
+`consensus.maxWallMs` is an optional positive integer (default `1200000`, 20 min) that sets
+the global wall-time budget (ms) for the server-side provider-arbiter convergence loop (the
+`consensus` tool). When the budget is spent the loop stops BEFORE starting the next round and
+returns UNRESOLVED with `stopReason: "budget-exhausted"`; it never aborts an in-flight
+provider call. Does not apply to the host-driven `/consensus` (`consensus-step`) path.
+
+- **Default.** `1200000` (20 min). A non-integer or non-positive value is ignored (no budget
+  is applied) without failing the config.
+- **Scope.** Provider-arbiter `consensus` tool only. The host-driven `consensus-step` path
+  has no server-side wall clock; the host controls timing there.
+- The budget is forwarded to `runToConvergence` as `opts.maxWallMs` and checked in
+  `core/consensus-loop.js` at the start of each round (`now() - startedAt >= maxWallMs`).
 
 ### camelCase config keys, wire mapping
 

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -43,7 +43,8 @@
   "consensus": {
     "arbiter": "auto",
     "blindVote": false,
-    "maxRounds": 5
+    "maxRounds": 5,
+    "maxWallMs": 1200000
   },
   "sessions": {
     "persist": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -91,6 +91,12 @@
           "maximum": 50,
           "default": 5,
           "description": "Maximum rounds for the server-side convergence loop (consensus-auto / consensus-step) before returning UNRESOLVED. Positive integer 1-50 (values above 50 are clamped to 50); defaults to 5 when unset or invalid."
+        },
+        "maxWallMs": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1200000,
+          "description": "Global wall-time budget (ms) for the server-side provider-arbiter convergence loop (the `consensus` tool). When the budget is spent the loop stops BEFORE starting the next round and returns UNRESOLVED with stopReason \"budget-exhausted\"; it never aborts an in-flight provider call. Does not apply to the host-driven /consensus (consensus-step) path. Default 1200000 (20 min)."
         }
       }
     },

--- a/core/orchestrate.js
+++ b/core/orchestrate.js
@@ -305,12 +305,17 @@ function okText(/** @type {any} */ res) {
  * revision keeps the current plan.
  * @param {Provider[]} providers  peer panel
  * @param {DelegationRequest} req  `prompt` is the initial plan
- * @param {{arbiter?:Provider, maxRounds?:number, logger?:Logger, orientationFiles?:import("./types.js").FileRef[]}} [opts]
- * @returns {Promise<{converged:boolean, verdict:(string|null), confidence:string, finalReport?:string, rounds:any[], opinions:any[], error?:string}>}
+ * @param {{arbiter?:Provider, maxRounds?:number, maxWallMs?:number, now?:()=>number, logger?:Logger, orientationFiles?:import("./types.js").FileRef[]}} [opts]
+ * @returns {Promise<{converged:boolean, verdict:(string|null), confidence:string, finalReport?:string, rounds:any[], opinions:any[], error?:string, stopReason?:string}>}
  */
 async function runToConvergence(providers, req, opts = {}) {
   const arbiter = opts.arbiter;
   const logger = opts.logger || NULL_LOGGER;
+  const now = typeof opts.now === "function" ? opts.now : Date.now;
+  const maxWallMs = typeof opts.maxWallMs === "number" && opts.maxWallMs > 0 ? opts.maxWallMs : null;
+  const startedAt = now();
+  /** @type {(string|null)} */
+  let stopReason = null;
   if (!arbiter) return { converged: false, verdict: null, confidence: "none", rounds: [], opinions: [], error: "no-arbiter" };
 
   let state = loop.initConsensusLoop({
@@ -327,6 +332,9 @@ async function runToConvergence(providers, req, opts = {}) {
   // failure-isolated. Return a structured error with whatever we have so far.
   try {
     while (state.status !== "converged" && state.status !== "unresolved") {
+      // Budget gates STARTING a round; it never interrupts the in-flight fan-out
+      // below, so a legitimately slow peer answer is always collected in full.
+      if (maxWallMs !== null && now() - startedAt >= maxWallMs) { stopReason = "budget-exhausted"; break; }
       const { peerPrompt, blindPrompt } = loop.prepareRound(state);
       // Blind pass runs concurrently with the peer fan-out; isolate its failure.
       const roundNo = state.round;
@@ -422,6 +430,7 @@ async function runToConvergence(providers, req, opts = {}) {
     finalReport,
     rounds: state.history,
     opinions: lastResults,
+    ...(stopReason ? { stopReason } : {}),
   };
 }
 

--- a/core/orchestrate.js
+++ b/core/orchestrate.js
@@ -81,8 +81,17 @@ async function callProvider(provider, req, logger, tool, cache, orientationFiles
   const started = Date.now();
   /** @type {DelegationResult} */
   let r;
+  // One ask attempt, cloning files so a provider cannot mutate the caller's refs.
+  const askOnce = () => provider.ask({ ...req, files: req.files ? req.files.map((f) => ({ ...f })) : undefined });
   try {
-    r = await provider.ask({ ...req, files: req.files ? req.files.map((f) => ({ ...f })) : undefined });
+    r = await askOnce();
+    // Consume `retryable` for the ONE safe case: a pre-response transport failure
+    // (errorKind "network" == connect/DNS/socket error before any bytes). Retry it
+    // exactly once. NEVER retry timeout (may have burned tokens / risks the
+    // slow-but-good case), rate-limit (same limit), or auth/config (won't self-heal).
+    if (r.isError && r.errorKind === "network") {
+      r = await askOnce();
+    }
   } catch (e) {
     // A provider that REJECTS (rather than returning an error envelope) must not
     // break the call OR vanish from the log. Synthesize + log a uniform error -

--- a/core/orchestrate.js
+++ b/core/orchestrate.js
@@ -10,6 +10,10 @@ const { NULL_LOGGER } = require("./debug-log.js");
 
 /** @typedef {import("./debug-log.js").Logger} Logger */
 
+// Drop a peer from the panel after this many CONSECUTIVE rounds of timeout, so one
+// chronically-slow model cannot add its full per-call ceiling to every round.
+const CIRCUIT_BREAK_AFTER = 2;
+
 /**
  * Emit one `provider_result` debug event for a settled call. Never throws.
  * @param {Logger} logger
@@ -316,6 +320,9 @@ async function runToConvergence(providers, req, opts = {}) {
   const startedAt = now();
   /** @type {(string|null)} */
   let stopReason = null;
+  let activeProviders = providers;
+  /** @type {Map<string, number>} consecutive-timeout streak per provider name */
+  const timeoutStreak = new Map();
   if (!arbiter) return { converged: false, verdict: null, confidence: "none", rounds: [], opinions: [], error: "no-arbiter" };
 
   let state = loop.initConsensusLoop({
@@ -335,12 +342,13 @@ async function runToConvergence(providers, req, opts = {}) {
       // Budget gates STARTING a round; it never interrupts the in-flight fan-out
       // below, so a legitimately slow peer answer is always collected in full.
       if (maxWallMs !== null && now() - startedAt >= maxWallMs) { stopReason = "budget-exhausted"; break; }
+      if (!activeProviders.length) { stopReason = "all-providers-circuit-broken"; break; }
       const { peerPrompt, blindPrompt } = loop.prepareRound(state);
       // Blind pass runs concurrently with the peer fan-out; isolate its failure.
       const roundNo = state.round;
       const [blindRes, peerResults] = await Promise.all([
         Promise.resolve().then(() => arbiter.ask(withOrientation(arbiter, { ...req, prompt: blindPrompt }, opts.orientationFiles))).then((r) => r, () => null),
-        askAll(providers, { ...req, prompt: peerPrompt }, { logger, tool: "consensus", orientationFiles: opts.orientationFiles }),
+        askAll(activeProviders, { ...req, prompt: peerPrompt }, { logger, tool: "consensus", orientationFiles: opts.orientationFiles }),
       ]);
       state = loop.recordBlindVerdict(state, okText(blindRes) || "(blind pass unavailable)");
 
@@ -351,6 +359,14 @@ async function runToConvergence(providers, req, opts = {}) {
           : { ...parseReview(typeof r.text === "string" ? r.text : ""), source: r.provider, isError: false, ms: r.ms }
       );
       state = loop.addOpinions(state, lastResults);
+
+      // Update per-peer timeout streaks from THIS round, then trim the panel for the
+      // next round. A non-timeout result (success or any other error) resets the streak.
+      for (const rr of lastResults) {
+        if (rr.isError && rr.errorKind === "timeout") timeoutStreak.set(rr.source, (timeoutStreak.get(rr.source) || 0) + 1);
+        else timeoutStreak.set(rr.source, 0);
+      }
+      activeProviders = providers.filter((p) => (timeoutStreak.get(p.name) || 0) < CIRCUIT_BREAK_AFTER);
 
       // Peer dissent => this round CANNOT converge (checkConvergence requires every
       // responding peer to APPROVE), so the revision is GUARANTEED needed: overlap it

--- a/core/providers/codex.js
+++ b/core/providers/codex.js
@@ -2,6 +2,14 @@
 /** @typedef {import("../types.js").Provider} Provider */
 const { spawn } = require("node:child_process");
 
+// Default per-call wall-time ceiling for a Codex run. Without this the spawner's
+// kill timer is never armed (the `timeoutMs ? ... : null` below), so a hung or
+// runaway `codex exec` runs UNBOUNDED - the root cause of the observed ~38-min
+// single-call outlier. 600s mirrors the Gemini bridge's MAX ceiling: generous for
+// a deep GPT answer, fatal to an unbounded hang. Overridable per-call via
+// req.timeoutMs, or per-construction via opts.timeoutMs.
+const CODEX_DEFAULT_TIMEOUT_MS = 600000;
+
 /**
  * Map codex stderr to the shared errorKind vocabulary.
  * @param {string} [stderr]
@@ -68,12 +76,16 @@ function defaultRun({ prompt, cwd, timeoutMs, mode }) {
  * @param {boolean} [opts.allowImplement]  construction-time lock (first of two AND-ed locks).
  *   When false/absent, this provider is read-only no matter what `req.mode` says. Set ONLY in a
  *   composition root that has a local workspace + a human-gated write surface (section 3).
+ * @param {number} [opts.timeoutMs]  construction-time default per-call ceiling (ms). Falls back to CODEX_DEFAULT_TIMEOUT_MS.
  * @returns {Provider}
  */
 function makeCodexProvider(opts = {}) {
   const run = opts.run || defaultRun;
   const model = opts.model || "default"; // codex resolves its own model from config.toml
   const allowImplement = opts.allowImplement === true;
+  const defaultTimeoutMs = typeof opts.timeoutMs === "number" && opts.timeoutMs > 0
+    ? opts.timeoutMs
+    : CODEX_DEFAULT_TIMEOUT_MS;
   return {
     name: "codex",
     // canImplement reflects the construction lock so discovery (panel) is honest about THIS
@@ -85,7 +97,11 @@ function makeCodexProvider(opts = {}) {
       // Two-lock gate: write only when constructed write-capable AND this call explicitly asks.
       const mode = allowImplement && req.mode === "implement" ? "implement" : "advisory";
       const full = req.developerInstructions ? `${req.developerInstructions}\n\n---\n\n${req.prompt}` : req.prompt;
-      const { code, stdout, stderr } = await run({ prompt: full, cwd: req.cwd, timeoutMs: req.timeoutMs, mode });
+      // Effective ceiling: explicit per-call wins, else the construction default,
+      // else the module default. Always a positive number, so defaultRun's kill
+      // timer is ALWAYS armed - no Codex call can run unbounded.
+      const timeoutMs = typeof req.timeoutMs === "number" && req.timeoutMs > 0 ? req.timeoutMs : defaultTimeoutMs;
+      const { code, stdout, stderr } = await run({ prompt: full, cwd: req.cwd, timeoutMs, mode });
       if (code === 0) {
         // Codex CLI has no per-call reasoning-effort knob in this integration -> null.
         return { provider: "codex", model, text: stdout.trim(), isError: false, ms: Date.now() - started, reasoningEffort: null };
@@ -106,4 +122,4 @@ function makeCodexProvider(opts = {}) {
   };
 }
 
-module.exports = { makeCodexProvider, classifyCodex, codexExecArgs };
+module.exports = { makeCodexProvider, classifyCodex, codexExecArgs, CODEX_DEFAULT_TIMEOUT_MS };

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -743,6 +743,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         arbiter,
         warnings: allWarnings,
         error: out.error,
+        stopReason: out.stopReason,
       };
       // parts drives persistence (only on a real run). blindVerdict is per-round in
       // the loop, so the final record stores null (the verdict + opinions are the
@@ -811,6 +812,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         arbiter: p.arbiter, warnings: p.warnings,
         converged: p.converged, confidence: p.confidence, rounds: p.rounds,
         synthesizeAlways: false, error: p.error == null ? null : p.error,
+        stopReason: p.stopReason,
       };
       if (!parts) return { payload: envelope, parts: null }; // error path - do not persist
       return { payload: envelope, parts: { ...parts, synthesis: null, synthesizeAlways: false } };

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -729,7 +729,8 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
       const maxRounds = Number.isInteger(maxRoundsOverride) && /** @type {number} */ (maxRoundsOverride) > 0
         ? maxRoundsOverride
         : (Number.isInteger(cc.maxRounds) && cc.maxRounds > 0 ? cc.maxRounds : undefined);
-      const out = await runToConvergence(peers, withPersona(req, expert), { arbiter: arbiterP, maxRounds, logger: currentLogger(), orientationFiles: orient(req) });
+      const maxWallMs = Number.isInteger(cc.maxWallMs) && cc.maxWallMs > 0 ? cc.maxWallMs : undefined;
+      const out = await runToConvergence(peers, withPersona(req, expert), { arbiter: arbiterP, maxRounds, maxWallMs, logger: currentLogger(), orientationFiles: orient(req) });
       const allWarnings = out.error ? warnings.concat([`loop: ${out.error}`]) : warnings;
       const rounds = Array.isArray(out.rounds) ? out.rounds.length : 0;
       const arbiter = { mode: "server", provider: arbiterP.name };

--- a/server/openrouter/config.js
+++ b/server/openrouter/config.js
@@ -19,6 +19,11 @@ const DEFAULT_ARBITER = "auto";
 // (multiple paid provider calls), so an unbounded value is a cost/runaway vector.
 // An over-cap config value is clamped to this (with a warning), not dropped.
 const MAX_ROUNDS_CAP = 50;
+// Default wall-clock budget (ms) for the consensus loop. Absent or invalid config
+// values fall back to this constant so the 20-min cap is enforced even for configs
+// that pre-date the feature. A present-but-invalid value degrades to the default
+// WITH a warning (unlike maxRounds which omits when invalid, here we always emit).
+const DEFAULT_CONSENSUS_MAX_WALL_MS = 1200000;
 // sessions block defaults (opt-in store; default OFF).
 const DEFAULT_SESSIONS_MAX_RECORDS = 200;
 const DEFAULT_SESSIONS_MAX_AGE_DAYS = 30;
@@ -348,7 +353,7 @@ function resolveConsensus(rawConsensus, models) {
     // The user DID set consensus (just malformed) -> degrade to auto but treat as
     // explicit (arbiterDefaulted:false), so host auto-detect does not override it.
     warnings.push(`consensus must be an object (got ${JSON.stringify(rawConsensus)}); using "${DEFAULT_ARBITER}"`);
-    return { consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: false, blindVote: false }, warnings };
+    return { consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: false, blindVote: false, maxWallMs: DEFAULT_CONSENSUS_MAX_WALL_MS }, warnings };
   }
   const block = isObject(rawConsensus) ? rawConsensus : {};
 
@@ -379,13 +384,26 @@ function resolveConsensus(rawConsensus, models) {
     }
   }
 
+  // maxWallMs: optional positive-integer wall-clock budget (ms) for the loop. A
+  // present-but-invalid value falls back to DEFAULT_CONSENSUS_MAX_WALL_MS with a
+  // warning (unlike maxRounds which is omitted on invalid; here the default always
+  // applies so the documented 20-min cap holds even for pre-feature configs).
+  let maxWallMs = DEFAULT_CONSENSUS_MAX_WALL_MS;
+  if (block.maxWallMs !== undefined) {
+    if (Number.isInteger(block.maxWallMs) && block.maxWallMs > 0) {
+      maxWallMs = block.maxWallMs;
+    } else {
+      warnings.push(`consensus.maxWallMs must be a positive integer (got ${JSON.stringify(block.maxWallMs)}); using ${DEFAULT_CONSENSUS_MAX_WALL_MS}`);
+    }
+  }
+
   // arbiterDefaulted=true ONLY when the user did not set an arbiter at all, so the
   // server can pick host (under Claude Code) vs auto (elsewhere). An explicit but
   // invalid arbiter degrades to auto with arbiterDefaulted=false (the user did choose).
   const wrap = (/** @type {any} */ arbiter, /** @type {boolean} */ arbiterDefaulted) => ({
     consensus: maxRounds === undefined
-      ? { arbiter, arbiterDefaulted, blindVote }
-      : { arbiter, arbiterDefaulted, blindVote, maxRounds },
+      ? { arbiter, arbiterDefaulted, blindVote, maxWallMs }
+      : { arbiter, arbiterDefaulted, blindVote, maxRounds, maxWallMs },
     warnings,
   });
 
@@ -437,7 +455,7 @@ function makeConfigReader(filePath) {
     try {
       text = fs.readFileSync(filePath, "utf8");
     } catch (_) {
-      return { ok: true, error: null, resolved: { version: 1, providers: {}, openrouter: disabledOpenRouter(), consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: true, blindVote: false }, sessions: { persist: false, maxRecords: DEFAULT_SESSIONS_MAX_RECORDS, maxAgeDays: DEFAULT_SESSIONS_MAX_AGE_DAYS, captureText: false }, consensusWarnings: [] } };
+      return { ok: true, error: null, resolved: { version: 1, providers: {}, openrouter: disabledOpenRouter(), consensus: { arbiter: DEFAULT_ARBITER, arbiterDefaulted: true, blindVote: false, maxWallMs: DEFAULT_CONSENSUS_MAX_WALL_MS }, sessions: { persist: false, maxRecords: DEFAULT_SESSIONS_MAX_RECORDS, maxAgeDays: DEFAULT_SESSIONS_MAX_AGE_DAYS, captureText: false }, consensusWarnings: [] } };
     }
     let parsed;
     try {

--- a/test/core-codex.test.js
+++ b/test/core-codex.test.js
@@ -69,3 +69,30 @@ test("CX4: a non-zero exit surfaces stdout in .message (diagnostic detail not lo
   assert.equal("text" in r, false); // error results carry no text key
   assert.equal(/** @type {any} */ (r).message, "diagnostic detail from codex");
 });
+
+const { makeCodexProvider: mkCx, CODEX_DEFAULT_TIMEOUT_MS } = require("../core/providers/codex.js");
+
+test("CX-timeout-1: ask passes the default timeout to run when the request carries none", async () => {
+  let seen;
+  const run = async (/** @type {any} */ a) => { seen = a.timeoutMs; return { code: 0, stdout: "ok", stderr: "" }; };
+  await mkCx({ run }).ask({ prompt: "x" });
+  assert.equal(seen, CODEX_DEFAULT_TIMEOUT_MS);
+  assert.equal(CODEX_DEFAULT_TIMEOUT_MS, 600000);
+});
+
+test("CX-timeout-2: an explicit req.timeoutMs overrides the default", async () => {
+  let seen;
+  const run = async (/** @type {any} */ a) => { seen = a.timeoutMs; return { code: 0, stdout: "ok", stderr: "" }; };
+  await mkCx({ run }).ask({ prompt: "x", timeoutMs: 12345 });
+  assert.equal(seen, 12345);
+});
+
+test("CX-timeout-3: a construction-time opts.timeoutMs is used when the request carries none, and req still wins", async () => {
+  let seen;
+  const run = async (/** @type {any} */ a) => { seen = a.timeoutMs; return { code: 0, stdout: "ok", stderr: "" }; };
+  const p = mkCx({ run, timeoutMs: 77000 });
+  await p.ask({ prompt: "x" });
+  assert.equal(seen, 77000);
+  await p.ask({ prompt: "x", timeoutMs: 5000 });
+  assert.equal(seen, 5000);
+});

--- a/test/core-orchestrate.test.js
+++ b/test/core-orchestrate.test.js
@@ -3,6 +3,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const { askAll, askOne, consensus, buildArbiterPrompt, buildAdjudicationPrompt, runToConvergence } = require("../core/orchestrate.js");
+const { askOne: askOneT } = require("../core/orchestrate.js");
 /** @typedef {import("../core/types.js").Provider} Provider */
 
 /** @param {string} name @param {string} [behavior] @returns {Provider} */
@@ -278,4 +279,49 @@ test("ORX9: runToConvergence adjudication/revision passes are NOT oriented (only
   const adjudication = calls.find((c) => c.kind === "adjudication");
   assert.deepEqual(blind.files, BUNDLE, "blind pass (cold question) is oriented");
   assert.equal(adjudication.files, undefined, "adjudication pass (peer text) is NOT oriented");
+});
+
+/** Provider whose ask() returns a scripted sequence of results, counting calls.
+ * @param {string} name
+ * @param {any[]} sequence
+ * @returns {any}
+ */
+function scriptedProvider(name, sequence) {
+  let i = 0;
+  const p = {
+    name,
+    calls: 0,
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    async health() { return { ok: true }; },
+    async ask() { p.calls++; return sequence[Math.min(i++, sequence.length - 1)]; },
+  };
+  return p;
+}
+/** @param {string} kind @returns {any} */
+const ERR = (kind) => ({ provider: "p", model: "m", isError: true, errorKind: kind, retryable: true, ms: 1 });
+/** @returns {any} */
+const OK = () => ({ provider: "p", model: "m", isError: false, text: "ok", ms: 1 });
+
+test("ORX-retry-1: a network error retries once and the retry's success is returned", async () => {
+  const p = scriptedProvider("p", [ERR("network"), OK()]);
+  const r = await askOneT(p, { prompt: "x" });
+  assert.equal(r.isError, false);
+  assert.equal(r.text, "ok");
+  assert.equal(p.calls, 2);
+});
+
+test("ORX-retry-2: a timeout error is NOT retried (slow/non-idempotent guard)", async () => {
+  const p = scriptedProvider("p", [ERR("timeout"), OK()]);
+  const r = await askOneT(p, { prompt: "x" });
+  assert.equal(r.isError, true);
+  assert.equal(r.errorKind, "timeout");
+  assert.equal(p.calls, 1);
+});
+
+test("ORX-retry-3: two consecutive network errors retry exactly once (no third call)", async () => {
+  const p = scriptedProvider("p", [ERR("network"), ERR("network"), OK()]);
+  const r = await askOneT(p, { prompt: "x" });
+  assert.equal(r.isError, true);
+  assert.equal(r.errorKind, "network");
+  assert.equal(p.calls, 2);
 });

--- a/test/core-run-to-convergence.test.js
+++ b/test/core-run-to-convergence.test.js
@@ -201,3 +201,30 @@ test("RC-budget: a spent wall-time budget stops the loop before the next round (
   assert.equal(out.stopReason, "budget-exhausted");
   assert.equal(out.rounds.length, 1); // only round 1 ran, not 5
 });
+
+/**
+ * A peer that always times out, counting how many rounds it was actually called in.
+ * @param {string} name
+ * @returns {any}
+ */
+function flakyTimeoutPeer(name) {
+  const p = {
+    name,
+    calls: 0,
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    health: async () => ({ ok: true }),
+    ask: async () => { p.calls++; return { provider: name, model: "stub", isError: true, errorKind: "timeout", retryable: true, ms: 1 }; },
+  };
+  return p;
+}
+
+test("RC-breaker: a peer that times out 2 rounds running is dropped for later rounds", async () => {
+  const flaky = flakyTimeoutPeer("flaky");
+  // A healthy dissenter keeps the loop from converging so it runs all 5 rounds.
+  const healthy = stub("healthy", () => "**Verdict**: REQUEST_CHANGES\n- [ops] x");
+  const arb = stub("arb", (p) => (p.includes("ADJUDICATE") ? "**Verdict**: REQUEST_CHANGES" : p.includes("REVISE") ? "nope" : "**Verdict**: REQUEST_CHANGES"));
+  const out = await runToConvergence([flaky, healthy], REQ, { arbiter: arb, maxRounds: 5 });
+  assert.equal(out.converged, false);
+  assert.equal(out.rounds.length, 5);   // healthy peer kept the loop going
+  assert.equal(flaky.calls, 2);         // called rounds 1 & 2, then circuit-broken
+});

--- a/test/core-run-to-convergence.test.js
+++ b/test/core-run-to-convergence.test.js
@@ -186,3 +186,18 @@ test("RC12: all peers APPROVE but arbiter blocks -> serial revision runs (the !p
   assert.equal(out.rounds.length, 2);
   assert.ok(arbPrompts.some((p) => p.includes("REVISE")), "serial revision should run when all peers approve but the arbiter blocks");
 });
+
+test("RC-budget: a spent wall-time budget stops the loop before the next round (no in-flight abort)", async () => {
+  // Persistent dissent would otherwise run all 5 rounds.
+  const peers = [stub("gpt", () => "**Verdict**: REQUEST_CHANGES\n- [ops] no rollback")];
+  const arb = stub("arb", (p) => (p.includes("ADJUDICATE") ? "**Verdict**: REQUEST_CHANGES" : p.includes("REVISE") ? "still not enough" : "**Verdict**: REQUEST_CHANGES"));
+  // Clock: startedAt=0, round-1 top-check=0 (under budget -> round runs),
+  // round-2 top-check=100000 (over the 5000 budget -> stop).
+  const times = [0, 0, 100000];
+  let i = 0;
+  const now = () => times[Math.min(i++, times.length - 1)];
+  const out = await runToConvergence(peers, REQ, { arbiter: arb, maxRounds: 5, maxWallMs: 5000, now });
+  assert.equal(out.converged, false);
+  assert.equal(out.stopReason, "budget-exhausted");
+  assert.equal(out.rounds.length, 1); // only round 1 ran, not 5
+});

--- a/test/core-setup.test.js
+++ b/test/core-setup.test.js
@@ -164,7 +164,7 @@ test("SU8: STARTER_CONFIG validates under validateConfig", () => {
   assert.ok(resolved);
   // openrouter ships disabled in the starter; consensus arbiter is the auto shorthand.
   assert.equal(resolved.openrouter.enabled, false);
-  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: false, blindVote: false });
+  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: false, blindVote: false, maxWallMs: 1200000 });
   assert.deepEqual(resolved.openrouter.models, []);
   assert.equal(resolved.openrouter.maxFanout, 3);
 });

--- a/test/mcp-consensus.test.js
+++ b/test/mcp-consensus.test.js
@@ -189,3 +189,27 @@ test("CA15: a per-call maxRounds above the cap is clamped to 50", async () => {
   assert.equal(payload.converged, false);
   assert.equal(payload.rounds, 50);
 });
+
+function timeoutVoter(name) {
+  return {
+    name,
+    capabilities: { canImplement: false, fileUpload: false, multiTurn: false },
+    async health() { return { ok: true }; },
+    /** @param {{prompt:string}} _req @returns {Promise<any>} */
+    async ask(_req) {
+      return { provider: name, model: "m", isError: true, errorKind: "timeout", text: "", ms: 1 };
+    },
+  };
+}
+
+test("CA16: stopReason is surfaced in the tool payload when the loop circuit-breaks", async () => {
+  // Both peers/arbiter always timeout → after CIRCUIT_BREAK_AFTER=2 rounds the peer
+  // panel is empty → loop breaks with stopReason:"all-providers-circuit-broken".
+  // Before the I1 fix, stopReason was absent from the payload entirely.
+  const srv = buildServer({
+    providers: [timeoutVoter("codex"), timeoutVoter("grok")],
+    getConfig: () => cfg({ maxRounds: 10 }),
+  });
+  const payload = await callTool(srv, "consensus", { prompt: "q" }, 21);
+  assert.equal(payload.stopReason, "all-providers-circuit-broken");
+});

--- a/test/openrouter-config.test.js
+++ b/test/openrouter-config.test.js
@@ -323,7 +323,7 @@ test("C11: malformed JSON => ok=false with parse error, no throw", () => {
 test("CB1: missing consensus block defaults arbiter to 'auto', no warnings", () => {
   const { ok, resolved } = validateConfig(base());
   assert.equal(ok, true);
-  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
+  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false, maxWallMs: 1200000 });
   assert.deepEqual(resolved.consensusWarnings, []);
 });
 
@@ -464,9 +464,37 @@ test("CB9: non-object consensus block degrades to auto AND warns (invalid->auto+
   }
 });
 
+// --- consensus.maxWallMs resolution ------------------------------------------
+
+test("CB-MW1: a valid positive-integer consensus.maxWallMs is preserved in the resolved block", () => {
+  const c = base();
+  c.consensus = { maxWallMs: 777000 };
+  const { resolved } = validateConfig(c);
+  assert.equal(resolved.consensus.maxWallMs, 777000);
+  assert.deepEqual(resolved.consensusWarnings, []);
+});
+
+test("CB-MW2: absent consensus.maxWallMs defaults to 1200000", () => {
+  const { resolved } = validateConfig(base());
+  assert.equal(resolved.consensus.maxWallMs, 1200000);
+});
+
+test("CB-MW3: invalid consensus.maxWallMs falls back to 1200000 + a warning", () => {
+  for (const bad of [-5, 0, 1.5, "x", true, null]) {
+    const c = base();
+    c.consensus = { maxWallMs: bad };
+    const { resolved } = validateConfig(c);
+    assert.equal(resolved.consensus.maxWallMs, 1200000, `${JSON.stringify(bad)}: default`);
+    assert.ok(
+      resolved.consensusWarnings.some((/** @type {string} */ w) => /maxWallMs must be a positive integer/.test(w)),
+      `${JSON.stringify(bad)}: warned`,
+    );
+  }
+});
+
 test("CB7: omitted openrouter block still carries consensus default auto", () => {
   const { resolved } = validateConfig({ version: 1 });
-  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
+  assert.deepEqual(resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false, maxWallMs: 1200000 });
   assert.deepEqual(resolved.consensusWarnings, []);
 });
 
@@ -474,7 +502,7 @@ test("CB8: missing config file => disabled openrouter + consensus default auto",
   const reader = makeConfigReader(path.join(os.tmpdir(), "definitely-absent-cdg-cb.json"));
   const r = reader.get();
   assert.equal(r.ok, true);
-  assert.deepEqual(r.resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false });
+  assert.deepEqual(r.resolved.consensus, { arbiter: "auto", arbiterDefaulted: true, blindVote: false, maxWallMs: 1200000 });
 });
 
 // --- sessions block ----------------------------------------------------------


### PR DESCRIPTION
## Problem

A recent `/consensus` run took 45+ minutes. The debug log showed a single provider call at ~38 min: a Codex (`codex exec`) subprocess running **unbounded**, because its kill timer was armed only when a `timeoutMs` was passed and the consensus path passed none. Several other calls sat at 420-600s. There was no retry, no wall-time budget, and no circuit-breaker, so a chronically-slow peer added its full ceiling to every one of up to 5 rounds.

## Approach

Four layered guards (smallest blast radius first) plus the config/docs to expose them. The strategy was designed via a cross-model panel (GPT / Gemini / Grok / OpenRouter); the plan and the final diff were cross-reviewed.

- **Bound Codex** (`core/providers/codex.js`): default 600s per-call ceiling (`CODEX_DEFAULT_TIMEOUT_MS`), overridable per-call or per-construction. The kill timer is now always armed. This alone fixes the observed incident on every arbiter path.
- **Transport-only retry** (`core/orchestrate.js` `callProvider`): consume the previously-ignored `retryable` flag for exactly one case, a pre-response `network` error, retried once. Never on timeout / rate-limit / auth (non-idempotent in cost; would risk the slow-but-good case).
- **Global wall-time budget** (`runToConvergence`): optional `maxWallMs` stops *starting* a new round once spent; it never aborts an in-flight call, so a legitimately slow Gemini answer is always collected. Returns `stopReason: "budget-exhausted"`.
- **Session circuit-breaker**: a peer that times out in 2 consecutive rounds is dropped from the panel for the rest of the session (`stopReason: "all-providers-circuit-broken"`).
- **Config + wiring + docs**: `consensus.maxWallMs` (default 1200000 ms = 20 min), wired config -> `resolveConsensus` -> the `consensus` tool -> the loop; `stopReason` surfaced in the tool payload. TECHNICAL / README / SETUP / CLAUDE docs updated.

Explicitly out of scope (documented in the plan): hedging (rejected: the fan-out already is the redundancy); budget/breaker on the host-driven `consensus-step` path (the Codex bound still fixes that path's incident); a Codex timeout config key.

## Worst case

Every per-call path now has a ceiling (Codex 600s, Gemini ~420s, Grok/OpenRouter 180s). Per-round wall-time approx max(peers) + max(adjudication, revision); the global budget caps the total. No unbounded path remains.

## Test plan

- New unit tests: Codex timeout plumbing (CX-timeout-1/2/3), transport retry (ORX-retry-1/2/3), budget (RC-budget), circuit-breaker (RC-breaker), config-path flow + payload (CB-MW1/2/3, CA16).
- `npm run check`: typecheck clean; **579 pass / 11 fail**. All 11 failures are pre-existing `listen EPERM 127.0.0.1` sandbox network-bind denials in `test/grok.test.js` / `test/openrouter.test.js`, untouched by this branch (they fail identically on `master`). No code-caused failures.
- Manual: a `consensus` run with a small `maxWallMs` returns fewer rounds and `stopReason: "budget-exhausted"`.

## Review

The plan and the final whole-branch diff were cross-reviewed by GPT / Gemini / Grok / OpenRouter plus a per-task spec+quality gate. The final whole-branch review caught a critical wiring gap (the config key was stripped by `resolveConsensus` and never reached the loop, so the budget was inert in production); it was fixed in the last commit and re-verified end-to-end.

## Commits

- `fix(codex)`: bound unbounded per-call timeout (default 600s)
- `fix(orchestrate)`: retry once on pre-response network errors only
- `feat(consensus)`: optional global wall-time budget for the convergence loop
- `feat(consensus)`: circuit-break a peer after 2 consecutive timeouts
- `feat(consensus)`: add `consensus.maxWallMs` budget config + docs
- `fix(consensus)`: wire `maxWallMs` through config resolution and surface `stopReason`
