### PR TITLE
fix: harden gemini bridge read-only flow

### DIFF
--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -23,6 +23,9 @@ const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes (Gemini 3 deep prompts run 200-
 const DEFAULT_RECOVERY_GRACE_MS = 120_000; // extra drain budget after the soft timeout
 const MAX_MS = 600_000;
 const VALID_SANDBOX_VALUES = new Set(["read-only", "workspace-write"]);
+const READ_ONLY_ANTI_ESCALATION =
+  "You are in a strict READ-ONLY sandbox. Use ONLY read_file / list_directory / search_file_content. " +
+  "NEVER call escalate_admin or request elevated permissions; if a tool is denied, answer from what you can read.";
 
 // agy's --print-timeout takes a Go duration string ("420s"). Convert ms.
 function goDuration(ms) {
@@ -59,12 +62,119 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function normalizeReadOnlyPrefix(text, sandbox) {
+  const base = typeof text === "string" ? text.trim() : "";
+  if (sandbox === "workspace-write") return base;
+  const lower = base.toLowerCase();
+  const alreadyGuarded =
+    lower.includes("never call escalate_admin") ||
+    lower.includes("never request elevated permissions");
+  if (alreadyGuarded) return base;
+  return base ? `${READ_ONLY_ANTI_ESCALATION}\n\n${base}` : READ_ONLY_ANTI_ESCALATION;
+}
+
+function resolveIncludeDirectories(rawDirs, cwd) {
+  const resolved = [];
+  const seen = new Set();
+  for (const dir of rawDirs ?? []) {
+    const normalized = typeof dir === "string" ? dir.trim() : "";
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    resolved.push(normalized);
+  }
+  const normalizedCwd = typeof cwd === "string" ? cwd.trim() : "";
+  if (resolved.length === 0 && normalizedCwd && !seen.has(normalizedCwd)) {
+    resolved.push(normalizedCwd);
+  }
+  return resolved;
+}
+
 // agy reports failures as "Error: <msg>" on stdout at exit 0. Any stdout LINE
 // starting with "Error:" is a failure even when the process exits 0 - the
 // sentinel can arrive after streamed partial output, so match line-anchored
 // (multiline), not just at the very start of the buffer.
 function stdoutIsError(s) {
   return /^\s*Error:\s/m.test(s);
+}
+
+function extractTextPayload(value) {
+  if (typeof value === "string") return value.trim();
+  if (Array.isArray(value)) {
+    const joined = value.map(extractTextPayload).filter(Boolean).join("\n\n").trim();
+    return joined;
+  }
+  if (!value || typeof value !== "object") return "";
+  if (typeof value.text === "string") return value.text.trim();
+  if (typeof value.message === "string") return value.message.trim();
+  if (typeof value.content === "string") return value.content.trim();
+  if (Array.isArray(value.content)) {
+    const joined = value.content.map(extractTextPayload).filter(Boolean).join("\n\n").trim();
+    if (joined) return joined;
+  }
+  if (Array.isArray(value.parts)) {
+    const joined = value.parts.map(extractTextPayload).filter(Boolean).join("\n\n").trim();
+    if (joined) return joined;
+  }
+  return "";
+}
+
+function extractFinalChannelMessage(stdout) {
+  const markers = Array.from(stdout.matchAll(/<\|channel\|>([A-Za-z0-9_-]+)<\|message\|>/g));
+  if (markers.length === 0) {
+    return { ok: false, code: "parse", message: "Gemini returned channelized stdout without any parseable channel frames." };
+  }
+  const prefix = stdout.slice(0, markers[0].index).trim();
+  if (prefix) {
+    return { ok: false, code: "parse", message: "Gemini returned channelized stdout prefixed by non-channel noise." };
+  }
+
+  const frames = markers.map((match, idx) => {
+    const start = match.index + match[0].length;
+    const end = idx + 1 < markers.length ? markers[idx + 1].index : stdout.length;
+    return {
+      channel: String(match[1] || "").toLowerCase(),
+      payload: stdout.slice(start, end).trim(),
+    };
+  });
+
+  const finalFrame = [...frames].reverse().find((frame) => frame.channel === "final");
+  if (!finalFrame) {
+    return { ok: false, code: "parse", message: "Gemini returned channelized stdout without a final answer channel." };
+  }
+  if (!finalFrame.payload) {
+    return { ok: false, code: "parse", message: "Gemini returned an empty final answer payload." };
+  }
+
+  let text = "";
+  if (/^[\[{"]/.test(finalFrame.payload)) {
+    try {
+      text = extractTextPayload(JSON.parse(finalFrame.payload));
+    } catch (_) {
+      return { ok: false, code: "parse", message: "Gemini returned a malformed final answer payload." };
+    }
+  } else {
+    text = finalFrame.payload;
+  }
+
+  const normalized = String(text || "").trim();
+  if (!normalized) {
+    return { ok: false, code: "parse", message: "Gemini returned a final answer channel without readable text." };
+  }
+  return { ok: true, response: normalized };
+}
+
+function normalizeGeminiStdout(stdout) {
+  const out = String(stdout || "").trim();
+  if (!out) {
+    return { ok: false, code: "parse", message: "No output from agy" };
+  }
+  if (stdoutIsError(out)) {
+    return { ok: false, message: out };
+  }
+  if (!out.includes("<|channel|>")) {
+    return { ok: true, response: out };
+  }
+  return extractFinalChannelMessage(out);
 }
 
 // --- Error Classification ---
@@ -222,7 +332,8 @@ async function runGemini(args, cwd, timeoutMs, recoveryGraceMs) {
 
       const out = stdout.trim();
       const trimmedErr = stderr.trim();
-      const success = code === 0 && out && !stdoutIsError(out);
+      const normalized = normalizeGeminiStdout(out);
+      const success = code === 0 && normalized.ok;
 
       if (draining) {
         // Soft timeout already fired. Only a clean exit meeting the success
@@ -235,7 +346,7 @@ async function runGemini(args, cwd, timeoutMs, recoveryGraceMs) {
             "[claude-delegator] recovered agy answer via stdout drain after soft timeout (" +
             Math.round((Date.now() - spawnStartMs) / 1000) + "s)\n"
           );
-          return resolve({ response: out, threadId: resolveConversationId(effCwd) || "unknown", recovered: true });
+          return resolve({ response: normalized.response, threadId: resolveConversationId(effCwd) || "unknown", recovered: true });
         }
         return finishTimeout();
       }
@@ -251,22 +362,21 @@ async function runGemini(args, cwd, timeoutMs, recoveryGraceMs) {
             "; returning threadId:\"unknown\" (resume will be unavailable)\n"
           );
         }
-        return resolve({ response: out, threadId: threadId || "unknown" });
+        return resolve({ response: normalized.response, threadId: threadId || "unknown" });
       }
 
       // Failure. Prefer stderr so it is not masked by an stdout banner; then an
       // stdout Error: sentinel; then a generic message.
       let message;
       if (trimmedErr) message = trimmedErr;
-      else if (stdoutIsError(out)) message = out;
+      else if (!normalized.ok && normalized.message) message = normalized.message;
       else if (!out) message = `No output from agy`;
       else message = `agy exited with code ${code}`;
 
       const err = new Error(message);
       if (/timed out/i.test(message)) {
         err.code = "timeout";
-      } else if (!trimmedErr && !out) {
-        // Clean exit, nothing on either stream: empty/garbage output.
+      } else if (!normalized.ok && normalized.code === "parse") {
         err.code = "parse";
       }
       // Otherwise leave err.code undefined and let classifyGeminiError map the
@@ -396,10 +506,9 @@ const handlers = {
       if (args.sandbox === "workspace-write") sandboxFlags.push("--dangerously-skip-permissions");
       else sandboxFlags.push("--sandbox");
 
+      const includeDirectories = resolveIncludeDirectories(args["include-directories"], args.cwd);
       const addDirFlags = [];
-      if (args["include-directories"]) {
-        for (const dir of args["include-directories"]) addDirFlags.push("--add-dir", dir);
-      }
+      for (const dir of includeDirectories) addDirFlags.push("--add-dir", dir);
 
       if (name === "gemini") {
         // model is accepted + validated but never reaches argv (agy reads the
@@ -418,8 +527,9 @@ const handlers = {
         }
 
         agyArgs.push(...sandboxFlags, ...addDirFlags);
+        const developerInstructions = normalizeReadOnlyPrefix(args["developer-instructions"], args.sandbox);
         let prompt = args.prompt;
-        if (args["developer-instructions"]) prompt = `${args["developer-instructions"]}\n\n${prompt}`;
+        if (developerInstructions) prompt = `${developerInstructions}\n\n${prompt}`;
         agyArgs.push("-p", prompt);
       } else if (name === "gemini-reply") {
         if (!isNonEmptyString(args.threadId)) {
@@ -437,7 +547,7 @@ const handlers = {
         }
 
         agyArgs.push("--conversation", threadId, ...sandboxFlags, ...addDirFlags);
-        agyArgs.push("-p", args.prompt);
+        agyArgs.push("-p", normalizeReadOnlyPrefix(args.prompt, args.sandbox));
       } else {
         if (shouldRespond) sendError(id, -32601, `Tool not found: ${name}`);
         return;
@@ -533,4 +643,7 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports.resolveConversationId = resolveConversationId;
   module.exports.goDuration = goDuration;
   module.exports.stdoutIsError = stdoutIsError;
+  module.exports.normalizeGeminiStdout = normalizeGeminiStdout;
+  module.exports.extractFinalChannelMessage = extractFinalChannelMessage;
+  module.exports.extractTextPayload = extractTextPayload;
 }

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -156,6 +156,43 @@ test("O3: stderr failure -> isError, stderr wins over stdout banner", async () =
   assert.ok(!text.includes("agy config banner"), "stdout banner not surfaced");
 });
 
+test("O4: channel-noise stdout -> parse error instead of leaking commentary", async () => {
+  const child = startBridge({
+    fakeBin: "fake-agy-channel.sh",
+    env: { FAKE_AGY_STDOUT: '<|channel|>commentary<|message|>{"query":"includeHidden","toolAction":"Searching web"}\n' },
+  });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "hi" } },
+  });
+  setTimeout(() => child.stdin.end(), 1500);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.equal(r.result.isError, true, "isError");
+  assert.equal(r.result.errorKind, "parse", "channel-noise should classify as parse");
+  assert.match(r.result.content[0].text, /without a final answer channel/i);
+});
+
+test("O5: mixed channel-noise before final -> final answer extracted", async () => {
+  const child = startBridge({
+    fakeBin: "fake-agy-channel.sh",
+    env: { FAKE_AGY_STDOUT: '<|channel|>commentary<|message|>{"toolAction":"Searching web"}\n<|channel|>final<|message|>{"content":[{"type":"text","text":"FINAL OK"}]}\n' },
+  });
+  const responsesP = collectResponses(child);
+  send(child, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  send(child, {
+    jsonrpc: "2.0", id: 2, method: "tools/call",
+    params: { name: "gemini", arguments: { prompt: "hi" } },
+  });
+  setTimeout(() => child.stdin.end(), 1500);
+  const responses = await responsesP;
+  const r = responses.find((x) => x.id === 2);
+  assert.ok(!r.result.isError, "not an error: " + JSON.stringify(r.result));
+  assert.equal(r.result.content[0].text, "FINAL OK");
+});
+
 // --- timeout-recovery (stdout drain) ---
 
 test("R-A: drain completes -> recovered:true with final answer", async () => {
@@ -398,4 +435,18 @@ test("C4: resolveConversationId reads cwd->id map, returns null on miss", () => 
     if (prev === undefined) delete process.env.AGY_LAST_CONVERSATIONS;
     else process.env.AGY_LAST_CONVERSATIONS = prev;
   }
+});
+
+test("C5: normalizeGeminiStdout rejects analysis-only noise and malformed final payloads", () => {
+  const { normalizeGeminiStdout } = require("../server/gemini/index.js");
+
+  const analysisOnly = normalizeGeminiStdout("<|channel|>analysis<|message|>Reply with exactly PING_OK");
+  assert.equal(analysisOnly.ok, false);
+  assert.equal(analysisOnly.code, "parse");
+  assert.match(analysisOnly.message, /without a final answer channel/i);
+
+  const malformedFinal = normalizeGeminiStdout('<|channel|>final<|message|>{"content":[');
+  assert.equal(malformedFinal.ok, false);
+  assert.equal(malformedFinal.code, "parse");
+  assert.match(malformedFinal.message, /malformed final answer payload/i);
 });

--- a/test/fixtures/fake-agy-channel.sh
+++ b/test/fixtures/fake-agy-channel.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fake agy that writes caller-provided stdout verbatim and exits 0.
+set -euo pipefail
+
+if [ "${1:-}" = "--help" ]; then
+  echo "Usage of agy:"
+  exit 0
+fi
+
+printf '%s\0' "$@" >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+printf '\n' >> "${CDG_ARGV_LOG:-/tmp/cdg-argv.log}"
+
+printf '%s' "${FAKE_AGY_STDOUT:-}"
+exit 0


### PR DESCRIPTION
## What changed
- harden the Gemini bridge's read-only flow by auto-prepending the anti-escalation guard when the caller forgets it
- default `--add-dir` to `cwd` when `include-directories` is omitted so headless `agy` sessions stay anchored to the real repo workspace
- parse channelized stdout frames safely instead of surfacing raw `<|channel|>commentary...` noise as a successful model answer
- add regression coverage for channel-noise parsing and the read-only argv/prompt mapping path

## Why
Recent headless consensus runs could fail in two different ways:
- Gemini sometimes entered a permission/escalation path in read-only mode when the caller did not explicitly inject the anti-escalation instruction
- some bridge outputs contained channelized commentary noise rather than a clean final answer, which the bridge previously treated as plain success text

## Root cause
The bridge trusted the caller to always provide two fragile pieces of context:
- a read-only anti-escalation prompt prefix
- an explicit workspace anchor via `include-directories`

When either was missing, `agy` could drift into scratch-workspace or permission-oriented behavior. Separately, stdout normalization only checked for `Error:` sentinels and did not understand channel-framed outputs.

## Impact
- read-only Gemini calls are more resilient by default
- `/consensus` and other headless Gemini delegations no longer rely on every caller remembering the same guardrails
- channelized non-final noise is classified as parse failure instead of leaking misleading success output

## Validation
- `node --test test/bridge.test.js`
