### PR TITLE
fix(mcp): report the real version in serverInfo, not 0.1.0

### DIFF
--- a/.github/release/pre-commit.js
+++ b/.github/release/pre-commit.js
@@ -43,6 +43,13 @@ const TARGETS = [
   // different indents; sync both. Same-file targets re-read the file each pass.
   { rel: 'server.json', re: /^( {2}"version":\s*)"[^"]*"/m },
   { rel: 'server.json', re: /^( {6}"version":\s*)"[^"]*"/m },
+  // The stdio server's advertised serverInfo.version - what every MCP host (and
+  // the Glama inspector) displays. Not a JSON line, so this one is anchored on
+  // the serverInfo literal instead of an indent.
+  {
+    rel: 'server/mcp/index.js',
+    re: /(serverInfo: \{ name: "deliberation-mcp", version: )"[^"]*"/,
+  },
 ]
 
 function repoRoot() {

--- a/.github/release/pre-commit.js
+++ b/.github/release/pre-commit.js
@@ -71,8 +71,20 @@ function syncVersion(root, target, version) {
     throw new Error(`pre-commit: ${target.rel} not found`)
   }
   const src = fs.readFileSync(file, 'utf8')
-  if (!target.re.test(src)) {
+  // Require EXACTLY ONE match. A second one means something else in the file carries
+  // the same shape - a comment, an example, a block-commented copy - and the replace
+  // below is non-global, so it would rewrite whichever came first and leave the real
+  // value stale, silently. Ambiguity fails loudly instead of being guessed at.
+  const all = new RegExp(target.re.source, target.re.flags.includes('g') ? target.re.flags : target.re.flags + 'g')
+  const hits = src.match(all)
+  if (!hits) {
     throw new Error(`pre-commit: version line not found in ${target.rel}`)
+  }
+  if (hits.length !== 1) {
+    throw new Error(
+      `pre-commit: ${hits.length} lines match the version pattern in ${target.rel}; ` +
+        `exactly one expected, refusing to guess`
+    )
   }
   fs.writeFileSync(file, src.replace(target.re, `$1"${version}"`))
   return target.rel

--- a/.github/release/pre-commit.js
+++ b/.github/release/pre-commit.js
@@ -44,11 +44,13 @@ const TARGETS = [
   { rel: 'server.json', re: /^( {2}"version":\s*)"[^"]*"/m },
   { rel: 'server.json', re: /^( {6}"version":\s*)"[^"]*"/m },
   // The stdio server's advertised serverInfo.version - what every MCP host (and
-  // the Glama inspector) displays. Not a JSON line, so this one is anchored on
-  // the serverInfo literal instead of an indent.
+  // the Glama inspector) displays. Not a JSON line, so this one anchors on the
+  // `return` statement rather than an indent. The leading `^\s*return {` matters:
+  // without it, any COMMENT that quoted the same shape would win the non-global
+  // replace and the real literal would go stale, silently.
   {
     rel: 'server/mcp/index.js',
-    re: /(serverInfo: \{ name: "deliberation-mcp", version: )"[^"]*"/,
+    re: /^(\s*return \{ jsonrpc: "2\.0".*serverInfo: \{ name: "deliberation-mcp", version: )"[^"]*"/m,
   },
 ]
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,10 +64,20 @@ jobs:
             }
           }
 
+          // Mirrors pre-commit.js: exactly one match, or fail. A second line carrying the
+          // same shape (comment, example, block-commented copy) would let the check read a
+          // decoy while the real value drifts.
           function readMatch(p, re) {
             try {
-              const m = fs.readFileSync(p, 'utf8').match(re)
-              return m && m[1]
+              const src = fs.readFileSync(p, 'utf8')
+              const all = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g')
+              const hits = src.match(all)
+              if (!hits) return null
+              if (hits.length !== 1) {
+                console.error(`ERROR ${p}: ${hits.length} lines match the version pattern; exactly one expected`)
+                process.exit(1)
+              }
+              return src.match(re)[1]
             } catch (e) {
               console.error(`ERROR ${p}: ${e.message}`)
               process.exit(1)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,6 +64,16 @@ jobs:
             }
           }
 
+          function readMatch(p, re) {
+            try {
+              const m = fs.readFileSync(p, 'utf8').match(re)
+              return m && m[1]
+            } catch (e) {
+              console.error(`ERROR ${p}: ${e.message}`)
+              process.exit(1)
+            }
+          }
+
           // version.json is the CI-owned source of truth.
           const source = readJSON('version.json').version
           if (!(typeof source === 'string' && SEMVER.test(source))) {
@@ -79,6 +89,7 @@ jobs:
             ['server/mcp/package.json', readJSON('server/mcp/package.json').version],
             ['server.json', readJSON('server.json').version],
             ['server.json packages[0]', (readJSON('server.json').packages || [])[0]?.version],
+            ['server/mcp/index.js serverInfo', readMatch('server/mcp/index.js', /serverInfo: \{ name: "deliberation-mcp", version: "([^"]*)"/)],
           ]
 
           let bad = false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,7 +89,9 @@ jobs:
             ['server/mcp/package.json', readJSON('server/mcp/package.json').version],
             ['server.json', readJSON('server.json').version],
             ['server.json packages[0]', (readJSON('server.json').packages || [])[0]?.version],
-            ['server/mcp/index.js serverInfo', readMatch('server/mcp/index.js', /serverInfo: \{ name: "deliberation-mcp", version: "([^"]*)"/)],
+            // Anchored on the `return` line, matching pre-commit.js: a comment quoting
+            // the same shape must not be able to satisfy this check.
+            ['server/mcp/index.js serverInfo', readMatch('server/mcp/index.js', /^\s*return \{ jsonrpc: "2\.0".*serverInfo: \{ name: "deliberation-mcp", version: "([^"]*)"/m)],
           ]
 
           let bad = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,8 +279,10 @@ changelog. (The release-PR job also self-skips its own `chore(release):` commit 
 
 `version.json` is the single source of truth. When a releasable commit lands on `master`,
 `automated-release.yml` bumps it, regenerates `CHANGELOG.md`, and runs `.github/release/pre-commit.js` to sync the
-version in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and
-`package.json`. After the release PR merges, `tag-release.yml` tags `vX.Y.Z`, publishes the
+version in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
+`package.json`, `server.json`, `server/mcp/package.json`, the Codex host manifest, and the
+`serverInfo.version` literal in `server/mcp/index.js` (what every MCP host displays).
+After the release PR merges, `tag-release.yml` tags `vX.Y.Z`, publishes the
 GitHub Release, and nudges the `antonbabenko/agent-plugins` marketplace to re-pin. The
 `validate` check fails if any of those version fields drift from `version.json`. See
 CONTRIBUTING.md for the full flow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,9 @@ You never bump versions by hand.
    release (immediately if its dispatch token is set, otherwise within a day via cron).
 
 `version.json` is the single source of truth. `.claude-plugin/plugin.json`,
-`.claude-plugin/marketplace.json`, and `package.json` are kept in sync by CI
+`.claude-plugin/marketplace.json`, `package.json`, `server.json` (both version lines),
+`server/mcp/package.json`, `plugins/deliberation/.codex-plugin/plugin.json`, and the
+`serverInfo.version` literal in `server/mcp/index.js` are kept in sync by CI
 (`.github/release/pre-commit.js`). Do not edit those version fields by hand - the `validate`
 check fails if they drift.
 

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -1336,6 +1336,12 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         const ci = msg.params && msg.params.clientInfo;
         if (ci && typeof ci.name === "string") clientName = ci.name;
         // `logging: {}` advertises that we emit `notifications/message` (Phase 4 spike).
+        // serverInfo.version is SYNCED FROM version.json by .github/release/pre-commit.js,
+        // and checked by the validate workflow plus test M9 in test/mcp-server.test.js. Both
+        // find it by matching the shape of the return statement below, so do not reformat
+        // that line (quotes, spacing, key order) - the sync would silently stop finding it.
+        // Deliberately not restated here: a comment carrying that shape would shadow the
+        // real line and the sync would rewrite the comment instead.
         return { jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {}, logging: {} }, serverInfo: { name: "deliberation-mcp", version: "3.14.4" } } };
       }
       if (msg.method === "logging/setLevel") {

--- a/server/mcp/index.js
+++ b/server/mcp/index.js
@@ -1336,7 +1336,7 @@ function buildServer({ providers, getConfig, getConfigError, sessionsDir, notify
         const ci = msg.params && msg.params.clientInfo;
         if (ci && typeof ci.name === "string") clientName = ci.name;
         // `logging: {}` advertises that we emit `notifications/message` (Phase 4 spike).
-        return { jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {}, logging: {} }, serverInfo: { name: "deliberation-mcp", version: "0.1.0" } } };
+        return { jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {}, logging: {} }, serverInfo: { name: "deliberation-mcp", version: "3.14.4" } } };
       }
       if (msg.method === "logging/setLevel") {
         const level = msg.params && msg.params.level;

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -223,3 +223,12 @@ test("S-MCP9: session-get on an unknown id returns a not-found message", async (
   const payload = await callTool(srv, 15, "session-get", { sessionId: "nope" });
   assert.match(payload.error, /session not found/);
 });
+
+test("M9: initialize advertises version.json's version, not a stale literal", async () => {
+  const srv = buildServer({ providers: [fakeProvider("codex")], getConfig: () => config });
+  const res = await srv.handle({ jsonrpc: "2.0", id: 99, method: "initialize", params: {} });
+  assert.equal(res.result.serverInfo.name, "deliberation-mcp");
+  // The literal is synced from version.json by .github/release/pre-commit.js. Asserting it
+  // here means a reformat or a missed sync fails `npm run check` locally, not only in CI.
+  assert.equal(res.result.serverInfo.version, require("../version.json").version);
+});


### PR DESCRIPTION
## Why

The stdio server answered every MCP `initialize` with a hardcoded literal:

```js
serverInfo: { name: "deliberation-mcp", version: "0.1.0" }
```

The package it ships in is at 3.14.4. Every MCP host displays that value, so it is what the
registry shows: a Glama container build's instance log printed

```
serverInfo: { name: 'deliberation-mcp', version: '0.1.0' }
```

The literal had never been updated since the server was written, while seven other
version-bearing files are already kept in sync automatically from `version.json`.

## What

`version.json` already drives seven manifest version lines through
`.github/release/pre-commit.js`. This adds the `serverInfo` literal as an eighth target,
teaches the `validate` workflow's version-sync check to read it back, and adds a local test
so drift fails under `npm run check` rather than only in CI.

| File | Change |
|---|---|
| `server/mcp/index.js` | literal set to 3.14.4, plus a comment marking it as synced |
| `.github/release/pre-commit.js` | eighth `TARGETS` entry, and an exactly-one-match rule for all targets |
| `.github/workflows/validate.yml` | `readMatch()` helper + an eighth entry in `checks` |
| `test/mcp-server.test.js` | new test M9 |
| `CLAUDE.md`, `CONTRIBUTING.md` | both listed only three synced files; now all eight |

The seven pre-existing targets are indent-anchored JSON regexes. This one is a JavaScript
string literal, so it anchors on the `return` statement instead:

```js
re: /^(\s*return \{ jsonrpc: "2\.0".*serverInfo: \{ name: "deliberation-mcp", version: )"[^"]*"/m,
```

### Two shadowing defects, found and closed during review

**First cut.** The regex was unanchored, and the warning comment added at the literal quoted
the matched text. `syncVersion()` does a non-global `src.replace()`, so the comment became the
first match. Demonstrated before it shipped:

- the validate check read the comment's placeholder: `ERROR server/mcp/index.js serverInfo version not valid semver: "..."`
- a pre-commit dry run rewrote the comment and left the real literal stale, silently

That is the exact failure the comment was written to prevent. Fixed by anchoring on the
`return` line, which no `//` comment can satisfy, and by having the comment state the shape
rather than reproduce it.

**Second cut.** The review then pointed out that `^\s*return {` defeats a `//` comment but not
a line inside a `/* */` block, which still begins with whitespace and `return {`. Anchoring
harder only moves the goalposts, so both guards now require **exactly one match** and fail
otherwise:

```js
// pre-commit.js
if (hits.length !== 1) {
  throw new Error(`pre-commit: ${hits.length} lines match the version pattern in ${target.rel}; exactly one expected, refusing to guess`)
}
```

This closes every shadowing shape at once (block comments, examples, template strings) and
applies to all eight targets, not just the new one.

Remaining divergence paths through the automated flow: none. Reshaping the `return` line makes
`syncVersion()` throw, a second matching line fails both guards, a stale value fails the
equality check, and M9 fails locally under `npm run check`.

## Verification

| Check | Result |
|---|---|
| `npm run check` | typecheck clean, 779/779 tests (was 778) |
| `node --check` on `pre-commit.js` and `server/mcp/index.js` | pass |
| validate heredoc extracted and run verbatim | 8/8 in sync at 3.14.4 |
| all eight `TARGETS` regexes counted against their files | exactly one match each |
| decoy: `//`-commented `return` carrying `6.6.6` above the real line | check still reads the real 3.14.4 |
| decoy: `/* */`-block copy of the `return` line carrying `6.6.6` | both guards fail loudly, `2 lines match the version pattern; exactly one expected` |
| negative: literal forced back to `0.1.0` | exit 1, `ERROR server/mcp/index.js serverInfo=0.1.0 != version.json=3.14.4` |
| doc sweep: `rg '0\.1\.0\|serverInfo'` over README/TECHNICAL/SETUP/AGENTS/CONTRIBUTING/POWER/CLAUDE + `plugins/` + `examples/` | one hit, the new CLAUDE.md line describing this sync |

Two questions answered with evidence rather than assumption:

- **esbuild divergence.** `prepack` is a plain `--bundle` with no `--minify` and no `--define`, so the literal is emitted verbatim into `dist/index.js`.
- **Publish ordering.** `tag-release.yml` publishes from the tag, and `pre-commit.js` writes the synced files into the release commit that tag points at, so the published bundle is built from already-synced source.

## Pre-PR consensus review

Two rounds, panel of seven (codex, gemini, grok, and four OpenRouter delegates), per CLAUDE.md.
The loop ended `UNRESOLVED` with `stopReason: budget-exhausted` - the 20-minute
`consensus.maxWallMs` was spent before round 3 dispatched, not a stop on disagreement. Every
issue raised across both rounds is resolved below.

**Round 1** - Claude blind REQUEST CHANGES, codex REQUEST CHANGES, glm-5-3 three unique issues,
five APPROVE. All accepted, none dismissed:

- `scope` CONTRIBUTING.md still documented three synced targets (codex, glm-5-3, Claude blind). Fixed.
- `correctness` the drift guard existed only as a YAML heredoc that `npm run check` never runs (glm-5-3, Claude blind). Fixed by test M9.
- `ambiguity` the literal's formatting was load-bearing with no marker at the edit site (glm-5-3). Fixed, and fixing it exposed the first shadowing defect above.
- `ops` the doc sweep was asserted but unverified (glm-5-3). Executed; result in the table.

**Round 2** - four APPROVE, codex REQUEST CHANGES with no issues listed, deepseek REQUEST
CHANGES with two:

- `correctness` block-comment shadowing (deepseek). **Accepted and fixed** by the exactly-one-match rule.
- `ops` publish not gated on tests (deepseek, kimi-k3). **Deferred** - see below.
- `scope` dedupe the two regexes by exporting `TARGETS` and having the validate heredoc require it (glm-5-3). **Deferred**: glm-5-3's critique of my "cannot import repo code" justification was correct and that claim has been dropped, but the change needs `TARGETS` exported plus a restructure of the validate step to drive both JSON and non-JSON checks from one list. glm-5-3 rates it non-blocking; regex drift now fails loudly on both sides.
- `ops` the `/^\d+\.\d+\.\d+$/` gate rejects prereleases (glm-5-3). **Dismissed**: pre-existing gate, unchanged here, already governing the seven earlier targets; the repo cuts no prereleases and the failure would be loud, so it cannot cause silent drift.
- `ops` confirm branch protection requires the checks (glm-5-3). **Dismissed as an issue against this diff**: checked rather than assumed, and it is real (below), but it is a repository setting no pull request can change.

### Known gap, verified, not fixed here

The deferred ops finding is true and worse than the reviewers described:

```
tag-release.yml: no `needs:`, no test step - publish is gated only on the commit
                 message starting with `chore(release):`
gh api repos/antonbabenko/deliberation/branches/master/protection
              -> 404 "Branch not protected" - no required status checks
```

So a hand-made tag, or a direct push to `master`, can publish without CI having run. This
predates this branch and applies identically to the seven targets synced before it, which is
why it is deferred rather than bundled in: gating publish on the suite changes release-pipeline
behavior (a flaky test would block a publish whose tag already exists), and branch protection
is not a code change at all. It wants its own PR.

## Scope

`fix:` - user-visible: every MCP host was told the wrong version. It should cut a release, and
that release will be the first to drive this literal from `version.json`.

Deliberately not done: replacing the literal with a runtime `package.json` read or an esbuild
`--define`. It would have to resolve on both run paths (published `dist/index.js` and in-repo
`server/mcp/index.js`) and adds a bundler-coupled failure mode to a repo whose constraint is
zero runtime dependencies. The synced literal, a locally-runnable test, and an
exactly-one-match guard cover the observed defect.
