### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -62,7 +62,7 @@ jobs:
       # the required check.
       - name: Conventional Changelog (release branch)
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           github-token: ${{ secrets.RELEASE_TOKEN }}
           git-message: 'chore(release): {version}'

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -83,7 +83,7 @@ jobs:
           if [ ! -s /tmp/notes.md ]; then echo "Release ${VERSION}" > /tmp/notes.md; fi
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           name: ${{ steps.ver.outputs.tag }}
@@ -99,7 +99,7 @@ jobs:
       # @antonbabenko/deliberation-mcp linked to this repo + workflow.
       - name: Set up Node for publish
         if: steps.tag.outputs.created == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## What

GitHub is force-running our Node 20 actions on Node 24 and warning on every run ([example](https://github.com/antonbabenko/deliberation/actions/runs/30255096213/job/89941724578#step:8:27)). Bumps every action to a major that declares `using: node24`.

| Action | Before | After |
|---|---|---|
| `actions/setup-node` | v4 | v7 |
| `actions/checkout` | v4 | v6 |
| `softprops/action-gh-release` | v2 | v3 |
| `TriPSs/conventional-changelog-action` | v5 | v6 |

`checkout` was already on v6 in `tag-release.yml` and `automated-release.yml`; this only brings `validate.yml` in line.

## Breaking-change review

- `setup-node@v7` - ESM migration + Node 24 runtime. No input removals; `node-version`, `cache`, `registry-url` unchanged.
- `action-gh-release@v3` - runtime move only. `v2.6.2` remains the last Node 20 line.
- `conventional-changelog-action@v6` - only breaking change is `prerelease` deriving `pre[major|minor|patch]`. This workflow does not set `prerelease`, so no behavior change.
- Each floating major tag (`v7`, `v6`, `v3`) was confirmed to exist and resolve.

## Test plan

- [ ] `validate` check passes on this PR (exercises `checkout@v6` + `setup-node@v7`)
- [ ] No Node 20 deprecation warning in the run annotations
- [ ] After merge: `automated-release` runs clean with `conventional-changelog-action@v6` (this is a `ci:` commit, so it is a hidden type - expect skip-on-empty, no release PR)
- [ ] `action-gh-release@v3` is only exercised on the next real release tag