### PR TITLE
build: add a Dockerfile so container builds stop guessing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Minimal image for the unified deliberation MCP server.
+# Zero third-party runtime deps - only core/ and server/ are needed at runtime.
+FROM node:22-alpine
+
+RUN npm install -g mcp-proxy@6.4.3
+
+WORKDIR /app
+COPY core ./core
+COPY server ./server
+COPY package.json ./
+
+USER node
+
+CMD ["mcp-proxy", "--", "node", "server/mcp/index.js"]

--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ The package also ships a `deliberation-setup` bin. Run it once with `npx -y --pa
 
 </details>
 
+### Run in Docker
+
+The repo ships a `Dockerfile` for running the standalone server in a container. It wraps the stdio server in `mcp-proxy`, the same shape MCP hosting providers expect:
+
+```bash
+docker build -t deliberation-mcp .
+docker run -i --rm \
+  -e XAI_API_KEY -e OPENROUTER_API_KEY \
+  -v ~/.config/deliberation:/home/node/.config/deliberation:ro \
+  deliberation-mcp
+```
+
+Grok and OpenRouter work from the keys alone. GPT and Gemini do not - they shell out to the `codex` and `agy` CLIs, which are not in the image, so those two providers report `not-found` / `missing-cli` inside the container.
+
 ### Native plugins per host (Cursor / Codex / Kiro / OpenCode)
 
 Beyond the raw MCP config above, deliberation ships **native plugin artifacts** for four hosts so the experience matches the Claude Code plugin (persona-bearing experts + when-to-delegate guidance, not just bare tools). All of these are **generated from the canonical sources** by `node scripts/sync-hosts.js` and committed, so they never drift (a CI drift test enforces it). Each host scans the repo for its own files:


### PR DESCRIPTION
## Why

A container build of this repo at `1cab2cb` failed before a single repo layer ran:

```
debian:trixie-slim: failed to resolve source metadata for docker.io/library/debian:trixie-slim:
no active session for 75a46425-4e22-4754-a4f7-4dc37d515dce: context deadline exceeded
```

123 seconds spent failing to read the base image manifest, with the buildkit client session gone. That specific failure is builder-side infrastructure and no repo change can prevent it.

What the repo *can* control is how much build surface it exposes. Without a `Dockerfile`, the generated spec was:

- `debian:trixie-slim` + `apt-get` (ca-certificates, curl, git)
- NodeSource `setup_26.x` + `nodejs`
- `npm i -g mcp-proxy pnpm`
- the `astral.sh/uv` installer + `uv python install 3.14 --preview`
- `git clone` of the repo, on top of the build context it had already loaded

Five network installers across four hosts, and roughly 2-4 minutes of build, for a server whose entire runtime dependency set is six `node:` core modules. Every one of those is another chance for the same class of flake.

## What

A 13-line `Dockerfile`:

```dockerfile
FROM node:22-alpine
RUN npm install -g mcp-proxy@6.4.3
WORKDIR /app
COPY core ./core
COPY server ./server
COPY package.json ./
USER node
CMD ["mcp-proxy", "--", "node", "server/mcp/index.js"]
```

Notes on the choices:

- **No install step.** `rg` over `core/` and `server/` finds only `node:child_process`, `node:crypto`, `node:fs`, `node:fs/promises`, `node:os`, `node:path`. There is nothing to install and nothing to bundle - `server/mcp/dist/` matters only for the npm package.
- **`COPY core` / `COPY server` rather than `COPY . .`** keeps `.git`, `test/`, `docs/`, `plugins/`, `assets/` and any local `node_modules` out of the image, and avoids a `.dockerignore` that would have to track a growing set of host-artifact directories.
- **`mcp-proxy@6.4.3` and the `CMD` shape are unchanged** from the generated spec, so the runtime contract stays the same.
- **`USER node`** is safe: the server never writes to `/app`. Its state lives under XDG paths in `$HOME`, which is what the README's volume mount targets.
- Node 22 satisfies `server/mcp/package.json`'s `engines: { "node": ">=18" }`.

Plus a short `### Run in Docker` section in the README, which states the real limitation: Grok and OpenRouter work from keys alone, but GPT and Gemini shell out to the `codex` and `agy` CLIs, which are not in the image, so those two report `not-found` / `missing-cli` inside a container.

## Verification

| Check | Result |
|---|---|
| `docker build -t deliberation-mcp .` | passes, 181MB, 4.3s |
| `docker run --rm deliberation-mcp mcp-proxy --version` | `6.4.3` |
| `initialize` + `tools/list` over stdio in the container | `serverInfo.name: deliberation-mcp`, first tool `ask-all` |
| `npm run check` | typecheck clean, 760/760 tests pass |

## Scope

`build:` is deliberate - this adds no feature and fixes no user-visible defect, so it should not cut a release. It rides along with the next `feat:`/`fix:`.

No changes to `glama.json` (its schema allows exactly one property, `maintainers`), `server.json`, `package.json`, or any code.
